### PR TITLE
vec to smallvec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,7 @@ homepage = "https://github.com/maplant/scheme-rs"
 repository = "https://github.com/maplant/scheme-rs"
 
 [dependencies]
-async-trait = "0.1"
 derive_more = { version = "1.0", features = ["debug", "from"]}
-dyn-clone = "1.0.13"
 either = "1"
 futures = "0.3"
 indexmap = "2"
@@ -25,12 +23,10 @@ num = "0.4"
 scheme-rs-macros = { version = "0.1.0-alpha.1", path = "proc-macros" }
 rug = { version = "1", features = ["num-traits"] }
 rand = "0.8"
-thiserror = "1"
 tokio = { version = "1.41", features = ["full"] }
 unicode_categories = "0.1"
 reedline = "0.36"
-# TODO: Get rid of this dependency
-derivative = "2"
+smallvec = "1.14.0"
 
 [profile.release]
 lto = true

--- a/src/character.rs
+++ b/src/character.rs
@@ -2,8 +2,8 @@ mod unicode;
 
 use crate::{exception::Exception, gc::Gc, num::Number, registry::bridge, value::Value};
 use smallvec::{smallvec, SmallVec};
-use unicode_categories::UnicodeCategories;
 use unicode::*;
+use unicode_categories::UnicodeCategories;
 
 fn char_switch_case<I: Iterator<Item = char> + ExactSizeIterator>(
     ch: char,

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -17,8 +17,8 @@ pub use collection::init_gc;
 use collection::{dec_rc, inc_rc};
 use either::Either;
 use futures::future::Shared;
-use smallvec::SmallVec;
 pub use scheme_rs_macros::Trace;
+use smallvec::SmallVec;
 
 use std::{
     cell::UnsafeCell,

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -136,7 +136,10 @@ pub async fn cdr(val: &Gc<Value>) -> Result<SmallVec<[Gc<Value>; 1]>, Exception>
 }
 
 #[bridge(name = "set-car!", lib = "(base)")]
-pub async fn set_car(var: &Gc<Value>, val: &Gc<Value>) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
+pub async fn set_car(
+    var: &Gc<Value>,
+    val: &Gc<Value>,
+) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     let mut var = var.write();
     match &mut *var {
         Value::Pair(ref mut car, _cdr) => *car = val.clone(),
@@ -146,7 +149,10 @@ pub async fn set_car(var: &Gc<Value>, val: &Gc<Value>) -> Result<SmallVec<[Gc<Va
 }
 
 #[bridge(name = "set-cdr!", lib = "(base)")]
-pub async fn set_cdr(var: &Gc<Value>, val: &Gc<Value>) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
+pub async fn set_cdr(
+    var: &Gc<Value>,
+    val: &Gc<Value>,
+) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     let mut var = var.write();
     match &mut *var {
         Value::Pair(_car, ref mut cdr) => *cdr = val.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use scheme_rs::{
     syntax::Syntax,
     value::Value,
 };
+use smallvec::SmallVec;
 use std::borrow::Cow;
 
 struct InputParser;
@@ -99,9 +100,9 @@ async fn compile_and_run_str<'e>(
     runtime: &Gc<Runtime>,
     env: &Environment,
     input: &'e str,
-) -> Result<Vec<Gc<Value>>, EvalError<'e>> {
+) -> Result<SmallVec<[Gc<Value>; 1]>, EvalError<'e>> {
     let sexprs = Syntax::from_str(input, None)?;
-    let mut output = Vec::new();
+    let mut output = SmallVec::new();
     for sexpr in sexprs {
         let span = sexpr.span().clone();
         let expr = DefinitionBody::parse(runtime, &[sexpr], env, &span).await?;

--- a/src/num.rs
+++ b/src/num.rs
@@ -385,7 +385,10 @@ pub async fn add(args: &[Gc<Value>]) -> Result<SmallVec<[Gc<Value>; 1]>, Excepti
 }
 
 #[bridge(name = "-", lib = "(base)")]
-pub async fn sub(arg1: &Gc<Value>, args: &[Gc<Value>]) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
+pub async fn sub(
+    arg1: &Gc<Value>,
+    args: &[Gc<Value>],
+) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     let arg1 = arg1.read();
     let arg1: &Number = arg1.as_ref().try_into()?;
     if args.is_empty() {
@@ -413,7 +416,10 @@ pub async fn mul(args: &[Gc<Value>]) -> Result<SmallVec<[Gc<Value>; 1]>, Excepti
 }
 
 #[bridge(name = "/", lib = "(base)")]
-pub async fn div(arg1: &Gc<Value>, args: &[Gc<Value>]) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
+pub async fn div(
+    arg1: &Gc<Value>,
+    args: &[Gc<Value>],
+) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     let arg1 = arg1.read();
     let arg1: &Number = arg1.as_ref().try_into()?;
     if arg1.is_zero() {

--- a/src/num.rs
+++ b/src/num.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use num::{complex::Complex64, FromPrimitive, ToPrimitive, Zero};
 use rug::{Complete, Integer, Rational};
+use smallvec::{smallvec, SmallVec};
 use std::{
     cmp::Ordering,
     fmt,
@@ -352,43 +353,43 @@ unsafe impl Trace for Number {
 }
 
 #[bridge(name = "zero?", lib = "(base)")]
-pub async fn zero(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn zero(arg: &Gc<Value>) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     let arg = arg.read();
     let num: &Number = arg.as_ref().try_into()?;
-    Ok(vec![Gc::new(Value::Boolean(num.is_zero()))])
+    Ok(smallvec![Gc::new(Value::Boolean(num.is_zero()))])
 }
 
 #[bridge(name = "even?", lib = "(base)")]
-pub async fn even(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn even(arg: &Gc<Value>) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     let arg = arg.read();
     let num: &Number = arg.as_ref().try_into()?;
-    Ok(vec![Gc::new(Value::Boolean(num.is_even()))])
+    Ok(smallvec![Gc::new(Value::Boolean(num.is_even()))])
 }
 
 #[bridge(name = "odd?", lib = "(base)")]
-pub async fn odd(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn odd(arg: &Gc<Value>) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     let arg = arg.read();
     let num: &Number = arg.as_ref().try_into()?;
-    Ok(vec![Gc::new(Value::Boolean(num.is_odd()))])
+    Ok(smallvec![Gc::new(Value::Boolean(num.is_odd()))])
 }
 
 #[bridge(name = "+", lib = "(base)")]
-pub async fn add(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn add(args: &[Gc<Value>]) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     let mut result = Number::FixedInteger(0);
     for arg in args {
         let arg = arg.read();
         let num: &Number = arg.as_ref().try_into()?;
         result = &result + num;
     }
-    Ok(vec![Gc::new(Value::Number(result))])
+    Ok(smallvec![Gc::new(Value::Number(result))])
 }
 
 #[bridge(name = "-", lib = "(base)")]
-pub async fn sub(arg1: &Gc<Value>, args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn sub(arg1: &Gc<Value>, args: &[Gc<Value>]) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     let arg1 = arg1.read();
     let arg1: &Number = arg1.as_ref().try_into()?;
     if args.is_empty() {
-        Ok(vec![Gc::new(Value::Number(-arg1.clone()))])
+        Ok(smallvec![Gc::new(Value::Number(-arg1.clone()))])
     } else {
         let mut result = arg1.clone();
         for arg in args {
@@ -396,23 +397,23 @@ pub async fn sub(arg1: &Gc<Value>, args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>,
             let num: &Number = arg.as_ref().try_into()?;
             result = &result - num;
         }
-        Ok(vec![Gc::new(Value::Number(result))])
+        Ok(smallvec![Gc::new(Value::Number(result))])
     }
 }
 
 #[bridge(name = "*", lib = "(base)")]
-pub async fn mul(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn mul(args: &[Gc<Value>]) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     let mut result = Number::FixedInteger(1);
     for arg in args {
         let arg = arg.read();
         let num: &Number = arg.as_ref().try_into()?;
         result = &result * num;
     }
-    Ok(vec![Gc::new(Value::Number(result))])
+    Ok(smallvec![Gc::new(Value::Number(result))])
 }
 
 #[bridge(name = "/", lib = "(base)")]
-pub async fn div(arg1: &Gc<Value>, args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn div(arg1: &Gc<Value>, args: &[Gc<Value>]) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     let arg1 = arg1.read();
     let arg1: &Number = arg1.as_ref().try_into()?;
     if arg1.is_zero() {
@@ -427,11 +428,11 @@ pub async fn div(arg1: &Gc<Value>, args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>,
         }
         result = &result / num;
     }
-    Ok(vec![Gc::new(Value::Number(result))])
+    Ok(smallvec![Gc::new(Value::Number(result))])
 }
 
 #[bridge(name = "=", lib = "(base)")]
-pub async fn equals(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn equals(args: &[Gc<Value>]) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     if let Some((first, rest)) = args.split_first() {
         let first = first.read();
         let first: &Number = first.as_ref().try_into()?;
@@ -439,15 +440,15 @@ pub async fn equals(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
             let next = next.read();
             let next: &Number = next.as_ref().try_into()?;
             if first != next {
-                return Ok(vec![Gc::new(Value::Boolean(false))]);
+                return Ok(smallvec![Gc::new(Value::Boolean(false))]);
             }
         }
     }
-    Ok(vec![Gc::new(Value::Boolean(true))])
+    Ok(smallvec![Gc::new(Value::Boolean(true))])
 }
 
 #[bridge(name = ">", lib = "(base)")]
-pub async fn greater(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn greater(args: &[Gc<Value>]) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     if let Some((head, rest)) = args.split_first() {
         let mut prev = head.clone();
         for next in rest {
@@ -465,17 +466,17 @@ pub async fn greater(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
                     return Err(Exception::invalid_type("number", "complex"));
                 }
                 if prev <= next {
-                    return Ok(vec![Gc::new(Value::Boolean(false))]);
+                    return Ok(smallvec![Gc::new(Value::Boolean(false))]);
                 }
             }
             prev = next.clone();
         }
     }
-    Ok(vec![Gc::new(Value::Boolean(true))])
+    Ok(smallvec![Gc::new(Value::Boolean(true))])
 }
 
 #[bridge(name = ">=", lib = "(base)")]
-pub async fn greater_equal(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn greater_equal(args: &[Gc<Value>]) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     if let Some((head, rest)) = args.split_first() {
         let mut prev = head.clone();
         for next in rest {
@@ -491,17 +492,17 @@ pub async fn greater_equal(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Excepti
                     return Err(Exception::invalid_type("number", "complex"));
                 }
                 if prev < next {
-                    return Ok(vec![Gc::new(Value::Boolean(false))]);
+                    return Ok(smallvec![Gc::new(Value::Boolean(false))]);
                 }
             }
             prev = next.clone();
         }
     }
-    Ok(vec![Gc::new(Value::Boolean(true))])
+    Ok(smallvec![Gc::new(Value::Boolean(true))])
 }
 
 #[bridge(name = "<", lib = "(base)")]
-pub async fn lesser(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn lesser(args: &[Gc<Value>]) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     if let Some((head, rest)) = args.split_first() {
         let mut prev = head.clone();
         for next in rest {
@@ -517,17 +518,17 @@ pub async fn lesser(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
                     return Err(Exception::invalid_type("number", "complex"));
                 }
                 if prev >= next {
-                    return Ok(vec![Gc::new(Value::Boolean(false))]);
+                    return Ok(smallvec![Gc::new(Value::Boolean(false))]);
                 }
             }
             prev = next.clone();
         }
     }
-    Ok(vec![Gc::new(Value::Boolean(true))])
+    Ok(smallvec![Gc::new(Value::Boolean(true))])
 }
 
 #[bridge(name = "<=", lib = "(base)")]
-pub async fn lesser_equal(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn lesser_equal(args: &[Gc<Value>]) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     if let Some((head, rest)) = args.split_first() {
         let mut prev = head.clone();
         for next in rest {
@@ -543,55 +544,55 @@ pub async fn lesser_equal(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exceptio
                     return Err(Exception::invalid_type("number", "complex"));
                 }
                 if prev > next {
-                    return Ok(vec![Gc::new(Value::Boolean(false))]);
+                    return Ok(smallvec![Gc::new(Value::Boolean(false))]);
                 }
             }
             prev = next.clone();
         }
     }
-    Ok(vec![Gc::new(Value::Boolean(true))])
+    Ok(smallvec![Gc::new(Value::Boolean(true))])
 }
 
 #[bridge(name = "number?", lib = "(base)")]
