### PR TITLE
stop garbage collector spinning

### DIFF
--- a/src/gc/collection.rs
+++ b/src/gc/collection.rs
@@ -137,8 +137,7 @@ async unsafe fn process_mutation_buffer(
     // have occurred at this point by an extra epoch.
     let mut to_recv = mutation_buffer_rx
         .len()
-        .min(MIN_MUTATIONS_PER_EPOCH)
-        .max(MAX_MUTATIONS_PER_EPOCH);
+        .clamp(MAX_MUTATIONS_PER_EPOCH, MIN_MUTATIONS_PER_EPOCH);
 
     loop {
         mutation_buffer_rx.recv_many(mutation_buffer, to_recv).await;
@@ -152,7 +151,7 @@ async unsafe fn process_mutation_buffer(
         if mutation_buffer_rx.is_empty() {
             break;
         }
-        to_recv = mutation_buffer_rx.len().max(MAX_MUTATIONS_PER_EPOCH);
+        to_recv = mutation_buffer_rx.len().min(MAX_MUTATIONS_PER_EPOCH);
     }
 }
 

--- a/src/gc/collection.rs
+++ b/src/gc/collection.rs
@@ -140,22 +140,14 @@ async unsafe fn process_mutation_buffer(
     // have occurred at this point by an extra epoch.
     let mut to_recv = mutation_buffer_rx
         .len()
-        .min(MAX_MUTATIONS_PER_EPOCH)
-        .max(MIN_MUTATIONS_PER_EPOCH);
+        .min(MAX_MUTATIONS_PER_EPOCH);
 
-    loop {
-        mutation_buffer_rx.recv_many(mutation_buffer, to_recv).await;
-        for mutation in mutation_buffer.drain(..) {
-            match mutation.kind {
-                MutationKind::Inc => increment(mutation.gc),
-                MutationKind::Dec => decrement(mutation.gc),
-            }
+    mutation_buffer_rx.recv_many(mutation_buffer, to_recv).await;
+    for mutation in mutation_buffer.drain(..) {
+        match mutation.kind {
+            MutationKind::Inc => increment(mutation.gc),
+            MutationKind::Dec => decrement(mutation.gc),
         }
-
-        if mutation_buffer_rx.is_empty() {
-            break;
-        }
-        to_recv = mutation_buffer_rx.len().min(MAX_MUTATIONS_PER_EPOCH);
     }
 }
 

--- a/src/gc/collection.rs
+++ b/src/gc/collection.rs
@@ -98,10 +98,12 @@ async unsafe fn run_garbage_collector() {
         .take()
         .unwrap();
     while epoch(
-            &mut last_epoch,
-            &mut mutation_buffer_rx,
-            &mut mutation_buffer,
-        ).await {}
+        &mut last_epoch,
+        &mut mutation_buffer_rx,
+        &mut mutation_buffer,
+    )
+    .await
+    {}
 }
 
 // Run a collection epoch. Returns false if we've been cancelled and should exit.
@@ -133,7 +135,10 @@ async unsafe fn process_mutation_buffer(
 ) {
     // It is very important that we do not delay any mutations that
     // have occurred at this point by an extra epoch.
-    let to_recv = mutation_buffer_rx.len().min(MIN_MUTATIONS_PER_EPOCH).max(MAX_MUTATIONS_PER_EPOCH);
+    let to_recv = mutation_buffer_rx
+        .len()
+        .min(MIN_MUTATIONS_PER_EPOCH)
+        .max(MAX_MUTATIONS_PER_EPOCH);
     mutation_buffer_rx.recv_many(mutation_buffer, to_recv).await;
 
     for mutation in mutation_buffer.drain(..) {

--- a/src/gc/collection.rs
+++ b/src/gc/collection.rs
@@ -149,7 +149,7 @@ async unsafe fn process_mutation_buffer(
             }
         }
 
-        if mutation_buffer_rx.len() == 0 {
+        if mutation_buffer_rx.is_empty() {
             break;
         }
         to_recv = mutation_buffer_rx.len().max(MAX_MUTATIONS_PER_EPOCH);

--- a/src/gc/collection.rs
+++ b/src/gc/collection.rs
@@ -135,14 +135,24 @@ async unsafe fn process_mutation_buffer(
 ) {
     // It is very important that we do not delay any mutations that
     // have occurred at this point by an extra epoch.
-    let to_recv = mutation_buffer_rx.len().min(MIN_MUTATIONS_PER_EPOCH);
-    mutation_buffer_rx.recv_many(mutation_buffer, to_recv).await;
-
-    for mutation in mutation_buffer.drain(..) {
-        match mutation.kind {
-            MutationKind::Inc => increment(mutation.gc),
-            MutationKind::Dec => decrement(mutation.gc),
+    let mut to_recv = mutation_buffer_rx
+        .len()
+        .min(MIN_MUTATIONS_PER_EPOCH)
+        .max(MAX_MUTATIONS_PER_EPOCH);
+    
+    loop {
+        mutation_buffer_rx.recv_many(mutation_buffer, to_recv).await;
+        for mutation in mutation_buffer.drain(..) {
+            match mutation.kind {
+                MutationKind::Inc => increment(mutation.gc),
+                MutationKind::Dec => decrement(mutation.gc),
+            }
         }
+
+        if mutation_buffer_rx.len() == 0 { break; }
+        to_recv = mutation_buffer_rx
+            .len()
+            .max(MAX_MUTATIONS_PER_EPOCH);
     }
 }
 

--- a/src/gc/collection.rs
+++ b/src/gc/collection.rs
@@ -135,9 +135,7 @@ async unsafe fn process_mutation_buffer(
 ) {
     // It is very important that we do not delay any mutations that
     // have occurred at this point by an extra epoch.
-    let to_recv = mutation_buffer_rx
-        .len()
-        .min(MIN_MUTATIONS_PER_EPOCH);
+    let to_recv = mutation_buffer_rx.len().min(MIN_MUTATIONS_PER_EPOCH);
     mutation_buffer_rx.recv_many(mutation_buffer, to_recv).await;
 
     for mutation in mutation_buffer.drain(..) {

--- a/src/gc/collection.rs
+++ b/src/gc/collection.rs
@@ -84,6 +84,7 @@ pub fn init_gc() {
         .get_or_init(|| tokio::task::spawn(async { unsafe { run_garbage_collector().await } }));
 }
 
+const MIN_MUTATIONS_PER_EPOCH: usize = 10; // How many mutations to deal with at once
 const MAX_MUTATIONS_PER_EPOCH: usize = 10_000; // No idea what a good value is here.
 
 async unsafe fn run_garbage_collector() {
@@ -96,18 +97,11 @@ async unsafe fn run_garbage_collector() {
         .unwrap()
         .take()
         .unwrap();
-    loop {
-        if !epoch(
+    while epoch(
             &mut last_epoch,
             &mut mutation_buffer_rx,
             &mut mutation_buffer,
-        )
-        .await
-        {
-            return;
-        }
-        mutation_buffer.clear();
-    }
+        ).await {}
 }
 
 // Run a collection epoch. Returns false if we've been cancelled and should exit.
@@ -139,10 +133,10 @@ async unsafe fn process_mutation_buffer(
 ) {
     // It is very important that we do not delay any mutations that
     // have occurred at this point by an extra epoch.
-    let to_recv = mutation_buffer_rx.len();
+    let to_recv = mutation_buffer_rx.len().min(MIN_MUTATIONS_PER_EPOCH).max(MAX_MUTATIONS_PER_EPOCH);
     mutation_buffer_rx.recv_many(mutation_buffer, to_recv).await;
 
-    for mutation in mutation_buffer {
+    for mutation in mutation_buffer.drain(..) {
         match mutation.kind {
             MutationKind::Inc => increment(mutation.gc),
             MutationKind::Dec => decrement(mutation.gc),

--- a/src/gc/collection.rs
+++ b/src/gc/collection.rs
@@ -137,8 +137,7 @@ async unsafe fn process_mutation_buffer(
     // have occurred at this point by an extra epoch.
     let to_recv = mutation_buffer_rx
         .len()
-        .min(MIN_MUTATIONS_PER_EPOCH)
-        .max(MAX_MUTATIONS_PER_EPOCH);
+        .min(MIN_MUTATIONS_PER_EPOCH);
     mutation_buffer_rx.recv_many(mutation_buffer, to_recv).await;
 
     for mutation in mutation_buffer.drain(..) {

--- a/src/gc/collection.rs
+++ b/src/gc/collection.rs
@@ -139,7 +139,7 @@ async unsafe fn process_mutation_buffer(
         .len()
         .min(MIN_MUTATIONS_PER_EPOCH)
         .max(MAX_MUTATIONS_PER_EPOCH);
-    
+
     loop {
         mutation_buffer_rx.recv_many(mutation_buffer, to_recv).await;
         for mutation in mutation_buffer.drain(..) {
@@ -149,10 +149,10 @@ async unsafe fn process_mutation_buffer(
             }
         }
 
-        if mutation_buffer_rx.len() == 0 { break; }
-        to_recv = mutation_buffer_rx
-            .len()
-            .max(MAX_MUTATIONS_PER_EPOCH);
+        if mutation_buffer_rx.len() == 0 {
+            break;
+        }
+        to_recv = mutation_buffer_rx.len().max(MAX_MUTATIONS_PER_EPOCH);
     }
 }
 


### PR DESCRIPTION
The current garbage collector constantly spins which usually uses up 1 cpu core at 100%. This adds a condition variable for the garbage collector to make it only run every interval or whenever there is a mutation.

- **made garbage collector no longer spin**
- **rustfmt**
