### PR TITLE
implement some of lists functions (#31)

### DIFF
--- a/src/stdlib.scm
+++ b/src/stdlib.scm
@@ -302,6 +302,35 @@
  (if (null? l) m
   (cons (car l) (append (cdr l) m))))
 
+(define (make-list n)
+  (if (> n 0)
+      (cons #f (make-list (- n 1)))
+      '()))
+
+(define (list-copy lst)
+  (if (null? lst)
+      '()
+      (cons (car lst)
+            (list-copy (cdr lst)))))
+
+(define (list-tail lst n)
+  (if (> n 0)
+      (list-tail (cdr lst) (- n 1))
+      lst))
+
+(define (list-ref lst n)
+  (if (> n 0)
+      (list-ref (cdr lst) (- n 1))
+      (car lst)))
+
+(define (assoc k lst)
+  (if (null? lst)
+      #f
+      (let ((pair (car lst)))
+        (if (equal? (car pair) k)
+            pair
+            (assoc k (cdr lst))))))
+
 (define (map function list1 . more-lists)
   (define (some? function list)
     ;; returns #f if (function x) returns #t for 

--- a/tests/r6rs.scm
+++ b/tests/r6rs.scm
@@ -89,6 +89,27 @@
 (assert-eq (boolean=? #t) #t)
 (assert-eq (boolean=? #f) #t)
 
+;;  6.4. list procedures
+
+(assert-eq (make-list 2) '(#f #f))
+(assert-eq (make-list 5) '(#f #f #f #f #f))
+
+(define xs '(1 2 3 4 5))
+
+(assert-eq (eq? (list-copy xs) xs) #f)
+(assert-eq (eq? xs xs) #t)
+
+(assert-eq (list-ref xs 2) 3)
+(assert-eq (list-ref xs 3) 4)
+
+(assert-eq (list-tail xs 3) '(4 5))
+
+(define alist '((a . 1) (b . 2)))
+
+(assert-eq (assoc 'a alist) '(a . 1))
+(assert-eq (assoc 'b alist) '(b . 2))
+(assert-eq (assoc 'c alist) #f)
+
 ;; 11.2.2. Syntax definitions
 
 (assert-eq (let ()


### PR DESCRIPTION
make-list, list-copy, list-tail, list-ref, assoc

Note that, when testing out `list-copy` that the following happened 
```
> (let ((x '( 1 2 3))) (eq? x x))
$1 = #t
> (let ((x '( 1 2 3))) (eq? x (list-copy x)))
$2 = #t
```
Assuming that the implementation of `list-copy` is correct, my expectation for the output for the second `eq?` expression is to be `#f`. But it looks like `eq?` is an alias for `eqv?`. Regardless of the behavior of `eq?` right now, I haven't found another way to `list-copy` out yet. And other functions are as simple as they get and I played around them on the repl.

Do advise.