### PR TITLE
Slay the syntax beast once and for all

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -408,12 +408,12 @@ impl Eval for ast::Lambda {
     ) -> Result<Vec<Gc<Value>>, RuntimeError> {
         // TODO: Optimize the AST with smart pointers to prevent constantly
         // cloning.
+
         let (args, remaining) = self.args.to_args_and_remaining();
         Ok(vec![Gc::new(Value::Procedure(Procedure {
             up: env.clone(),
             args,
             remaining,
-            // mark: self.mark,
             body: self.body.clone(),
             is_variable_transformer: false,
         }))])

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -69,10 +69,10 @@ pub fn expression<'a, 'b>(i: &'b [Token<'a>]) -> Result<(&'b [Token<'a>], Syntax
         )),
         // Lists:
         [n @ token!(Lexeme::LParen), token!(Lexeme::RParen), tail @ ..] => {
-            Ok((tail, Syntax::new_nil(n.span.clone())))
+            Ok((tail, Syntax::new_null(n.span.clone())))
         }
         [n @ token!(Lexeme::LBracket), token!(Lexeme::RBracket), tail @ ..] => {
-            Ok((tail, Syntax::new_nil(n.span.clone())))
+            Ok((tail, Syntax::new_null(n.span.clone())))
         }
         [p @ token!(Lexeme::LParen), tail @ ..] => match list(tail, p.span.clone(), Lexeme::RParen)
         {
@@ -103,7 +103,7 @@ pub fn expression<'a, 'b>(i: &'b [Token<'a>]) -> Result<(&'b [Token<'a>], Syntax
                     vec![
                         Syntax::new_identifier("quote", q.span.clone()),
                         expr,
-                        Syntax::new_nil(expr_span),
+                        Syntax::new_null(expr_span),
                     ],
                     q.span.clone(),
                 ),
@@ -119,7 +119,7 @@ pub fn expression<'a, 'b>(i: &'b [Token<'a>]) -> Result<(&'b [Token<'a>], Syntax
                     vec![
                         Syntax::new_identifier("syntax", s.span.clone()),
                         expr,
-                        Syntax::new_nil(expr_span),
+                        Syntax::new_null(expr_span),
                     ],
                     s.span.clone(),
                 ),
@@ -161,14 +161,14 @@ fn list<'a, 'b>(
         match remaining {
             // Proper lists:
             [token, tail @ ..] if token.lexeme == closing => {
-                output.push(Syntax::new_nil(token.span.clone()));
+                output.push(Syntax::new_null(token.span.clone()));
                 return Ok((tail, Syntax::new_list(output, span)));
             }
             [token!(Lexeme::Period), end @ token!(Lexeme::LParen), token!(Lexeme::RParen), token, tail @ ..]
             | [token!(Lexeme::Period), end @ token!(Lexeme::LBracket), token!(Lexeme::RBracket), token, tail @ ..]
                 if token.lexeme == closing =>
             {
-                output.push(Syntax::new_nil(end.span.clone()));
+                output.push(Syntax::new_null(end.span.clone()));
                 return Ok((tail, Syntax::new_list(output, span)));
             }
             // Improper lists:

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -25,11 +25,13 @@ pub trait Callable: Send + Sync + 'static {
     ) -> Result<ValuesOrPreparedCall, RuntimeError>;
 }
 
-#[derive(Clone)]
+#[derive(Clone, derive_more::Debug)]
 pub struct Procedure {
+    #[debug(skip)]
     pub up: Env,
     pub args: Vec<Identifier>,
     pub remaining: Option<Identifier>,
+    #[debug(skip)]
     pub body: Body,
     pub is_variable_transformer: bool,
 }

--- a/src/stdlib.scm
+++ b/src/stdlib.scm
@@ -119,6 +119,13 @@
       ((var init) ...)
       body1 body2 ...))))
 
+(define-syntax letrec*
+  (syntax-rules ()
+    ((letrec* ((var1 init1) ...) body1 body2 ...)
+     (let ((var1 <undefined>) ...)
+       (set! var1 init1) ...
+       (let () body1 body2 ...)))))
+
 (define (values . things)
   (call-with-current-continuation
    (lambda (cont) (apply cont things))))
@@ -196,3 +203,65 @@
           (assoc ... (rest-formal newtemp))
           bindings
           body1 body2 ...))))))
