### PR TITLE
add character functions

### DIFF
--- a/src/character.rs
+++ b/src/character.rs
@@ -25,3 +25,85 @@ pub async fn integer_to_char(int: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exceptio
     // char->integer returns a number larger than 0x10FFFF if integer is not an unicode scalar
     Ok(vec![Gc::new(Value::Number(Number::FixedInteger(0x10FFFF + 1)))])
 }
+
+macro_rules! impl_char_operator {
+    (
+        $bridge_name:literal,
+        $function_name:ident,
+        $cmp_function:ident $(,)?
+    ) => {
+        #[bridge(name = $bridge_name, lib = "(base)")]
+        pub async fn $function_name(req_lhs: &Gc<Value>, req_rhs: &Gc<Value>, opt_chars: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+            for window in [req_lhs, req_rhs]
+                .into_iter()
+                .chain(opt_chars)
+                .map(|ch| {
+                    let ch = ch.read();
+                    ch.as_ref().try_into()
+                })
+                .collect::<Result<Vec<char>, Exception>>()?
+                .windows(2) {
+                
+                if !window.first()
+                    .and_then(|lhs| Some((lhs, window.get(1)?)))
+                    .map(|(lhs, rhs)| lhs.$cmp_function(rhs))
+                    .unwrap_or(true) {
+                    return Ok(vec![Gc::new(Value::Boolean(false))]);
+                }
+            }
+
+            Ok(vec![Gc::new(Value::Boolean(true))])
+        }
+    }
+}
+macro_rules! impl_char_ci_operator {
+    (
+        $bridge_name:literal,
+        $function_name:ident,
+        $cmp_function:ident $(,)?
+    ) => {
+        #[bridge(name = $bridge_name, lib = "(base)")]
+        pub async fn $function_name(req_lhs: &Gc<Value>, req_rhs: &Gc<Value>, opt_chars: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+            for window in [req_lhs, req_rhs]
+                .into_iter()
+                .chain(opt_chars)
+                .map(|ch| {
+                    let ch = ch.read();
+                    <&Value as TryInto<char>>::try_into(ch.as_ref())
+                        .and_then(|ch| {
+                            let mut ch = ch.to_lowercase();
+                            let len = ch.len();
+                            if len == 1 {
+                                Err(Exception::wrong_num_of_unicode_chars(1, len))
+                            } else {
+                                Ok(ch.next().unwrap())
+                            }
+                        })
+                })
+                .collect::<Result<Vec<char>, Exception>>()?
+                .windows(2) {
+                
+                if !window.first()
+                    .and_then(|lhs| Some((lhs, window.get(1)?)))
+                    .map(|(lhs, rhs)| lhs.$cmp_function(rhs))
+                    .unwrap_or(true) {
+                    return Ok(vec![Gc::new(Value::Boolean(false))]);
+                }
+            }
+
+            Ok(vec![Gc::new(Value::Boolean(true))])
+        }
+    }
+}
+
+impl_char_operator!("char=?",  char_eq, eq);
+impl_char_operator!("char<?",  char_lt, lt);
+impl_char_operator!("char>?",  char_gt, gt);
+impl_char_operator!("char>=?", char_ge, ge);
+impl_char_operator!("char<=?", char_le, le);
+
+impl_char_ci_operator!("char-ci-=?",  char_ci_eq, eq);
+impl_char_ci_operator!("char-ci-<?",  char_ci_lt, lt);
+impl_char_ci_operator!("char-ci->?",  char_ci_gt, gt);
+impl_char_ci_operator!("char-ci->=?", char_ci_ge, ge);
+impl_char_ci_operator!("char-ci-<=?", char_ci_le, le);

--- a/src/character.rs
+++ b/src/character.rs
@@ -1,0 +1,27 @@
+use crate::{
+    exception::Exception, gc::Gc, lists::slice_to_list, num::Number, registry::bridge, value::Value,
+};
+use rug::Integer;
+
+#[bridge(name = "char->integer", lib = "(base)")]
+pub async fn char_to_integer(ch: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+    let ch = ch.read();
+    let ch: char = ch.as_ref().try_into()?;
+
+    Ok(vec![Gc::new(Value::Number(Number::FixedInteger(<char as Into<u32>>::into(ch).into())))])
+}
+
+#[bridge(name = "integer->char", lib = "(base)")]
+pub async fn integer_to_char(int: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+    let int = int.read();
+    let int: &Number = int.as_ref().try_into()?;
+    let int: u64 = int.to_u64();
+    if let Ok(int) = <u64 as TryInto<u32>>::try_into(int) {
+        if let Some(ch) = char::from_u32(int) {
+            return Ok(vec![Gc::new(Value::Character(ch))]);
+        }
+    }
+
+    // char->integer returns a number larger than 0x10FFFF if integer is not an unicode scalar
+    Ok(vec![Gc::new(Value::Number(Number::FixedInteger(0x10FFFF + 1)))])
+}

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -84,6 +84,10 @@ impl Exception {
         ))
     }
 