-pub async fn is_number(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn is_number(arg: &Gc<Value>) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     let arg = arg.read();
-    Ok(vec![Gc::new(Value::Boolean(matches!(
+    Ok(smallvec![Gc::new(Value::Boolean(matches!(
         &*arg,
         Value::Number(_)
     )))])
 }
 
 #[bridge(name = "integer?", lib = "(base)")]
-pub async fn is_integer(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn is_integer(arg: &Gc<Value>) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     let arg = arg.read();
-    Ok(vec![Gc::new(Value::Boolean(matches!(
+    Ok(smallvec![Gc::new(Value::Boolean(matches!(
         &*arg,
         Value::Number(Number::FixedInteger(_)) | Value::Number(Number::BigInteger(_))
     )))])
 }
 
 #[bridge(name = "rational?", lib = "(base)")]
-pub async fn is_rational(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn is_rational(arg: &Gc<Value>) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     let arg = arg.read();
-    Ok(vec![Gc::new(Value::Boolean(matches!(
+    Ok(smallvec![Gc::new(Value::Boolean(matches!(
         &*arg,
         Value::Number(Number::Rational(_))
     )))])
 }
 
 #[bridge(name = "real?", lib = "(base)")]
-pub async fn is_real(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn is_real(arg: &Gc<Value>) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     let arg = arg.read();
-    Ok(vec![Gc::new(Value::Boolean(matches!(
+    Ok(smallvec![Gc::new(Value::Boolean(matches!(
         &*arg,
         Value::Number(Number::Real(_))
     )))])
 }
 
 #[bridge(name = "complex?", lib = "(base)")]
-pub async fn is_complex(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn is_complex(arg: &Gc<Value>) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     let arg = arg.read();
-    Ok(vec![Gc::new(Value::Boolean(matches!(
+    Ok(smallvec![Gc::new(Value::Boolean(matches!(
         &*arg,
         Value::Number(Number::Complex(_))
     )))])

--- a/src/records.rs
+++ b/src/records.rs
@@ -1,7 +1,5 @@
 //! Rudimentary structure support. CPS will probably make a lot of this redundant.
 
-use std::collections::HashMap;
-
 use crate::{
     ast::ParseAstError,
     env::{Environment, Var},
@@ -9,6 +7,8 @@ use crate::{
     syntax::{Identifier, Span, Syntax},
     value::Value,
 };
+use smallvec::SmallVec;
+use std::collections::HashMap;
 
 /// Type declaration for a record.
 #[derive(Debug, Trace, Clone)]
@@ -41,7 +41,7 @@ fn is_subtype_of(lhs: &Gc<RecordType>, rhs: &Gc<RecordType>) -> bool {
 #[derive(Debug, Trace, Clone)]
 pub struct Record {
     record_type: Gc<RecordType>,
-    fields: Vec<Gc<Value>>,
+    fields: SmallVec<[Gc<Value>; 1]>,
 }
 
 #[derive(Clone, Trace, Debug)]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -18,6 +18,7 @@ use inkwell::{
     targets::{InitializationConfig, Target},
     AddressSpace, OptimizationLevel,
 };
+use smallvec::SmallVec;
 use std::{collections::HashMap, mem::ManuallyDrop};
 use tokio::sync::{mpsc, oneshot};
 
@@ -297,7 +298,7 @@ unsafe extern "C" fn make_forward(
 ) -> *mut Application {
     let op = Gc::from_ptr(op);
     let to_forward = Gc::from_ptr(to_forward);
-    let mut args = Vec::new();
+    let mut args = SmallVec::new();
     list_to_vec(&to_forward, &mut args);
     let op_ref = op.read();
     let op: &Closure = op_ref.as_ref().try_into().unwrap();
@@ -309,7 +310,7 @@ unsafe extern "C" fn make_forward(
 /// Create a boxed application that simply returns its arguments
 pub(crate) unsafe extern "C" fn make_return_values(args: *mut GcInner<Value>) -> *mut Application {
     let args = Gc::from_ptr(args);
-    let mut flattened = Vec::new();
+    let mut flattened = SmallVec::new();
     list_to_vec(&args, &mut flattened);
 
     let app = Application::new_empty(flattened);

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -10,6 +10,7 @@ use crate::{
     value::Value,
 };
 use futures::future::BoxFuture;
+use smallvec::{smallvec, SmallVec};
 use std::{
     collections::{BTreeSet, HashSet},
     fmt,
@@ -144,7 +145,7 @@ impl Syntax {
         match &*datum {
             Value::Null => Syntax::new_null(Span::default()),
             Value::Pair(lhs, rhs) => {
-                let mut list = Vec::new();
+                let mut list = SmallVec::new();
                 list.push(lhs.clone());
                 list_to_vec_with_null(rhs, &mut list);
                 // TODO: Use futures combinators
@@ -554,12 +555,12 @@ impl Syntax {
 pub async fn syntax_to_datum(
     _cont: &Option<Arc<Continuation>>,
     syn: &Gc<Value>,
-) -> Result<Vec<Gc<Value>>, RuntimeError> {
+) -> Result<SmallVec<[Gc<Value>; 1]>, RuntimeError> {
     let syn = syn.read();
     let Value::Syntax(ref syn) = &*syn else {
         return Err(RuntimeError::invalid_type("syntax", syn.type_name()));
     };
-    Ok(vec![Gc::new(Value::from_syntax(syn))])
+    Ok(smallvec![Gc::new(Value::from_syntax(syn))])
 }
 */
 
@@ -567,7 +568,7 @@ pub async fn syntax_to_datum(
 pub async fn datum_to_syntax(
     template_id: &Gc<Value>,
     datum: &Gc<Value>,
-) -> Result<Vec<Gc<Value>>, Exception> {
+) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     let template_id = template_id.read();
     let Value::Syntax(Syntax::Identifier {
         ident: template_id, ..
@@ -575,7 +576,7 @@ pub async fn datum_to_syntax(
     else {
         return Err(Exception::invalid_type("syntax", template_id.type_name()));
     };
-    Ok(vec![Gc::new(Value::Syntax(Syntax::from_datum(
+    Ok(smallvec![Gc::new(Value::Syntax(Syntax::from_datum(
         &template_id.marks,
         datum,
     )))])

--- a/src/value.rs
+++ b/src/value.rs
@@ -245,7 +245,7 @@ macro_rules! impl_from_into_iter_for_list_value {
                 crate::lists::slice_to_list(&iter)
             }
         }
-    }
+    };
 }
 impl_from_into_iter_for_list_value!(Vec<Gc<Value>>);
 impl_from_into_iter_for_list_value!(SmallVec<[Gc<Value>; 1]>);
@@ -387,7 +387,10 @@ pub async fn vector_pred(arg: &Gc<Value>) -> Result<SmallVec<[Gc<Value>; 1]>, Ex
 #[bridge(name = "null?", lib = "(base)")]
 pub async fn null_pred(arg: &Gc<Value>) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     let arg = arg.read();
-    Ok(smallvec![Gc::new(Value::Boolean(matches!(&*arg, Value::Null)))])
+    Ok(smallvec![Gc::new(Value::Boolean(matches!(
+        &*arg,
+        Value::Null
+    )))])
 }
 
 #[bridge(name = "pair?", lib = "(base)")]

--- a/src/vectors.rs
+++ b/src/vectors.rs
@@ -92,7 +92,10 @@ impl Indexer for VectorIndexer {
 }
 
 #[bridge(name = "make-vector", lib = "(base)")]
-pub async fn make_vector(n: &Gc<Value>, with: &[Gc<Value>]) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
+pub async fn make_vector(
+    n: &Gc<Value>,
+    with: &[Gc<Value>],
+) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     let n = n.read();
     let n: &Number = n.as_ref().try_into()?;
     let n = n.to_u64();
@@ -122,7 +125,10 @@ pub async fn vector(args: &[Gc<Value>]) -> Result<SmallVec<[Gc<Value>; 1]>, Exce
 }
 
 #[bridge(name = "vector-ref", lib = "(base)")]
-pub async fn vector_ref(vec: &Gc<Value>, index: &Gc<Value>) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
+pub async fn vector_ref(
+    vec: &Gc<Value>,
+    index: &Gc<Value>,
+) -> Result<SmallVec<[Gc<Value>; 1]>, Exception> {
     let vec = vec.read();
     let vec: &Vec<Value> = vec.as_ref().try_into()?;
 


### PR DESCRIPTION
Convert `Vec<Gc<Value>>` into `SmallVec<[Gc<Value>; 1]>`.

This does not add any dependencies, as it is already used by crossterm.

- **fixed merge conflict**
- **cargo fmt**