+
+(define-syntax when
+  (syntax-rules ()
+    ((when test result1 result2 ...)
+     (if test
+         (begin result1 result2 ...)))))
+
+(define-syntax unless
+  (syntax-rules ()
+    ((unless test result1 result2 ...)
+     (if (not test)
+         (begin result1 result2 ...)))))
+
+(define-syntax do
+  (syntax-rules ()
+    ((do ((var init step ...) ...)
+         (test expr ...)
+       command ...)
+     (letrec
+         ((loop
+           (lambda (var ...)
+             (if test
+                 (begin
+                   #f ; avoid empty begin
+                   expr ...)
+                 (begin
+                   command
+                   ...
+                   (loop (do "step" var step ...)
+                         ...))))))
+       (loop init ...)))
+    ((do "step" x)
+     x)
+    ((do "step" x y)
+     y)))
+
+(define-syntax case-lambda
+  (syntax-rules ()
+    ((_ (fmls b1 b2 ...))
+     (lambda fmls b1 b2 ...))
+    ((_ (fmls b1 b2 ...) ...)
+     (lambda args
+       (let ((n (length args)))
+         (case-lambda-help args n
+                           (fmls b1 b2 ...) ...))))))
+
+(define-syntax case-lambda-help
+  (syntax-rules ()
+    ((_ args n)
+     (assertion-violation #f
+                          "unexpected number of arguments"))
+    ((_ args n ((x ...) b1 b2 ...) more ...)
+     (if (= n (length '(x ...)))
+         (apply (lambda (x ...) b1 b2 ...) args)
+         (case-lambda-help args n more ...)))
+    ((_ args n ((x1 x2 ... . r) b1 b2 ...) more ...)
+     (if (>= n (length '(x1 x2 ...)))
+         (apply (lambda (x1 x2 ... . r) b1 b2 ...)
+                args)
+         (case-lambda-help args n more ...)))
+    ((_ args n (r b1 b2 ...) more ...)
+     (apply (lambda r b1 b2 ...) args))))

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -40,10 +40,11 @@ impl From<InputSpan<'_>> for Span {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, derive_more::Debug)]
 pub enum Syntax {
     /// An empty list.
     Null {
+        #[debug(skip)]
         span: Span,
     },
     /// A nested grouping of pairs. If the expression is a proper list, then the
@@ -51,19 +52,25 @@ pub enum Syntax {
     /// at least two elements.
     List {
         list: Vec<Syntax>,
+        #[debug(skip)]
         span: Span,
     },
     Vector {
         vector: Vec<Syntax>,
+        #[debug(skip)]
         span: Span,
     },
     Literal {
         literal: Literal,
+        #[debug(skip)]
         span: Span,
     },
     Identifier {
+        //        #[debug(flatten = ".name")]
         ident: Identifier,
+        #[debug(skip)]
         bound: bool,
+        #[debug(skip)]
         span: Span,
     },
 }
@@ -114,6 +121,8 @@ impl Syntax {
             Self::List { mut list, span } => {
                 if let [Syntax::Null { .. }] = list.as_slice() {
                     list.pop().unwrap()
+                } else if list.is_empty() {
+                    Syntax::Null { span }
                 } else {
                     Self::List { list, span }
                 }
@@ -439,10 +448,16 @@ impl Default for Mark {
     }
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Hash, PartialEq, Eq)]
 pub struct Identifier {
     pub name: String,
     pub marks: BTreeSet<Mark>,
+}
+
+impl fmt::Debug for Identifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name)
+    }
 }
 
 impl Identifier {
@@ -481,11 +496,11 @@ impl Syntax {
 
     // There's got to be a better way:
 
-    pub fn new_nil(span: impl Into<Span>) -> Self {
+    pub fn new_null(span: impl Into<Span>) -> Self {
         Self::Null { span: span.into() }
     }
 
-    pub fn is_nil(&self) -> bool {
+    pub fn is_null(&self) -> bool {
         matches!(self, Self::Null { .. })
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -89,7 +89,7 @@ impl Value {
                 Self::Character(c) => format!("\\x{c}"),
                 Self::ByteVector(_) => "<byte_vector>".to_string(),
                 Self::Syntax(syntax) => format!("{:#?}", syntax),
-                Self::Procedure(_) => "<lambda>".to_string(),
+                Self::Procedure(proc) => format!("<{proc:?}>"),
                 Self::ExternalFn(_) => "<external_fn>".to_string(),
                 Self::Future(_) => "<future>".to_string(),
                 Self::Transformer(_) => "<transformer>".to_string(),
@@ -216,6 +216,18 @@ pub fn eqv<'a>(a: &'a Gc<Value>, b: &'a Gc<Value>) -> BoxFuture<'a, bool> {
         let b = b.read().await;
         a.eqv(&b).await
     })
+}
+
+#[builtin("not")]
+pub async fn not(
+    _cont: &Option<Arc<Continuation>>,
+    a: &Gc<Value>,
+) -> Result<Vec<Gc<Value>>, RuntimeError> {
+    let a = a.read().await;
+    Ok(vec![Gc::new(Value::Boolean(matches!(
+        &*a,
+        Value::Boolean(false)
+    )))])
 }
 
 #[builtin("eqv?")]


### PR DESCRIPTION
I think this is the final implementation of the expander, at least until I figure out how to do this faster.

Instead of patching it I just decided to re-write it in a way that actually makes sense and follows the rules. 

As far as I can tell, all "exotic" control flow features that can be implemented with macros now are and _work_.