+    pub fn wrong_num_of_unicode_chars(expected: usize, provided: usize) -> Self {
+        Self::error(format!("Expected to receive {expected} unicode characters from transform, received {provided}"))
+    }
+
     pub fn wrong_num_of_args(expected: usize, provided: usize) -> Self {
         Self::error(format!(
             "Expected {expected} arguments, provided {provided}"

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -85,7 +85,9 @@ impl Exception {
     }
 
     pub fn wrong_num_of_unicode_chars(expected: usize, provided: usize) -> Self {
-        Self::error(format!("Expected to receive {expected} unicode characters from transform, received {provided}"))
+        Self::error(format!(
+            "Expected to receive {expected} unicode characters from transform, received {provided}"
+        ))
     }
 
     pub fn wrong_num_of_args(expected: usize, provided: usize) -> Self {

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -274,7 +274,7 @@ pub enum Character {
     /// `#\xcafe` characters
     Unicode(String),
 }
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum EscapedCharacter {
     Alarm,
     Backspace,

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -97,8 +97,8 @@ impl<'a> Lexeme<'a> {
 
 fn lexeme(i: InputSpan) -> IResult<InputSpan, Lexeme<'static>> {
     alt((
-        map(identifier, Lexeme::identifier_owned),
         map(character, Lexeme::Character),
+        map(identifier, Lexeme::identifier_owned),
         map(boolean, Lexeme::Boolean),
         map(string, Lexeme::string_owned),
         map(number, Lexeme::number_owned),
@@ -285,6 +285,22 @@ pub enum EscapedCharacter {
     Return,
     Space,
     Tab,
+}
+impl Into<char> for EscapedCharacter {
+    fn into(self) -> char {
+        // from r7rs 6.6
+        match self {
+            Self::Alarm => '\u{0007}',
+            Self::Backspace => '\u{0008}',
+            Self::Delete => '\u{007F}',
+            Self::Escape => '\u{001B}',
+            Self::Newline => '\u{000A}',
+            Self::Null => '\u{0000}',
+            Self::Return => '\u{000D}',
+            Self::Space => ' ',
+            Self::Tab => '\u{0009}',
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -131,8 +131,11 @@ fn character(i: InputSpan) -> IResult<InputSpan, Character> {
                 )),
                 Character::Escaped,
             ),
-            preceded(tag_no_case("x"), map(hex_digit1, |s: InputSpan| Character::Unicode(s.to_string()))),
-            map(anychar, Character::Literal)
+            preceded(
+                tag_no_case("x"),
+                map(hex_digit1, |s: InputSpan| Character::Unicode(s.to_string())),
+            ),
+            map(anychar, Character::Literal),
         )),
     )(i)
 }
@@ -286,19 +289,19 @@ pub enum EscapedCharacter {
     Space,
     Tab,
 }
-impl Into<char> for EscapedCharacter {
-    fn into(self) -> char {
+impl From<EscapedCharacter> for char {
+    fn from(c: EscapedCharacter) -> char {
         // from r7rs 6.6
-        match self {
-            Self::Alarm => '\u{0007}',
-            Self::Backspace => '\u{0008}',
-            Self::Delete => '\u{007F}',
-            Self::Escape => '\u{001B}',
-            Self::Newline => '\u{000A}',
-            Self::Null => '\u{0000}',
-            Self::Return => '\u{000D}',
-            Self::Space => ' ',
-            Self::Tab => '\u{0009}',
+        match c {
+            EscapedCharacter::Alarm => '\u{0007}',
+            EscapedCharacter::Backspace => '\u{0008}',
+            EscapedCharacter::Delete => '\u{007F}',
+            EscapedCharacter::Escape => '\u{001B}',
+            EscapedCharacter::Newline => '\u{000A}',
+            EscapedCharacter::Null => '\u{0000}',
+            EscapedCharacter::Return => '\u{000D}',
+            EscapedCharacter::Space => ' ',
+            EscapedCharacter::Tab => '\u{0009}',
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate self as scheme_rs;
 
 pub mod ast;
+pub mod character;
 pub mod cps;
 pub mod env;
 pub mod exception;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -257,7 +257,7 @@ fn character<'a>(i: &Token<'a>) -> Result<Literal, ParseSyntaxError<'a>> {
     let char = i.lexeme.to_char();
     match char {
         LexCharacter::Literal(c) => Ok(Literal::Character(*c)),
-        LexCharacter::Escaped(e) => todo!(),
+        LexCharacter::Escaped(e) => Ok(Literal::Character((*e).into())),
         LexCharacter::Unicode(u) => {
             Ok(Literal::Character(char::try_from(ParseSyntaxError::try_parse_hex(u, i.span.clone())?)?))
         },

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,8 +1,12 @@
 use crate::{
     ast::Literal,
-    lex::{Fragment, InputSpan, LexError, Lexeme, Token},
+    lex::{Character as LexCharacter, Fragment, InputSpan, LexError, Lexeme, Token},
     num::Number,
     syntax::Syntax,
+};
+use std::{
+    borrow::Cow,
+    char::CharTryFromError,
 };
 use rug::Integer;
 
@@ -17,6 +21,7 @@ pub enum ParseSyntaxError<'a> {
     InvalidPeriodLocation { span: InputSpan<'a> },
     UnclosedParen { span: InputSpan<'a> },
     DocCommentMustPrecedeDefine,
+    CharTryFrom(CharTryFromError),
     LexError(LexError<'a>),
 }
 
@@ -25,8 +30,20 @@ impl<'a> From<LexError<'a>> for ParseSyntaxError<'a> {
         Self::LexError(lex)
     }
 }
+impl From<CharTryFromError> for ParseSyntaxError<'_> {
+    fn from(e: CharTryFromError) -> Self {
+        Self::CharTryFrom(e)
+    }
+}
 
 impl<'a> ParseSyntaxError<'a> {
+    fn try_parse_hex<S: AsRef<str> + ?Sized>(hex: &S, span: InputSpan<'a>) -> Result<u32, Self> {
+        u32::from_str_radix(hex.as_ref(), 16).ok().ok_or_else(|| Self::InvalidHexValue {
+            value: hex.as_ref().to_string(),
+            span,
+        })
+    }
+
     fn invalid_period(token: &Token<'a>) -> Self {
         Self::InvalidPeriodLocation {
             span: token.span.clone(),
@@ -58,6 +75,9 @@ pub fn expression<'a, 'b>(
         // Literals:
         [b @ token!(Lexeme::Boolean(_)), tail @ ..] => {
             Ok((tail, Syntax::new_literal(boolean(b)?, b.span.clone())))
+        }
+        [c @ token!(Lexeme::Character(_)), tail @ ..] => {
+            Ok((tail, Syntax::new_literal(character(c)?, c.span.clone())))
         }
         [n @ token!(Lexeme::Number(_)), tail @ ..] => {
             Ok((tail, Syntax::new_literal(number(n)?, n.span.clone())))
@@ -233,6 +253,17 @@ fn boolean<'a>(i: &Token<'a>) -> Result<Literal, ParseSyntaxError<'a>> {
     Ok(Literal::Boolean(i.lexeme.to_boolean()))
 }
 
+fn character<'a>(i: &Token<'a>) -> Result<Literal, ParseSyntaxError<'a>> {
+    let char = i.lexeme.to_char();
+    match char {
+        LexCharacter::Literal(c) => Ok(Literal::Character(*c)),
+        LexCharacter::Escaped(e) => todo!(),
+        LexCharacter::Unicode(u) => {
+            Ok(Literal::Character(char::try_from(ParseSyntaxError::try_parse_hex(u, i.span.clone())?)?))
+        },
+    }
+}
+
 fn number<'a>(i: &Token<'a>) -> Result<Literal, ParseSyntaxError<'a>> {
     let number = i.lexeme.to_number();
     // TODO: Parse correctly
@@ -251,12 +282,7 @@ fn string<'a>(i: &Token<'a>) -> Result<Literal, ParseSyntaxError<'a>> {
             Fragment::Escaped(c) => output.push(*c),
             Fragment::Unescaped(s) => output.push_str(s),
             Fragment::HexValue(hex) => {
-                let Ok(hex_value) = u32::from_str_radix(hex, 16) else {
-                    return Err(ParseSyntaxError::InvalidHexValue {
-                        value: hex.to_string(),
-                        span: i.span.clone(),
-                    });
-                };
+                let hex_value = ParseSyntaxError::try_parse_hex(hex, i.span.clone())?;
                 let Some(c) = char::from_u32(hex_value) else {
                     return Err(ParseSyntaxError::InvalidHexValue {
                         value: hex.to_string(),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -4,11 +4,8 @@ use crate::{
     num::Number,
     syntax::Syntax,
 };
-use std::{
-    borrow::Cow,
-    char::CharTryFromError,
-};
 use rug::Integer;
+use std::char::CharTryFromError;
 
 #[derive(Debug)]
 pub enum ParseSyntaxError<'a> {
@@ -38,10 +35,12 @@ impl From<CharTryFromError> for ParseSyntaxError<'_> {
 
 impl<'a> ParseSyntaxError<'a> {
     fn try_parse_hex<S: AsRef<str> + ?Sized>(hex: &S, span: InputSpan<'a>) -> Result<u32, Self> {
-        u32::from_str_radix(hex.as_ref(), 16).ok().ok_or_else(|| Self::InvalidHexValue {
-            value: hex.as_ref().to_string(),
-            span,
-        })
+        u32::from_str_radix(hex.as_ref(), 16)
+            .ok()
+            .ok_or_else(|| Self::InvalidHexValue {
+                value: hex.as_ref().to_string(),
+                span,
+            })
     }
 
     fn invalid_period(token: &Token<'a>) -> Self {
@@ -258,9 +257,9 @@ fn character<'a>(i: &Token<'a>) -> Result<Literal, ParseSyntaxError<'a>> {
     match char {
         LexCharacter::Literal(c) => Ok(Literal::Character(*c)),
         LexCharacter::Escaped(e) => Ok(Literal::Character((*e).into())),
-        LexCharacter::Unicode(u) => {
-            Ok(Literal::Character(char::try_from(ParseSyntaxError::try_parse_hex(u, i.span.clone())?)?))
-        },
+        LexCharacter::Unicode(u) => Ok(Literal::Character(char::try_from(
+            ParseSyntaxError::try_parse_hex(u, i.span.clone())?,
+        )?)),
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -70,6 +70,7 @@ impl Value {
             ast::Literal::Number(n) => Value::Number(n.clone()),
             ast::Literal::Boolean(b) => Value::Boolean(*b),
             ast::Literal::String(s) => Value::String(s.clone()),
+            ast::Literal::Character(c) => Value::Character(*c),
             _ => todo!("Literal evaluation not implemented"),
         }
     }
@@ -179,7 +180,7 @@ impl fmt::Display for Value {
                 write!(f, ")")
             }
             Self::Null => write!(f, "()"),
-            Self::Character(c) => write!(f, "\\x{c}"),
+            Self::Character(c) => write!(f, "#\\{c}"),
             Self::ByteVector(_) => write!(f, "<byte-vector>"),
             // TODO: This shouldn't be debug output.
             Self::Syntax(syntax) => write!(f, "{:?}", syntax),
@@ -216,7 +217,7 @@ impl fmt::Debug for Value {
                 write!(f, ")")
             }
             Self::Null => write!(f, "()"),
-            Self::Character(c) => write!(f, "\\x{c}"),
+            Self::Character(c) => write!(f, "#\\{c}"),
             Self::ByteVector(_) => write!(f, "<byte-vector>"),
             Self::Syntax(syntax) => write!(f, "{:?}", syntax),
             Self::Closure(_) => write!(f, "<procedure>"),

--- a/src/value.rs
+++ b/src/value.rs
@@ -280,9 +280,21 @@ macro_rules! impl_try_from_value_for {
             }
         }
     };
+    ($ty:ty, $enum_variant:ident, $type_name:literal, copy) => {
+        impl_try_from_value_for!($ty, $enum_variant, $type_name);
+        impl TryFrom<&Value> for $ty {
+            type Error = Exception;
+            fn try_from(v: &Value) -> Result<$ty, Self::Error> {
+                match v {
+                    Value::$enum_variant(i) => Ok(*i),
+                    e => Err(Exception::invalid_type($type_name, e.type_name())),
+                }
+            }
+        }
+    }
 }
 
-impl_try_from_value_for!(bool, Boolean, "bool");
+impl_try_from_value_for!(bool, Boolean, "bool", copy);
 impl_try_from_value_for!(Number, Number, "number");
 impl_try_from_value_for!(Closure, Closure, "procedure");
 impl_try_from_value_for!(Record, Record, "record");
@@ -291,7 +303,7 @@ impl_try_from_value_for!(Transformer, Transformer, "transformer");
 impl_try_from_value_for!(CapturedEnv, CapturedEnv, "environment");
 impl_try_from_value_for!(Syntax, Syntax, "syntax");
 impl_try_from_value_for!(Vec<Value>, Vector, "vector");
-impl_try_from_value_for!(char, Character, "char");
+impl_try_from_value_for!(char, Character, "char", copy);
 impl_try_from_value_for!(String, String, "string");
 
 pub fn eqv(a: &Gc<Value>, b: &Gc<Value>) -> bool {

--- a/src/value.rs
+++ b/src/value.rs
@@ -291,7 +291,7 @@ macro_rules! impl_try_from_value_for {
                 }
             }
         }
-    }
+    };
 }
 
 impl_try_from_value_for!(bool, Boolean, "bool", copy);

--- a/tests/r7rs.scm
+++ b/tests/r7rs.scm
@@ -25,11 +25,10 @@
   (list->vector '(dididit dah))
   #(dididit dah))
 
-; cannot lex
-; (assert-eq
-;   (string->vector "ABC")
-;   #(#\A #\B #\C))
-; (assert-eq (vector->string #(#\A #\B #\C)) "ABC")
+ (assert-eq
+   (string->vector "ABC")
+   #(#\A #\B #\C))
+ (assert-eq (vector->string #(#\A #\B #\C)) "ABC")
 
 (define a #(1 8 2 8))
 (define b (vector-copy a))

--- a/tests/r7rs.scm
+++ b/tests/r7rs.scm
@@ -1,8 +1,11 @@
 ;; r7rs.scm - Compatibility test for the R7RS small implementation
 
+;; 6.6 Characters
+(assert-eq (char->integer #\a) 97)
+(assert-eq (integer->char 97) #\a)
+
 ;; 6.8 Vectors
 
-; not part of r7rs examples
 (assert-eq (make-vector 10 'a) #(a a a a a a a a a a))
 
 (assert-eq (vector 'a 'b 'c) #(a b c))
@@ -30,22 +33,24 @@
    #(#\A #\B #\C))
  (assert-eq (vector->string #(#\A #\B #\C)) "ABC")
 
-(define a #(1 8 2 8))
-(define b (vector-copy a))
-(define c (vector-copy b 1 3))
-(vector-set! b 0 3)
+(let* ((a #(1 8 2 8))
+       (b (vector-copy a))
+       (c (vector-copy b 1 3)))
 
-(assert-eq b #(3 8 2 8))
-(assert-eq c #(8 2))
+  (vector-set! b 0 3)
 
-(set! a (vector 1 2 3 4 5))
-(set! b (vector 10 20 30 40 50))
-(vector-copy! b 1 a 0 2)
-(assert-eq b #(10 1 2 40 50))
+  (assert-eq b #(3 8 2 8))
+  (assert-eq c #(8 2)))
+
+(let ((a (vector 1 2 3 4 5))
+      (b (vector 10 20 30 40 50)))
+
+  (vector-copy! b 1 a 0 2)
+  (assert-eq b #(10 1 2 40 50)))
 
 (assert-eq (vector-append #(a b c) #(d e f))
            #(a b c d e f))
 
-(define v (vector 1 2 3 4 5))
-(vector-fill! v 'smash 2 4)
-(assert-eq v #(1 2 smash smash 5))
+(let ((v (vector 1 2 3 4 5)))
+  (vector-fill! v 'smash 2 4)
+  (assert-eq v #(1 2 smash smash 5)))


### PR DESCRIPTION
# Implemented
 - `char->integer`
 - `integer->char`
 - `char=?`
 - `char<?`
 - `char>?`
 - `char>=?`
 - `char<=?`
 - `char-ci-=?`
 - `char-ci-<?`
 - `char-ci->?`
 - `char-ci->=?`
 - `char-ci-<=?`
 - `char-alphabetic?`
 - `char-numeric?`
 - `char-whitespace?`
 - `char-upper?`
 - `char-lower?`

# Todo:
I don't know how to implement these since I don't know unicode that well.
 - `digit-value`
 - `char-upcase`
 - `char-downcase`
 - `char-foldcase`

- **add char lexer**
- **added lexing characters**
- **uncommented test**
- **made tests not global**
- **added parsing escaped characters**
- **made tests not global**
- **added character comparisons**
- **added character unicode class predicates**
