### PR TITLE
Fix memory leak regression introduced by compilation

### DIFF
--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -566,18 +566,23 @@ where
 
 unsafe impl<T> Trace for Box<T>
 where
-    T: GcOrTrace,
+    T: GcOrTrace + ?Sized,
 {
-    unsafe fn visit_children(&self, visitor: unsafe fn(OpaqueGcPtr)) {
-        self.as_ref().visit_or_recurse(visitor);
+    unsafe fn visit_children(&self, _visitor: unsafe fn(OpaqueGcPtr)) {
+        // self.as_ref().visit_or_recurse(visitor);
     }
 
+    /*
     unsafe fn finalize(&mut self) {
+        println!("finalizing box!");
         self.as_mut().finalize_or_skip();
-        todo!("need to dealloc data without dropping box");
+        std::alloc::dealloc(self.as_mut() as *mut T as *mut u8, Layout::new::<T>());
+        // todo!("need to dealloc data without dropping box");
     }
+    */
 }
 
+/*
 unsafe impl<T> Trace for [T]
 where
     T: GcOrTrace,
@@ -594,6 +599,7 @@ where
         }
     }
 }
+*/
 
 unsafe impl<T> Trace for std::sync::Arc<T>
 where

--- a/src/stdlib.scm
+++ b/src/stdlib.scm
@@ -27,7 +27,6 @@
 ;; 
 ;; Aliases:
 ;; 
-(define eq? eqv?)
 (define equal? eqv?) ;; TODO(map): This is INCORRECT, needs to be fixed!
 (define (member obj list)
   (memp (lambda (x) (equal? x obj)) list))

--- a/src/value.rs
+++ b/src/value.rs
@@ -308,6 +308,11 @@ pub async fn not(a: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
     )))])
 }
 
+#[bridge(name = "eq?", lib = "(base)")]
+pub async fn eq_pred(a: &Gc<Value>, b: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+    Ok(vec![Gc::new(Value::Boolean(a == b))])
+}
+
 #[bridge(name = "eqv?", lib = "(base)")]
 pub async fn eqv_pred(a: &Gc<Value>, b: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
     Ok(vec![Gc::new(Value::Boolean(eqv(a, b)))])

--- a/tests/r6rs.scm
+++ b/tests/r6rs.scm
@@ -222,6 +222,18 @@
 ;;               (list a b x y)))
 ;;           (x y x y))
 
+;; 11.5. Equivalence predicates
+
+;; Right now, constants have a new allocation per each instance. This is obviously
+;; wrong, but a much deeper problem than one with the implementation of eq?
+
+(assert-eq (eq? (list 'a) (list 'a))
+           #f)
+
+(assert-eq (let ((x 1))
+             (eq? x x))
+           #t)
+
 (assert-eq (let loopv ((n 1))
              (if (> n 10)
                  '()


### PR DESCRIPTION
There were a couple of issues here:

- Closures allocated were not added to `allocs` in codegen, and thus never dropped.
- Boxes had a bad impl for Trace, meaning they were never allocated. Essentially we were deferring their impl to their inner type because we didn't have a `?Sized` bounds.

There are some other issues, like functions retaining an up pointer when recursing which endlessly grows the heap, but this will at least reclaim memory on bounded loops. 