### PR TITLE
fixed "make-vector"

### DIFF
--- a/src/vectors.rs
+++ b/src/vectors.rs
@@ -96,13 +96,18 @@ pub async fn make_vector(n: &Gc<Value>, with: &[Gc<Value>]) -> Result<Vec<Gc<Val
     let n: &Number = n.as_ref().try_into()?;
     let n = n.to_u64();
 
-    Ok((0..n)
-        .map(|_| {
-            with.first()
-                .cloned()
-                .unwrap_or_else(|| Gc::new(Value::Null))
-        })
-        .collect())
+    Ok(vec![Gc::new(Value::Vector(
+        (0..n)
+            .map(|_| {
+                with.first()
+                    .map(|with| {
+                        let with = with.read();
+                        with.clone()
+                    })
+                    .unwrap_or_else(|| Value::Null)
+            })
+            .collect::<Vec<_>>(),
+    ))])
 }
 
 #[bridge(name = "vector", lib = "(base)")]

--- a/tests/r7rs.scm
+++ b/tests/r7rs.scm
@@ -2,6 +2,9 @@
 
 ;; 6.8 Vectors
 
+; not part of r7rs examples
+(assert-eq (make-vector 10 'a) #(a a a a a a a a a a))
+
 (assert-eq (vector 'a 'b 'c) #(a b c))
 
 (assert-eq (vector-ref '#(1 1 2 3 5 8 13 21) 5) 8)


### PR DESCRIPTION
The old `make-vector` procedure returns multiple values instead of multiple values inside of a vec.
# Old
```scm
(make-vector 10 'a)
; -> $1 = 'a
; -> $2 = 'a
; -> $3 = 'a
; -> $4 = 'a
; -> $5 = 'a
; -> $6 = 'a
; -> $7 = 'a
; -> $8 = 'a
; -> $9 = 'a
; -> $10 = 'a
```
# New
```scm
(make-vector 10 'a)
; -> #('a 'a 'a 'a 'a 'a 'a 'a 'a 'a)
```
