### PR TITLE
Fix values and call-by-values

### DIFF
--- a/src/cps/analysis.rs
+++ b/src/cps/analysis.rs
@@ -103,6 +103,10 @@ impl Cps {
                 free.extend(op.to_local());
                 free
             }
+            Self::Forward(op, arg) => vec![op.to_local(), arg.to_local()]
+                .into_iter()
+                .flatten()
+                .collect(),
             Self::Closure {
                 args,
                 body,
@@ -136,6 +140,10 @@ impl Cps {
                 globals.extend(op.to_global());
                 globals
             }
+            Self::Forward(op, arg) => vec![op.to_global(), arg.to_global()]
+                .into_iter()
+                .flatten()
+                .collect(),
             Self::Closure {
                 args,
                 body,

--- a/src/cps/compile.rs
+++ b/src/cps/compile.rs
@@ -325,14 +325,14 @@ fn compile_call_with_cc(
     Cps::Closure {
         args: ClosureArgs::new(vec![k1], false, None),
         body: Box::new(Cps::Closure {
-            args: ClosureArgs::new(vec![arg], false, Some(Local::gensym())),
+            args: ClosureArgs::new(vec![arg], true, Some(Local::gensym())),
             body: Box::new(Cps::PrimOp(
                 PrimOp::CloneClosure,
                 vec![Value::from(k1)],
                 cloned_closure,
-                Box::new(Cps::App(
+                Box::new(Cps::Forward(
                     Value::from(cloned_closure),
-                    vec![Value::from(arg)],
+                    Value::from(arg),
                 )),
             )),
             val: escape_procedure,

--- a/src/cps/compile.rs
+++ b/src/cps/compile.rs
@@ -330,10 +330,7 @@ fn compile_call_with_cc(
                 PrimOp::CloneClosure,
                 vec![Value::from(k1)],
                 cloned_closure,
-                Box::new(Cps::Forward(
-                    Value::from(cloned_closure),
-                    Value::from(arg),
-                )),
+                Box::new(Cps::Forward(Value::from(cloned_closure), Value::from(arg))),
             )),
             val: escape_procedure,
             cexp: Box::new(Cps::Closure {

--- a/src/cps/mod.rs
+++ b/src/cps/mod.rs
@@ -140,7 +140,6 @@ impl ClosureArgs {
 
     fn num_required(&self) -> usize {
         self.args.len().saturating_sub(self.variadic as usize)
-        // + self.continuation.is_some() as usize
     }
 }
 
@@ -153,6 +152,7 @@ pub enum Cps {
     /// Function application.
     App(Value, Vec<Value>),
     /// Forward a list of values into an application.
+    // TODO: I'm not sure I like this name
     Forward(Value, Value),
     /// Branching.
     If(Value, Box<Cps>, Box<Cps>),

--- a/src/cps/mod.rs
+++ b/src/cps/mod.rs
@@ -152,6 +152,8 @@ pub enum Cps {
     PrimOp(PrimOp, Vec<Value>, Local, Box<Cps>),
     /// Function application.
     App(Value, Vec<Value>),
+    /// Forward a list of values into an application.
+    Forward(Value, Value),
     /// Branching.
     If(Value, Box<Cps>, Box<Cps>),
     /// Closure generation. The result of this operation is a *const Value::Closure

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -366,14 +366,14 @@ pub fn call_with_values<'a>(
         // Fetch the producer
         let producer = {
             let producer_ref = producer.read();
-            let producer: &Closure = producer_ref.as_ref().try_into().unwrap();
+            let producer: &Closure = producer_ref.as_ref().try_into()?;
             producer.clone()
         };
 
         // Get the details of the consumer:
         let (num_required_args, variadic) = {
             let consumer_ref = consumer.read();
-            let consumer: &Closure = consumer_ref.as_ref().try_into().unwrap();
+            let consumer: &Closure = consumer_ref.as_ref().try_into()?;
             (consumer.num_required_args, consumer.variadic)
         };
 

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -318,3 +318,80 @@ pub(crate) fn deep_clone_value(
         }
     }
 }
+
+unsafe extern "C" fn call_consumer_with_values(
+    _runtime: *mut GcInner<Runtime>,
+    env: *const *mut GcInner<Value>,
+    _globals: *const *mut GcInner<Value>,
+    args: *const *mut GcInner<Value>,
+) -> *mut Application {
+    // env[0] is the consumer
+    let consumer = Gc::from_ptr(env.read());
+    let consumer = {
+        let consumer_ref = consumer.read();
+        let consumer: &Closure = consumer_ref.as_ref().try_into().unwrap();
+        consumer.clone()
+    };
+    // env[1] is the continuation
+    let cont = Gc::from_ptr(env.add(1).read());
+
+    let mut collected_args: Vec<_> = (0..consumer.num_required_args)
+        .map(|i| Gc::from_ptr(args.add(i).read()))
+        .collect();
+
+    // I hate this constant going back and forth from variadice to list. I have
+    // to figure out a way to make it consistent
+    if consumer.variadic {
+        let rest_args = Gc::from_ptr(args.add(consumer.num_required_args).read());
+        let mut vec = Vec::new();
+        list_to_vec(&rest_args, &mut vec);
+        collected_args.extend(vec);
+    }
+
+    collected_args.push(cont);
+
+    Box::into_raw(Box::new(Application::new(consumer, collected_args)))
+}
+
+pub fn call_with_values<'a>(
+    args: &'a [Gc<Value>],
+    _rest_args: &'a [Gc<Value>],
+    cont: &'a Gc<Value>,
+) -> BoxFuture<'a, Result<Application, Exception>> {
+    Box::pin(async move {
+        let [producer, consumer] = args else {
+            return Err(Exception::wrong_num_of_args(2, args.len()));
+        };
+
+        // Fetch the producer
+        let producer = {
+            let producer_ref = producer.read();
+            let producer: &Closure = producer_ref.as_ref().try_into().unwrap();
+            producer.clone()
+        };
+        // Get the details of the consumer:
+        let (num_required_args, variadic) = {
+            let consumer_ref = consumer.read();
+            let consumer: &Closure = consumer_ref.as_ref().try_into().unwrap();
+            (consumer.num_required_args, consumer.variadic)
+        };
+
+        let call_consumer_closure = Closure::new(
+            producer.runtime.clone(),
+            vec![consumer.clone(), cont.clone()],
+            Vec::new(),
+            FuncPtr::SyncFunc(call_consumer_with_values),
+            num_required_args,
+            variadic,
+            false,
+        );
+        Ok(Application::new(
+            producer,
+            vec![Gc::new(Value::Closure(call_consumer_closure))],
+        ))
+    })
+}
+
+inventory::submit! {
+    BridgeFn::new("call-with-values", "(base)", 2, false, call_with_values)
+}

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -339,7 +339,7 @@ unsafe extern "C" fn call_consumer_with_values(
         .map(|i| Gc::from_ptr(args.add(i).read()))
         .collect();
 
-    // I hate this constant going back and forth from variadice to list. I have
+    // I hate this constant going back and forth from variadic to list. I have
     // to figure out a way to make it consistent
     if consumer.variadic {
         let rest_args = Gc::from_ptr(args.add(consumer.num_required_args).read());
@@ -369,6 +369,7 @@ pub fn call_with_values<'a>(
             let producer: &Closure = producer_ref.as_ref().try_into().unwrap();
             producer.clone()
         };
+
         // Get the details of the consumer:
         let (num_required_args, variadic) = {
             let consumer_ref = consumer.read();
@@ -385,6 +386,7 @@ pub fn call_with_values<'a>(
             variadic,
             false,
         );
+
         Ok(Application::new(
             producer,
             vec![Gc::new(Value::Closure(call_consumer_closure))],

--- a/tests/r6rs.scm
+++ b/tests/r6rs.scm
@@ -201,8 +201,6 @@
              y)
            5)
 
-#|
-
 (assert-eq (let-values (((a b) (values 1 2))
                         ((c d) (values 3 4)))
              (list a b c d))
@@ -217,8 +215,6 @@
                           ((x y) (values a b)))
                (list a b x y)))
            '(x y a b))
-
-|#
 
 
 ;;(assert-eq (let ((a 'a) (b 'b) (x 'x) (y 'y))


### PR DESCRIPTION
Both of these were temporarily lost with the transition to CPS. They're back now, and much slower!