### PR TITLE
Clone continuation stacks on-demand

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -360,6 +360,6 @@ pub async fn disp(
     _cont: &Option<Arc<Continuation>>,
     arg: &Gc<Value>,
 ) -> Result<Vec<Gc<Value>>, RuntimeError> {
-    println!("{}", arg.read().await.fmt().await);
+    print!("{}", arg.read().await.fmt().await);
     Ok(vec![Gc::new(Value::Null)])
 }


### PR DESCRIPTION
I noticed that the classic yin-yang puzzle[1]  wasn't working properly. Turns out I was forgetting to clone the stacks! That's fixed now. Because it's an expensive operation, it's only ever done at points where scheme is given access to a first-class  continuation. If you have a continuation that you would like to use, be sure to run `clone_stack` on it. 


[1]:
```scheme
(let* ((yin
         ((lambda (cc) (display "@") cc) (call-with-current-continuation (lambda (c) c))))
       (yang
         ((lambda (cc) (display "*") cc) (call-with-current-continuation (lambda (c) c)))))
    (yin yang))
 ```