### PR TITLE
implement negative number lexing

### DIFF
--- a/src/lex.rs
+++ b/src/lex.rs
@@ -47,25 +47,6 @@ pub enum Lexeme<'a> {
     HashCommaAt,
 }
 
-//impl Lexeme<'static> {
-//    fn identifier_owned(s: String) -> Self {
-//        Self::Identifier(Cow::Owned(s))
-//    }
-//
-//    fn number_owned<'a>(num: Number<'a>) -> Self {
-//        todo!()
-//        //Self::Number(Number {
-//        //    radix: num.radix,
-//        //    negative: num.negative,
-//        //    contents: num.contents,
-//        //})
-//    }
-//
-//    fn string_owned(v: Vec<Fragment<'static>>) -> Self {
-//        Self::String(v)
-//    }
-//}
-
 impl<'a> Lexeme<'a> {
     pub fn to_boolean(&self) -> bool {
         let Lexeme::Boolean(b) = self else {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast::Literal,
-    lex::{Character as LexCharacter, Fragment, InputSpan, LexError, Lexeme, NumberLexeme, Token, TryFromNumberLexemeError},
+    lex::{Character as LexCharacter, Fragment, InputSpan, LexError, Lexeme, Number as LexNumber, Token, TryFromNumberError},
     num::Number,
     syntax::Syntax,
 };
@@ -20,7 +20,7 @@ pub enum ParseSyntaxError<'a> {
     CharTryFrom(CharTryFromError),
     Lex(LexError<'a>),
     TryFromInt(TryFromIntError),
-    TryFromNumberLexeme(TryFromNumberLexemeError<'a>),
+    TryFromNumber(TryFromNumberError<'a>),
 }
 impl fmt::Display for ParseSyntaxError<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -47,7 +47,7 @@ impl fmt::Display for ParseSyntaxError<'_> {
             Self::CharTryFrom(e) => write!(f, "{}", e),
             Self::Lex(e) => write!(f, "{}", e),
             Self::TryFromInt(e) => write!(f, "{}", e),
-            Self::TryFromNumberLexeme(e) => write!(f, "{}", e),
+            Self::TryFromNumber(e) => write!(f, "{}", e),
         }
     }
 }
@@ -68,9 +68,9 @@ impl From<CharTryFromError> for ParseSyntaxError<'_> {
         Self::CharTryFrom(e)
     }
 }
-impl<'a> From<TryFromNumberLexemeError<'a>> for ParseSyntaxError<'a> {
-    fn from(e: TryFromNumberLexemeError<'a>) -> Self {
-        Self::TryFromNumberLexeme(e)
+impl<'a> From<TryFromNumberError<'a>> for ParseSyntaxError<'a> {
+    fn from(e: TryFromNumberError<'a>) -> Self {
+        Self::TryFromNumber(e)
     }
 }
 
@@ -344,10 +344,10 @@ fn character<'a>(i: &Token<'a>) -> Result<Literal, ParseSyntaxError<'a>> {
     }
 }
 
-fn number<'a>(i: &NumberLexeme<'a>) -> Result<Literal, ParseSyntaxError<'a>> {
-    <NumberLexeme as TryInto<i64>>::try_into(*i)
+fn number<'a>(i: &LexNumber<'a>) -> Result<Literal, ParseSyntaxError<'a>> {
+    <LexNumber as TryInto<i64>>::try_into(*i)
         .map(Number::FixedInteger)
-        .or_else(|_| <NumberLexeme as TryInto<Integer>>::try_into(*i)
+        .or_else(|_| <LexNumber as TryInto<Integer>>::try_into(*i)
             .map(Number::BigInteger))
         .map(Literal::Number)
         .map_err(ParseSyntaxError::from)

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,10 +1,12 @@
 use crate::{
     ast::Literal,
-    lex::{Character as LexCharacter, Fragment, InputSpan, LexError, Lexeme, Number as LexNumber, Token, TryFromNumberError},
+    lex::{
+        Character as LexCharacter, Fragment, InputSpan, LexError, Lexeme, Number as LexNumber,
+        Token, TryFromNumberError,
+    },
     num::Number,
     syntax::Syntax,
 };
-use num::BigInt;
 use rug::Integer;
 use std::{char::CharTryFromError, error::Error as StdError, fmt, num::TryFromIntError};
 
@@ -122,9 +124,7 @@ pub fn expression<'a, 'b>(
         [Token {
             lexeme: Lexeme::Number(n),
             span,
-        }, tail @ ..] => {
-            Ok((tail, Syntax::new_literal(number(n)?, span.clone())))
-        }
+        }, tail @ ..] => Ok((tail, Syntax::new_literal(number(n)?, span.clone()))),
         [s @ token!(Lexeme::String(_)), tail @ ..] => {
             Ok((tail, Syntax::new_literal(string(s)?, s.span.clone())))
         }
@@ -347,8 +347,7 @@ fn character<'a>(i: &Token<'a>) -> Result<Literal, ParseSyntaxError<'a>> {
 fn number<'a>(i: &LexNumber<'a>) -> Result<Literal, ParseSyntaxError<'a>> {
     <LexNumber as TryInto<i64>>::try_into(*i)
         .map(Number::FixedInteger)
-        .or_else(|_| <LexNumber as TryInto<Integer>>::try_into(*i)
-            .map(Number::BigInteger))
+        .or_else(|_| <LexNumber as TryInto<Integer>>::try_into(*i).map(Number::BigInteger))
         .map(Literal::Number)
         .map_err(ParseSyntaxError::from)
 }

--- a/tests/r7rs.scm
+++ b/tests/r7rs.scm
@@ -8,14 +8,14 @@
 
 (assert-eq (negative? 1) #f)
 (assert-eq (negative? 0) #f)
-(assert-eq (negative? (- 1)) #t)
+(assert-eq (negative? -1) #t)
 
 (assert-eq (abs 1) 1)
 (assert-eq (abs 0) 0)
-(assert-eq (abs (- 1)) 1)
+(assert-eq (abs -1) 1)
 
 (assert-eq (min 2 4 1 3) 1)
-(assert-eq (min 2 4 (- 1 ) 3) (- 1))
+(assert-eq (min 2 4 -1 3) -1)
 (assert-eq (min 2 4 3) 2)
 
 (assert-eq (max 2 4 1 3) 4)


### PR DESCRIPTION
- **added negative number lexer and removed unnessecary allocations**
- **finished negative numbers**
- **passed tests**
- **renamed `NumberLexeme` to `Number`**
- **cargo clippy|fmt**
- **changed `(- number)` to `-number` in tests**
- **removed `impl_try_into_number_lexeme_for_big_int` macro**
