### PR TITLE
Expand primitive operators to include common arithmetic and comparison functions 

### DIFF
--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -48,7 +48,7 @@ pub fn bridge(args: TokenStream, item: TokenStream) -> TokenStream {
     let wrapper: ItemFn = if !is_variadic {
         let arg_indices: Vec<_> = (0..num_args).collect();
         parse_quote! {
-            fn #wrapper_name<'a>(
+            pub(crate) fn #wrapper_name<'a>(
                 args: &'a [::scheme_rs::gc::Gc<::scheme_rs::value::Value>],
                 rest_args: &'a [::scheme_rs::gc::Gc<::scheme_rs::value::Value>],
                 cont: &'a ::scheme_rs::gc::Gc<::scheme_rs::value::Value>,
@@ -78,7 +78,7 @@ pub fn bridge(args: TokenStream, item: TokenStream) -> TokenStream {
     } else {
         let arg_indices: Vec<_> = (0..num_args).collect();
         parse_quote! {
-            fn #wrapper_name<'a>(
+            pub(crate) fn #wrapper_name<'a>(
                 args: &'a [::scheme_rs::gc::Gc<::scheme_rs::value::Value>],
                 rest_args: &'a [::scheme_rs::gc::Gc<::scheme_rs::value::Value>],
                 cont: &'a ::scheme_rs::gc::Gc<::scheme_rs::value::Value>,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -412,7 +412,11 @@ impl Expression {
     #[allow(unpredictable_function_pointer_comparisons)]
     pub fn to_primop(&self) -> Option<PrimOp> {
         use crate::{
-            num::{add_wrapper, div_wrapper, mul_wrapper, sub_wrapper},
+            num::{
+                add_builtin_wrapper, div_builtin_wrapper, equal_builtin_wrapper,
+                greater_builtin_wrapper, greater_equal_builtin_wrapper, lesser_builtin_wrapper,
+                lesser_equal_builtin_wrapper, mul_builtin_wrapper, sub_builtin_wrapper,
+            },
             proc::{Closure, FuncPtr::Bridge},
         };
 
@@ -420,10 +424,15 @@ impl Expression {
             let val_ref = global.value_ref().read();
             let val: &Closure = val_ref.as_ref().try_into().ok()?;
             match val.func {
-                Bridge(ptr) if ptr == add_wrapper => Some(PrimOp::Add),
-                Bridge(ptr) if ptr == sub_wrapper => Some(PrimOp::Sub),
-                Bridge(ptr) if ptr == mul_wrapper => Some(PrimOp::Mul),
-                Bridge(ptr) if ptr == div_wrapper => Some(PrimOp::Div),
+                Bridge(ptr) if ptr == add_builtin_wrapper => Some(PrimOp::Add),
+                Bridge(ptr) if ptr == sub_builtin_wrapper => Some(PrimOp::Sub),
+                Bridge(ptr) if ptr == mul_builtin_wrapper => Some(PrimOp::Mul),
+                Bridge(ptr) if ptr == div_builtin_wrapper => Some(PrimOp::Div),
+                Bridge(ptr) if ptr == equal_builtin_wrapper => Some(PrimOp::Equal),
+                Bridge(ptr) if ptr == greater_builtin_wrapper => Some(PrimOp::Greater),
+                Bridge(ptr) if ptr == greater_equal_builtin_wrapper => Some(PrimOp::GreaterEqual),
+                Bridge(ptr) if ptr == lesser_builtin_wrapper => Some(PrimOp::Lesser),
+                Bridge(ptr) if ptr == lesser_equal_builtin_wrapper => Some(PrimOp::LesserEqual),
                 _ => None,
             }
         } else {

--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -337,6 +337,11 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
             PrimOp::Sub => "sub",
             PrimOp::Mul => "mul",
             PrimOp::Div => "div",
+            PrimOp::Equal => "equal",
+            PrimOp::Greater => "greater",
+            PrimOp::GreaterEqual => "greater_equal",
+            PrimOp::Lesser => "lesser",
+            PrimOp::LesserEqual => "lesser_equal",
             _ => unreachable!(),
         };
 

--- a/src/cps/mod.rs
+++ b/src/cps/mod.rs
@@ -97,6 +97,11 @@ pub enum PrimOp {
     Sub,
     Mul,
     Div,
+    Equal,
+    Greater,
+    GreaterEqual,
+    Lesser,
+    LesserEqual,
 
     // Macro expansion primitive operators:
     CaptureEnvironment,

--- a/src/cps/mod.rs
+++ b/src/cps/mod.rs
@@ -28,7 +28,7 @@ mod codegen;
 mod compile;
 mod reduce;
 
-pub use compile::{Compile, TopLevelExpr};
+pub use compile::Compile;
 
 #[derive(Clone, PartialEq)]
 pub enum Value {
@@ -89,8 +89,10 @@ impl fmt::Debug for Value {
 
 #[derive(Copy, Clone, Debug, Trace)]
 pub enum PrimOp {
-    // Math primitive operators (to be implemented):
+    /// Set cell value:
     Set,
+
+    // Math primitive operators:
     Add,
     Sub,
     Mul,

--- a/src/env.rs
+++ b/src/env.rs
@@ -361,6 +361,10 @@ impl Global {
     pub fn value(self) -> Gc<Value> {
         self.val
     }
+
+    pub fn value_ref(&self) -> &Gc<Value> {
+        &self.val
+    }
 }
 
 impl fmt::Debug for Global {

--- a/src/num.rs
+++ b/src/num.rs
@@ -373,11 +373,11 @@ pub async fn odd(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
 }
 
 #[bridge(name = "+", lib = "(base)")]
-pub async fn add(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
-    Ok(vec![Gc::new(Value::Number(add_vals(args)?))])
+pub async fn add_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+    Ok(vec![Gc::new(Value::Number(add(args)?))])
 }
 
-pub(crate) fn add_vals(vals: &[Gc<Value>]) -> Result<Number, Exception> {
+pub(crate) fn add(vals: &[Gc<Value>]) -> Result<Number, Exception> {
     let mut result = Number::FixedInteger(0);
     for val in vals {
         let val = val.read();
@@ -388,11 +388,14 @@ pub(crate) fn add_vals(vals: &[Gc<Value>]) -> Result<Number, Exception> {
 }
 
 #[bridge(name = "-", lib = "(base)")]
-pub async fn sub(arg1: &Gc<Value>, args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
-    Ok(vec![Gc::new(Value::Number(sub_vals(arg1, args)?))])
+pub async fn sub_builtin(
+    arg1: &Gc<Value>,
+    args: &[Gc<Value>],
+) -> Result<Vec<Gc<Value>>, Exception> {
+    Ok(vec![Gc::new(Value::Number(sub(arg1, args)?))])
 }
 
-pub(crate) fn sub_vals(val1: &Gc<Value>, vals: &[Gc<Value>]) -> Result<Number, Exception> {
+pub(crate) fn sub(val1: &Gc<Value>, vals: &[Gc<Value>]) -> Result<Number, Exception> {
     let val1 = val1.read();
     let val1: &Number = val1.as_ref().try_into()?;
     let mut val1 = val1.clone();
@@ -409,11 +412,11 @@ pub(crate) fn sub_vals(val1: &Gc<Value>, vals: &[Gc<Value>]) -> Result<Number, E
 }
 
 #[bridge(name = "*", lib = "(base)")]
-pub async fn mul(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
-    Ok(vec![Gc::new(Value::Number(mul_vals(args)?))])
+pub async fn mul_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+    Ok(vec![Gc::new(Value::Number(mul(args)?))])
 }
 
-pub(crate) fn mul_vals(vals: &[Gc<Value>]) -> Result<Number, Exception> {
+pub(crate) fn mul(vals: &[Gc<Value>]) -> Result<Number, Exception> {
     let mut result = Number::FixedInteger(1);
     for val in vals {
         let val = val.read();
@@ -424,11 +427,14 @@ pub(crate) fn mul_vals(vals: &[Gc<Value>]) -> Result<Number, Exception> {
 }
 
 #[bridge(name = "/", lib = "(base)")]
-pub async fn div(arg1: &Gc<Value>, args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
-    Ok(vec![Gc::new(Value::Number(div_vals(arg1, args)?))])
+pub async fn div_builtin(
+    arg1: &Gc<Value>,
+    args: &[Gc<Value>],
+) -> Result<Vec<Gc<Value>>, Exception> {
+    Ok(vec![Gc::new(Value::Number(div(arg1, args)?))])
 }
 
-pub(crate) fn div_vals(val1: &Gc<Value>, vals: &[Gc<Value>]) -> Result<Number, Exception> {
+pub(crate) fn div(val1: &Gc<Value>, vals: &[Gc<Value>]) -> Result<Number, Exception> {
     let val1 = val1.read();
     let val1: &Number = val1.as_ref().try_into()?;
     if val1.is_zero() {
@@ -450,24 +456,32 @@ pub(crate) fn div_vals(val1: &Gc<Value>, vals: &[Gc<Value>]) -> Result<Number, E
 }
 
 #[bridge(name = "=", lib = "(base)")]
-pub async fn equals(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
-    if let Some((first, rest)) = args.split_first() {
+pub async fn equal_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+    Ok(vec![Gc::new(Value::Boolean(equal(args)?))])
+}
+
+pub(crate) fn equal(vals: &[Gc<Value>]) -> Result<bool, Exception> {
+    if let Some((first, rest)) = vals.split_first() {
         let first = first.read();
         let first: &Number = first.as_ref().try_into()?;
         for next in rest {
             let next = next.read();
             let next: &Number = next.as_ref().try_into()?;
             if first != next {
-                return Ok(vec![Gc::new(Value::Boolean(false))]);
+                return Ok(false);
             }
         }
     }
-    Ok(vec![Gc::new(Value::Boolean(true))])
+    Ok(true)
 }
 
 #[bridge(name = ">", lib = "(base)")]
-pub async fn greater(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
-    if let Some((head, rest)) = args.split_first() {
+pub async fn greater_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+    Ok(vec![Gc::new(Value::Boolean(greater(args)?))])
+}
+
+pub(crate) fn greater(vals: &[Gc<Value>]) -> Result<bool, Exception> {
+    if let Some((head, rest)) = vals.split_first() {
         let mut prev = head.clone();
         for next in rest {
             {
@@ -484,18 +498,22 @@ pub async fn greater(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
                     return Err(Exception::invalid_type("number", "complex"));
                 }
                 if prev <= next {
-                    return Ok(vec![Gc::new(Value::Boolean(false))]);
+                    return Ok(false);
                 }
             }
             prev = next.clone();
         }
     }
-    Ok(vec![Gc::new(Value::Boolean(true))])
+    Ok(true)
 }
 
 #[bridge(name = ">=", lib = "(base)")]
-pub async fn greater_equal(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
-    if let Some((head, rest)) = args.split_first() {
+pub async fn greater_equal_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+    Ok(vec![Gc::new(Value::Boolean(greater_equal(args)?))])
+}
+
+pub(crate) fn greater_equal(vals: &[Gc<Value>]) -> Result<bool, Exception> {
+    if let Some((head, rest)) = vals.split_first() {
         let mut prev = head.clone();
         for next in rest {
             {
@@ -510,18 +528,22 @@ pub async fn greater_equal(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Excepti
                     return Err(Exception::invalid_type("number", "complex"));
                 }
                 if prev < next {
-                    return Ok(vec![Gc::new(Value::Boolean(false))]);
+                    return Ok(false);
                 }
             }
             prev = next.clone();
         }
     }
-    Ok(vec![Gc::new(Value::Boolean(true))])
+    Ok(true)
 }
 
 #[bridge(name = "<", lib = "(base)")]
-pub async fn lesser(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
-    if let Some((head, rest)) = args.split_first() {
+pub async fn lesser_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+    Ok(vec![Gc::new(Value::Boolean(lesser(args)?))])
+}
+
+pub(crate) fn lesser(vals: &[Gc<Value>]) -> Result<bool, Exception> {
+    if let Some((head, rest)) = vals.split_first() {
         let mut prev = head.clone();
         for next in rest {
             {
@@ -536,18 +558,22 @@ pub async fn lesser(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
                     return Err(Exception::invalid_type("number", "complex"));
                 }
                 if prev >= next {
-                    return Ok(vec![Gc::new(Value::Boolean(false))]);
+                    return Ok(false);
                 }
             }
             prev = next.clone();
         }
     }
-    Ok(vec![Gc::new(Value::Boolean(true))])
+    Ok(true)
 }
 
 #[bridge(name = "<=", lib = "(base)")]
-pub async fn lesser_equal(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
-    if let Some((head, rest)) = args.split_first() {
+pub async fn lesser_equal_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+    Ok(vec![Gc::new(Value::Boolean(lesser_equal(args)?))])
+}
+
+pub(crate) fn lesser_equal(vals: &[Gc<Value>]) -> Result<bool, Exception> {
+    if let Some((head, rest)) = vals.split_first() {
         let mut prev = head.clone();
         for next in rest {
             {
@@ -562,13 +588,13 @@ pub async fn lesser_equal(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exceptio
                     return Err(Exception::invalid_type("number", "complex"));
                 }
                 if prev > next {
-                    return Ok(vec![Gc::new(Value::Boolean(false))]);
+                    return Ok(false);
                 }
             }
             prev = next.clone();
         }
     }
-    Ok(vec![Gc::new(Value::Boolean(true))])
+    Ok(true)
 }
 
 #[bridge(name = "number?", lib = "(base)")]

--- a/src/num.rs
+++ b/src/num.rs
@@ -374,60 +374,79 @@ pub async fn odd(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
 
 #[bridge(name = "+", lib = "(base)")]
 pub async fn add(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+    Ok(vec![Gc::new(Value::Number(add_vals(args)?))])
+}
+
+pub(crate) fn add_vals(vals: &[Gc<Value>]) -> Result<Number, Exception> {
     let mut result = Number::FixedInteger(0);
-    for arg in args {
-        let arg = arg.read();
-        let num: &Number = arg.as_ref().try_into()?;
+    for val in vals {
+        let val = val.read();
+        let num: &Number = val.as_ref().try_into()?;
         result = &result + num;
     }
-    Ok(vec![Gc::new(Value::Number(result))])
+    Ok(result)
 }
 
 #[bridge(name = "-", lib = "(base)")]
 pub async fn sub(arg1: &Gc<Value>, args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
-    let arg1 = arg1.read();
-    let arg1: &Number = arg1.as_ref().try_into()?;
-    if args.is_empty() {
-        Ok(vec![Gc::new(Value::Number(-arg1.clone()))])
+    Ok(vec![Gc::new(Value::Number(sub_vals(arg1, args)?))])
+}
+
+pub(crate) fn sub_vals(val1: &Gc<Value>, vals: &[Gc<Value>]) -> Result<Number, Exception> {
+    let val1 = val1.read();
+    let val1: &Number = val1.as_ref().try_into()?;
+    let mut val1 = val1.clone();
+    if vals.is_empty() {
+        Ok(-val1)
     } else {
-        let mut result = arg1.clone();
-        for arg in args {
-            let arg = arg.read();
-            let num: &Number = arg.as_ref().try_into()?;
-            result = &result - num;
+        for val in vals {
+            let val = val.read();
+            let num: &Number = val.as_ref().try_into()?;
+            val1 = &val1 - num;
         }
-        Ok(vec![Gc::new(Value::Number(result))])
+        Ok(val1)
     }
 }
 
 #[bridge(name = "*", lib = "(base)")]
 pub async fn mul(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+    Ok(vec![Gc::new(Value::Number(mul_vals(args)?))])
+}
+
+pub(crate) fn mul_vals(vals: &[Gc<Value>]) -> Result<Number, Exception> {
     let mut result = Number::FixedInteger(1);
-    for arg in args {
-        let arg = arg.read();
-        let num: &Number = arg.as_ref().try_into()?;
+    for val in vals {
+        let val = val.read();
+        let num: &Number = val.as_ref().try_into()?;
         result = &result * num;
     }
-    Ok(vec![Gc::new(Value::Number(result))])
+    Ok(result)
 }
 
 #[bridge(name = "/", lib = "(base)")]
 pub async fn div(arg1: &Gc<Value>, args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
-    let arg1 = arg1.read();
-    let arg1: &Number = arg1.as_ref().try_into()?;
-    if arg1.is_zero() {
+    Ok(vec![Gc::new(Value::Number(div_vals(arg1, args)?))])
+}
+
+pub(crate) fn div_vals(val1: &Gc<Value>, vals: &[Gc<Value>]) -> Result<Number, Exception> {
+    let val1 = val1.read();
+    let val1: &Number = val1.as_ref().try_into()?;
+    if val1.is_zero() {
         return Err(Exception::division_by_zero());
     }
-    let mut result = &Number::FixedInteger(1) / arg1;
-    for arg in args {
-        let arg = arg.read();
-        let num: &Number = arg.as_ref().try_into()?;
+    if vals.is_empty() {
+        return Ok(&Number::FixedInteger(1) / val1);
+    }
+    let mut result = val1.clone();
+    for val in vals {
+        let val = val.read();
+        let num: &Number = val.as_ref().try_into()?;
         if num.is_zero() {
             return Err(Exception::division_by_zero());
         }
         result = &result / num;
     }
-    Ok(vec![Gc::new(Value::Number(result))])
+    Ok(result)
 }
 
 #[bridge(name = "=", lib = "(base)")]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -287,6 +287,36 @@ fn install_runtime<'ctx>(ctx: &'ctx Context, module: &Module<'ctx>, ee: &Executi
     let sig = ptr_type.fn_type(&[ptr_type.into(), i32_type.into()], false);
     let f = module.add_function("div", sig, None);
     ee.add_global_mapping(&f, div as usize);
+
+    // fn equal(args: **Value, num_args: u32) -> *Value
+    //
+    let sig = ptr_type.fn_type(&[ptr_type.into(), i32_type.into()], false);
+    let f = module.add_function("equal", sig, None);
+    ee.add_global_mapping(&f, equal as usize);
+
+    // fn greater(args: **Value, num_args: u32) -> *Value
+    //
+    let sig = ptr_type.fn_type(&[ptr_type.into(), i32_type.into()], false);
+    let f = module.add_function("greater", sig, None);
+    ee.add_global_mapping(&f, greater as usize);
+
+    // fn greater_equal(args: **Value, num_args: u32) -> *Value
+    //
+    let sig = ptr_type.fn_type(&[ptr_type.into(), i32_type.into()], false);
+    let f = module.add_function("greater_equal", sig, None);
+    ee.add_global_mapping(&f, greater_equal as usize);
+
+    // fn lesser(args: **Value, num_args: u32) -> *Value
+    //
+    let sig = ptr_type.fn_type(&[ptr_type.into(), i32_type.into()], false);
+    let f = module.add_function("lesser", sig, None);
+    ee.add_global_mapping(&f, lesser as usize);
+
+    // fn lesser_equal(args: **Value, num_args: u32) -> *Value
+    //
+    let sig = ptr_type.fn_type(&[ptr_type.into(), i32_type.into()], false);
+    let f = module.add_function("lesser_equal", sig, None);
+    ee.add_global_mapping(&f, lesser_equal as usize);
 }
 
 /// Allocate a new Gc with a value of undefined
@@ -476,7 +506,7 @@ unsafe extern "C" fn add(vals: *const *mut GcInner<Value>, num_vals: u32) -> *mu
     let vals: Vec<_> = (0..num_vals)
         .map(|i| Gc::from_ptr(vals.add(i as usize).read()))
         .collect();
-    ManuallyDrop::new(Gc::new(Value::Number(num::add_vals(&vals).unwrap()))).as_ptr()
+    ManuallyDrop::new(Gc::new(Value::Number(num::add(&vals).unwrap()))).as_ptr()
 }
 
 /// Subtract all of the values
@@ -485,7 +515,7 @@ unsafe extern "C" fn sub(vals: *const *mut GcInner<Value>, num_vals: u32) -> *mu
         .map(|i| Gc::from_ptr(vals.add(i as usize).read()))
         .collect();
     ManuallyDrop::new(Gc::new(Value::Number(
-        num::sub_vals(&vals[0], &vals[1..]).unwrap(),
+        num::sub(&vals[0], &vals[1..]).unwrap(),
     )))
     .as_ptr()
 }
@@ -495,7 +525,7 @@ unsafe extern "C" fn mul(vals: *const *mut GcInner<Value>, num_vals: u32) -> *mu
     let vals: Vec<_> = (0..num_vals)
         .map(|i| Gc::from_ptr(vals.add(i as usize).read()))
         .collect();
-    ManuallyDrop::new(Gc::new(Value::Number(num::mul_vals(&vals).unwrap()))).as_ptr()
+    ManuallyDrop::new(Gc::new(Value::Number(num::mul(&vals).unwrap()))).as_ptr()
 }
 
 /// Divide all of the values
@@ -504,7 +534,54 @@ unsafe extern "C" fn div(vals: *const *mut GcInner<Value>, num_vals: u32) -> *mu
         .map(|i| Gc::from_ptr(vals.add(i as usize).read()))
         .collect();
     ManuallyDrop::new(Gc::new(Value::Number(
-        num::div_vals(&vals[0], &vals[1..]).unwrap(),
+        num::div(&vals[0], &vals[1..]).unwrap(),
     )))
     .as_ptr()
+}
+
+unsafe extern "C" fn equal(vals: *const *mut GcInner<Value>, num_vals: u32) -> *mut GcInner<Value> {
+    let vals: Vec<_> = (0..num_vals)
+        .map(|i| Gc::from_ptr(vals.add(i as usize).read()))
+        .collect();
+    ManuallyDrop::new(Gc::new(Value::Boolean(num::equal(&vals).unwrap()))).as_ptr()
+}
+
+unsafe extern "C" fn greater(
+    vals: *const *mut GcInner<Value>,
+    num_vals: u32,
+) -> *mut GcInner<Value> {
+    let vals: Vec<_> = (0..num_vals)
+        .map(|i| Gc::from_ptr(vals.add(i as usize).read()))
+        .collect();
+    ManuallyDrop::new(Gc::new(Value::Boolean(num::greater(&vals).unwrap()))).as_ptr()
+}
+
+unsafe extern "C" fn greater_equal(
+    vals: *const *mut GcInner<Value>,
+    num_vals: u32,
+) -> *mut GcInner<Value> {
+    let vals: Vec<_> = (0..num_vals)
+        .map(|i| Gc::from_ptr(vals.add(i as usize).read()))
+        .collect();
+    ManuallyDrop::new(Gc::new(Value::Boolean(num::greater_equal(&vals).unwrap()))).as_ptr()
+}
+
+unsafe extern "C" fn lesser(
+    vals: *const *mut GcInner<Value>,
+    num_vals: u32,
+) -> *mut GcInner<Value> {
+    let vals: Vec<_> = (0..num_vals)
+        .map(|i| Gc::from_ptr(vals.add(i as usize).read()))
+        .collect();
+    ManuallyDrop::new(Gc::new(Value::Boolean(num::lesser(&vals).unwrap()))).as_ptr()
+}
+
+unsafe extern "C" fn lesser_equal(
+    vals: *const *mut GcInner<Value>,
+    num_vals: u32,
+) -> *mut GcInner<Value> {
+    let vals: Vec<_> = (0..num_vals)
+        .map(|i| Gc::from_ptr(vals.add(i as usize).read()))
+        .collect();
+    ManuallyDrop::new(Gc::new(Value::Boolean(num::lesser_equal(&vals).unwrap()))).as_ptr()
 }

--- a/tests/r6rs.scm
+++ b/tests/r6rs.scm
@@ -278,6 +278,11 @@
               (set! n (- n 1))))
            '(a a a))
 
+;; 11.7 Arithmetic
+
+(assert-eq (/ 5) (/ 1 5))
+(assert-eq (/ 5 10) (/ 1 2))
+
 ;; 11.15 Control features
 
 ;; (assert-eq (let ((path '())


### PR DESCRIPTION
This is another enormously effective optimization, leading to a **60% improvement in the fib benchmark**:

```console
     Running benches/fib.rs (target/release/deps/fib-d03d6a32068599cc)
fib 10000               time:   [17.850 ms 19.474 ms 21.104 ms]
                        change: [-61.597% -58.231% -54.689%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Additionally, this fixes a bug in the implementation of division, which has gone unseen for its existence and made it effectively useless. It also fixes a memory leak in the `CPS::Halt` instruction.

A consequence of this PR is that for the moment, passing non-numbers to arithmetic operators will simply crash the program, rather than throwing an error.

This is due to a lack of proper error handling throughout `scheme-rs`, and will be my next major focus now that performance is under control.