### PR TITLE
Proper error handling

### DIFF
--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -53,7 +53,7 @@ pub fn bridge(args: TokenStream, item: TokenStream) -> TokenStream {
                 rest_args: &'a [::scheme_rs::gc::Gc<::scheme_rs::value::Value>],
                 cont: &'a ::scheme_rs::gc::Gc<::scheme_rs::value::Value>,
                 exception_handler: &'a Option<::scheme_rs::gc::Gc<::scheme_rs::exception::ExceptionHandler>>
-            ) -> futures::future::BoxFuture<'a, Result<scheme_rs::proc::Application, scheme_rs::exception::Condition>> {
+            ) -> futures::future::BoxFuture<'a, Result<scheme_rs::proc::Application, ::scheme_rs::gc::Gc<::scheme_rs::value::Value>>> {
                 let cont = {
                     let cont = cont.read();
                     if let ::scheme_rs::value::Value::Closure(proc) = &*cont {
@@ -84,7 +84,7 @@ pub fn bridge(args: TokenStream, item: TokenStream) -> TokenStream {
                 rest_args: &'a [::scheme_rs::gc::Gc<::scheme_rs::value::Value>],
                 cont: &'a ::scheme_rs::gc::Gc<::scheme_rs::value::Value>,
                 exception_handler: &'a Option<::scheme_rs::gc::Gc<::scheme_rs::exception::ExceptionHandler>>
-            ) -> futures::future::BoxFuture<'a, Result<scheme_rs::proc::Application, scheme_rs::exception::Condition>> {
+            ) -> futures::future::BoxFuture<'a, Result<scheme_rs::proc::Application, ::scheme_rs::gc::Gc<::scheme_rs::value::Value>>> {
                 let cont = {
                     let cont = cont.read();
                     if let ::scheme_rs::value::Value::Closure(proc) = &*cont {

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -70,6 +70,7 @@ pub fn bridge(args: TokenStream, item: TokenStream) -> TokenStream {
                                 #( &args[#arg_indices], )*
                             ).await?,
                             exception_handler.clone(),
+                            None // TODO
                         ))
                     }
                 )
@@ -101,6 +102,7 @@ pub fn bridge(args: TokenStream, item: TokenStream) -> TokenStream {
                                 rest_args
                             ).await?,
                             exception_handler.clone(),
+                            None // TODO
                         ))
                     }
                 )

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -53,7 +53,7 @@ pub fn bridge(args: TokenStream, item: TokenStream) -> TokenStream {
                 rest_args: &'a [::scheme_rs::gc::Gc<::scheme_rs::value::Value>],
                 cont: &'a ::scheme_rs::gc::Gc<::scheme_rs::value::Value>,
                 exception_handler: &'a Option<::scheme_rs::gc::Gc<::scheme_rs::exception::ExceptionHandler>>
-            ) -> futures::future::BoxFuture<'a, Result<scheme_rs::proc::Application, scheme_rs::exception::Exception>> {
+            ) -> futures::future::BoxFuture<'a, Result<scheme_rs::proc::Application, scheme_rs::exception::Condition>> {
                 let cont = {
                     let cont = cont.read();
                     if let ::scheme_rs::value::Value::Closure(proc) = &*cont {
@@ -84,7 +84,7 @@ pub fn bridge(args: TokenStream, item: TokenStream) -> TokenStream {
                 rest_args: &'a [::scheme_rs::gc::Gc<::scheme_rs::value::Value>],
                 cont: &'a ::scheme_rs::gc::Gc<::scheme_rs::value::Value>,
                 exception_handler: &'a Option<::scheme_rs::gc::Gc<::scheme_rs::exception::ExceptionHandler>>
-            ) -> futures::future::BoxFuture<'a, Result<scheme_rs::proc::Application, scheme_rs::exception::Exception>> {
+            ) -> futures::future::BoxFuture<'a, Result<scheme_rs::proc::Application, scheme_rs::exception::Condition>> {
                 let cont = {
                     let cont = cont.read();
                     if let ::scheme_rs::value::Value::Closure(proc) = &*cont {

--- a/src/character.rs
+++ b/src/character.rs
@@ -1,4 +1,4 @@
-use crate::{exception::Exception, gc::Gc, num::Number, registry::bridge, value::Value};
+use crate::{exception::Condition, gc::Gc, num::Number, registry::bridge, value::Value};
 use unicode_categories::UnicodeCategories;
 
 mod unicode;
@@ -7,18 +7,18 @@ use unicode::*;
 fn char_switch_case<I: Iterator<Item = char> + ExactSizeIterator>(
     ch: char,
     operation: fn(char) -> I,
-) -> Result<char, Exception> {
+) -> Result<char, Condition> {
     let mut ch = operation(ch);
     let len = ch.len();
     if len == 1 {
         Ok(ch.next().unwrap())
     } else {
-        Err(Exception::wrong_num_of_unicode_chars(1, len))
+        Err(Condition::wrong_num_of_unicode_chars(1, len))
     }
 }
 
 #[bridge(name = "char->integer", lib = "(base)")]
-pub async fn char_to_integer(ch: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn char_to_integer(ch: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let ch = ch.read();
     let ch: char = ch.as_ref().try_into()?;
 
@@ -28,7 +28,7 @@ pub async fn char_to_integer(ch: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception
 }
 
 #[bridge(name = "integer->char", lib = "(base)")]
-pub async fn integer_to_char(int: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn integer_to_char(int: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let int = int.read();
     let int: &Number = int.as_ref().try_into()?;
     let int: usize = int.try_into()?;
@@ -51,7 +51,7 @@ macro_rules! impl_char_operator {
         $cmp_function:ident)),* $(,)?
     ) => {
         $(#[bridge(name = $bridge_name, lib = "(base)")]
-        pub async fn $function_name(req_lhs: &Gc<Value>, req_rhs: &Gc<Value>, opt_chars: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+        pub async fn $function_name(req_lhs: &Gc<Value>, req_rhs: &Gc<Value>, opt_chars: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
             for window in [req_lhs, req_rhs]
                 .into_iter()
                 .chain(opt_chars)
@@ -59,7 +59,7 @@ macro_rules! impl_char_operator {
                     let ch = ch.read();
                     ch.as_ref().try_into()
                 })
-                .collect::<Result<Vec<char>, Exception>>()?
+                .collect::<Result<Vec<char>, Condition>>()?
                 .windows(2) {
 
                 if !window.first()
@@ -89,7 +89,7 @@ macro_rules! impl_char_ci_operator {
         $cmp_function:ident)),* $(,)?
     ) => {
         $(#[bridge(name = $bridge_name, lib = "(base)")]
-        pub async fn $function_name(req_lhs: &Gc<Value>, req_rhs: &Gc<Value>, opt_chars: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+        pub async fn $function_name(req_lhs: &Gc<Value>, req_rhs: &Gc<Value>, opt_chars: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
             for window in [req_lhs, req_rhs]
                 .into_iter()
                 .chain(opt_chars)
@@ -98,7 +98,7 @@ macro_rules! impl_char_ci_operator {
                     <&Value as TryInto<char>>::try_into(ch.as_ref())
                         .and_then(|c| char_switch_case(c, to_foldcase))
                 })
-                .collect::<Result<Vec<char>, Exception>>()?
+                .collect::<Result<Vec<char>, Condition>>()?
                 .windows(2) {
 
                 if !window.first()
@@ -124,7 +124,7 @@ impl_char_ci_operator![
 macro_rules! impl_char_predicate {
     ($(($bridge_name:literal, $function_name:ident, $predicate:ident)),* $(,)?) => {
         $(#[bridge(name = $bridge_name, lib = "(base)")]
-        pub async fn $function_name(ch: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+        pub async fn $function_name(ch: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
             let ch = ch.read();
             let ch: char = ch.as_ref().try_into()?;
             Ok(vec![Gc::new(Value::Boolean(ch.$predicate()))])
@@ -140,7 +140,7 @@ impl_char_predicate![
 ];
 
 #[bridge(name = "digit-value", lib = "(base)")]
-pub async fn digit_value(ch: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn digit_value(ch: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let ch = ch.read();
     let ch: char = ch.as_ref().try_into()?;
 
@@ -156,7 +156,7 @@ pub async fn digit_value(ch: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
 macro_rules! impl_char_case_converter {
     ($(($bridge_name:literal, $function_name:ident, $converter:expr)),* $(,)?) => {
         $(#[bridge(name = $bridge_name, lib = "(base)")]
-        pub async fn $function_name(ch: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+        pub async fn $function_name(ch: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
             let ch = ch.read();
             let ch: char = ch.as_ref().try_into()?;
             Ok(vec![Gc::new(Value::Character(char_switch_case(ch, $converter)?))])
@@ -169,7 +169,7 @@ impl_char_case_converter![
 ];
 
 #[bridge(name = "char-foldcase", lib = "(base)")]
-pub async fn char_foldcase(ch: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn char_foldcase(ch: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let ch = ch.read();
     let ch: char = ch.as_ref().try_into()?;
     Ok(vec![Gc::new(Value::Character(char_switch_case(

--- a/src/cps/analysis.rs
+++ b/src/cps/analysis.rs
@@ -42,7 +42,7 @@ impl Cps {
                 free.extend(cond.to_local());
                 free
             }
-            Cps::App(op, vals) => {
+            Cps::App(op, vals, _) => {
                 let mut free = values_to_locals(vals);
                 free.extend(op.to_local());
                 free
@@ -89,7 +89,7 @@ impl Cps {
                 globals.extend(cond.to_global());
                 globals
             }
-            Cps::App(op, vals) => {
+            Cps::App(op, vals, _) => {
                 let mut globals = values_to_globals(vals);
                 globals.extend(op.to_global());
                 globals
@@ -119,7 +119,7 @@ impl Cps {
                 let uses = merge_uses(success.uses(uses_cache).clone(), failure.uses(uses_cache));
                 add_value_use(uses, cond)
             }
-            Cps::App(op, vals) => {
+            Cps::App(op, vals, _) => {
                 let uses = values_to_uses(vals);
                 add_value_use(uses, op)
             }

--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -170,7 +170,7 @@ impl Cps {
             FuncPtr::Continuation(func),
             0,
             true,
-            true,
+            None,
         ))
     }
 }

--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -462,8 +462,7 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
             self.builder.build_store(ep, val)?;
         }
 
-        // Call make_application
-        let make_app = self.module.get_function("make_application").unwrap();
+        let make_app = self.module.get_function("apply").unwrap();
         let app = self
             .builder
             .build_call(
@@ -478,7 +477,7 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
                         .into_pointer_value()
                         .into(),
                 ],
-                "make_application",
+                "apply",
             )?
             .try_as_basic_value()
             .left()
@@ -502,8 +501,7 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
         let operator = self.value_codegen(operator)?;
         let arg = self.value_codegen(arg)?;
 
-        // Call make_forward
-        let make_forward = self.module.get_function("make_forward").unwrap();
+        let make_forward = self.module.get_function("forward").unwrap();
         let app = self
             .builder
             .build_call(
@@ -517,7 +515,7 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
                         .into_pointer_value()
                         .into(),
                 ],
-                "make_forward",
+                "forward",
             )?
             .try_as_basic_value()
             .left()
@@ -538,11 +536,10 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
         allocs: Option<Rc<Allocs<'ctx>>>,
     ) -> Result<(), BuilderError> {
         let val = self.value_codegen(args)?;
-        // Call make_return_values
-        let make_app = self.module.get_function("make_return_values").unwrap();
+        let make_app = self.module.get_function("halt").unwrap();
         let app = self
             .builder
-            .build_call(make_app, &[val.into()], "make_return_values")?
+            .build_call(make_app, &[val.into()], "halt")?
             .try_as_basic_value()
             .left()
             .unwrap();

--- a/src/cps/mod.rs
+++ b/src/cps/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     ast::Literal,
     env::{Global, Local, Var},
     gc::Trace,
+    runtime::{CallSiteId, FunctionDebugInfoId},
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -161,7 +162,7 @@ pub enum Cps {
     PrimOp(PrimOp, Vec<Value>, Local, Box<Cps>),
 
     /// Function application.
-    App(Value, Vec<Value>),
+    App(Value, Vec<Value>, Option<CallSiteId>),
 
     /// Forward a list of values into an application.
     // TODO: I'm not sure I like this name
@@ -176,6 +177,7 @@ pub enum Cps {
         body: Box<Cps>,
         val: Local,
         cexp: Box<Cps>,
+        debug_info_id: Option<FunctionDebugInfoId>,
     },
 
     /// Halt execution and return the values
@@ -193,7 +195,7 @@ impl Cps {
                 substitute_values(args, substitutions);
                 cexp.substitute(substitutions);
             }
-            Self::App(value, values) => {
+            Self::App(value, values, _) => {
                 substitute_value(value, substitutions);
                 substitute_values(values, substitutions);
             }

--- a/src/cps/reduce.rs
+++ b/src/cps/reduce.rs
@@ -44,6 +44,7 @@ impl Cps {
                 body,
                 val,
                 cexp,
+                debug_info_id,
             } => {
                 let body = body.beta_reduction(single_use_functions, uses_cache);
                 let cexp = cexp.beta_reduction(single_use_functions, uses_cache);
@@ -61,6 +62,7 @@ impl Cps {
                             body: Box::new(body),
                             val,
                             cexp: Box::new(cexp),
+                            debug_info_id,
                         }
                     } else {
                         cexp
@@ -72,10 +74,11 @@ impl Cps {
                         body: Box::new(body),
                         val,
                         cexp: Box::new(cexp),
+                        debug_info_id,
                     }
                 }
             }
-            Cps::App(Value::Var(Var::Local(operator)), applied)
+            Cps::App(Value::Var(Var::Local(operator)), applied, call_site_id)
                 if single_use_functions.contains_key(&operator) =>
             {
                 let (args, mut body) = single_use_functions.remove(&operator).unwrap();
@@ -83,7 +86,7 @@ impl Cps {
                 if args.args.len() != applied.len() {
                     // Not really sure what to do about variadic args right now
                     single_use_functions.insert(operator, (args, body));
-                    return Cps::App(Value::Var(Var::Local(operator)), applied);
+                    return Cps::App(Value::Var(Var::Local(operator)), applied, call_site_id);
                 }
 
                 // Get the substitutions:

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -6,7 +6,7 @@ use crate::{
     gc::{Gc, GcInner, Trace},
     proc::{Application, Closure, FuncPtr},
     registry::BridgeFn,
-    runtime::{CallSiteId, FunctionDebugInfoId, Runtime},
+    runtime::{Runtime, IGNORE_FUNCTION},
     syntax::{Identifier, Span},
     value::Value,
 };
@@ -213,6 +213,7 @@ pub fn with_exception_handler<'a>(
             thunk.clone(),
             vec![cont.clone()],
             Some(Gc::new(exception_handler)),
+            None,
         ))
     })
 }
@@ -250,10 +251,11 @@ pub fn raise<'a>(
                     FuncPtr::Continuation(reraise_exception),
                     0,
                     true,
-                    todo!()
+                    Some(IGNORE_FUNCTION),
                 ))),
             ],
             handler.prev_handler.clone(),
+            None,
         ))
     })
 }
@@ -291,10 +293,11 @@ unsafe extern "C" fn reraise_exception(
             FuncPtr::Bridge(raise),
             1,
             false,
-            todo!()
+            Some(IGNORE_FUNCTION),
         ),
         vec![exception, cont],
         curr_handler,
+        None,
     )))
 }
 
@@ -321,6 +324,7 @@ pub fn raise_continuable<'a>(
             handler.curr_handler,
             vec![condition.clone(), cont.clone()],
             handler.prev_handler,
+            None,
         ))
     })
 }

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -36,7 +36,7 @@ impl fmt::Display for Exception {
                     writeln!(f, "(backtrace truncated)")?;
                     break;
                 }
-                writeln!(f, "{i}: {frame}\n")?;
+                writeln!(f, "{i}: {frame}")?;
             }
         }
         Ok(())

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -28,15 +28,15 @@ impl Exception {
 impl fmt::Display for Exception {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const MAX_BACKTRACE_LEN: usize = 20;
-        write!(f, "Uncaught exception: {}\n", self.obj)?;
+        writeln!(f, "Uncaught exception: {}", self.obj)?;
         if !self.backtrace.is_empty() {
-            write!(f, "Stack trace:\n")?;
+            writeln!(f, "Stack trace:")?;
             for (i, frame) in self.backtrace.iter().rev().enumerate() {
                 if i >= MAX_BACKTRACE_LEN {
-                    write!(f, "(backtrace truncated)\n")?;
+                    writeln!(f, "(backtrace truncated)")?;
                     break;
                 }
-                write!(f, "{i}: {frame}\n")?;
+                writeln!(f, "{i}: {frame}\n")?;
             }
         }
         Ok(())
@@ -290,7 +290,7 @@ unsafe extern "C" fn reraise_exception(
     _globals: *const *mut GcInner<Value>,
     _args: *const *mut GcInner<Value>,
     exception_handler: *mut GcInner<ExceptionHandler>,
-) -> *mut Application {
+) -> *mut Result<Application, Condition> {
     let runtime = Gc::from_ptr(runtime);
 
     // env[0] is the exception
@@ -305,7 +305,7 @@ unsafe extern "C" fn reraise_exception(
         Some(Gc::from_ptr(exception_handler))
     };
 
-    Box::into_raw(Box::new(Application::new(
+    Box::into_raw(Box::new(Ok(Application::new(
         Closure::new(
             runtime,
             Vec::new(),
@@ -318,7 +318,7 @@ unsafe extern "C" fn reraise_exception(
         vec![exception, cont],
         curr_handler,
         None,
-    )))
+    ))))
 }
 
 /// Raises an exception to the current exception handler and coninues with the

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -141,7 +141,7 @@ impl_into_exception_for!(std::num::TryFromIntError);
 pub struct Frame {
     pub proc: String,
     pub span: Span,
-    pub repeated: usize,
+    // pub repeated: usize,
 }
 
 impl Frame {
@@ -149,7 +149,7 @@ impl Frame {
         Self {
             proc,
             span,
-            repeated: 0,
+            // repeated: 0,
         }
     }
 }

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -239,7 +239,7 @@ pub fn raise<'a>(
             return Err(Condition::wrong_num_of_args(1, args.len()).into());
         };
 
-        // TODO: Make condition non-continuable whe it is re-raised
+        // TODO: Make condition non-continuable when it is re-raised
 
         let Some(ref handler) = exception_handler else {
             return Err(condition.clone());

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -2,7 +2,7 @@ use crate::{
     ast::{Expression, Literal},
     cps::Compile,
     env::CapturedEnv,
-    exception::{Exception, ExceptionHandler},
+    exception::{Exception, Condition, ExceptionHandler},
     gc::{Gc, Trace},
     proc::{Application, Closure},
     syntax::{Identifier, Span, Syntax},
@@ -403,7 +403,7 @@ pub fn call_transformer<'a>(
     env: &'a [Gc<Value>],
     cont: &'a Gc<Value>,
     exception_handler: &'a Option<Gc<ExceptionHandler>>,
-) -> BoxFuture<'a, Result<Application, Exception>> {
+) -> BoxFuture<'a, Result<Application, Condition>> {
     Box::pin(async move {
         let [captured_env, trans, arg] = args else {
             panic!("wrong args");
@@ -425,7 +425,7 @@ pub fn call_transformer<'a>(
             let arg = Syntax::from_datum(&BTreeSet::default(), arg);
 
             // Expand the argument:
-            trans.expand(&arg).ok_or_else(Exception::syntax_error)?
+            trans.expand(&arg).ok_or_else(Condition::syntax_error)?
         };
 
         let captured_env = {
@@ -449,7 +449,10 @@ pub fn call_transformer<'a>(
             .compile_expr_with_env(cps_expr, collected_env)
             .await
             .unwrap();
-        let transformer_result = compiled.call(&[]).await?;
+        let transformer_result = compiled.call(&[]).await
+            .map_err(|_err| -> Condition {
+                todo!()
+            })?;
         let application =
             Application::new(cont, transformer_result, exception_handler.clone(), None);
 

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -450,7 +450,8 @@ pub fn call_transformer<'a>(
             .await
             .unwrap();
         let transformer_result = compiled.call(&[]).await?;
-        let application = Application::new(cont, transformer_result, exception_handler.clone());
+        let application =
+            Application::new(cont, transformer_result, exception_handler.clone(), None);
 
         Ok(application)
     })

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -2,7 +2,7 @@ use crate::{
     ast::{Expression, Literal},
     cps::Compile,
     env::CapturedEnv,
-    exception::{Exception, Condition, ExceptionHandler},
+    exception::{Condition, ExceptionHandler},
     gc::{Gc, Trace},
     proc::{Application, Closure},
     syntax::{Identifier, Span, Syntax},
@@ -403,7 +403,7 @@ pub fn call_transformer<'a>(
     env: &'a [Gc<Value>],
     cont: &'a Gc<Value>,
     exception_handler: &'a Option<Gc<ExceptionHandler>>,
-) -> BoxFuture<'a, Result<Application, Condition>> {
+) -> BoxFuture<'a, Result<Application, Gc<Value>>> {
     Box::pin(async move {
         let [captured_env, trans, arg] = args else {
             panic!("wrong args");
@@ -449,10 +449,7 @@ pub fn call_transformer<'a>(
             .compile_expr_with_env(cps_expr, collected_env)
             .await
             .unwrap();
-        let transformer_result = compiled.call(&[]).await
-            .map_err(|_err| -> Condition {
-                todo!()
-            })?;
+        let transformer_result = compiled.call(&[]).await?;
         let application =
             Application::new(cont, transformer_result, exception_handler.clone(), None);
 

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -1,4 +1,4 @@
-use crate::{exception::Exception, gc::Gc, num::Number, registry::bridge, value::Value};
+use crate::{exception::Condition, gc::Gc, num::Number, registry::bridge, value::Value};
 use std::fmt;
 
 pub fn display_list(car: &Gc<Value>, cdr: &Gc<Value>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -100,7 +100,7 @@ pub fn list_to_vec_with_null(curr: &Gc<Value>, out: &mut Vec<Gc<Value>>) {
 }
 
 #[bridge(name = "list", lib = "(base)")]
-pub async fn list(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn list(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
     // Construct the list in reverse
     let mut cdr = Gc::new(Value::Null);
     for arg in args.iter().rev() {
@@ -110,32 +110,32 @@ pub async fn list(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
 }
 
 #[bridge(name = "cons", lib = "(base)")]
-pub async fn cons(car: &Gc<Value>, cdr: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn cons(car: &Gc<Value>, cdr: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let car = Gc::new(car.read().clone());
     let cdr = Gc::new(cdr.read().clone());
     Ok(vec![Gc::new(Value::Pair(car, cdr))])
 }
 
 #[bridge(name = "car", lib = "(base)")]
-pub async fn car(val: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn car(val: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let val = val.read();
     match &*val {
         Value::Pair(car, _cdr) => Ok(vec![car.clone()]),
-        _ => Err(Exception::invalid_type("pair", val.type_name())),
+        _ => Err(Condition::invalid_type("pair", val.type_name())),
     }
 }
 
 #[bridge(name = "cdr", lib = "(base)")]
-pub async fn cdr(val: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn cdr(val: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let val = val.read();
     match &*val {
         Value::Pair(_car, cdr) => Ok(vec![cdr.clone()]),
-        _ => Err(Exception::invalid_type("pair", val.type_name())),
+        _ => Err(Condition::invalid_type("pair", val.type_name())),
     }
 }
 
 #[bridge(name = "set-car!", lib = "(base)")]
-pub async fn set_car(var: &Gc<Value>, val: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn set_car(var: &Gc<Value>, val: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let mut var = var.write();
     match &mut *var {
         Value::Pair(ref mut car, _cdr) => *car = val.clone(),
@@ -145,7 +145,7 @@ pub async fn set_car(var: &Gc<Value>, val: &Gc<Value>) -> Result<Vec<Gc<Value>>,
 }
 
 #[bridge(name = "set-cdr!", lib = "(base)")]
-pub async fn set_cdr(var: &Gc<Value>, val: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn set_cdr(var: &Gc<Value>, val: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let mut var = var.write();
     match &mut *var {
         Value::Pair(_car, ref mut cdr) => *cdr = val.clone(),
@@ -155,7 +155,7 @@ pub async fn set_cdr(var: &Gc<Value>, val: &Gc<Value>) -> Result<Vec<Gc<Value>>,
 }
 
 #[bridge(name = "length", lib = "(base)")]
-pub async fn length(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn length(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let mut length = 0;
     let mut arg = arg.clone();
     loop {
@@ -172,7 +172,7 @@ pub async fn length(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
 }
 
 #[bridge(name = "list->vector", lib = "(base)")]
-pub async fn list_to_vector(list: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn list_to_vector(list: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let mut vec = Vec::new();
     list_to_vec(list, &mut vec);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use scheme_rs::{
     gc::Gc,
     lex::LexError,
     parse::ParseSyntaxError,
+    proc::Application,
     registry::Registry,
     runtime::Runtime,
     syntax::Syntax,
@@ -111,7 +112,9 @@ async fn compile_and_run_str<'e>(
         // println!("Compiled: {compiled:#?}");
 
         let closure = runtime.compile_expr(compiled).await.unwrap();
-        let result = closure.apply(&[], None).await?.eval().await?;
+        let result = Application::new(closure, Vec::new(), None, None)
+            .eval()
+            .await?;
         output.extend(result)
     }
     Ok(output)

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,9 @@ async fn main() {
                     n_results += 1;
                 }
             }
+            Err(EvalError::Exception(exception)) => {
+                print!("{exception}");
+            }
             Err(err) => {
                 println!("Error: {err:?}");
             }

--- a/src/num.rs
+++ b/src/num.rs
@@ -1,5 +1,5 @@
 use crate::{
-    exception::Exception,
+    exception::Condition,
     gc::{Gc, Trace},
     registry::bridge,
     value::Value,
@@ -476,32 +476,32 @@ enum NumberToUsizeErrorKind {
 }
 
 #[bridge(name = "zero?", lib = "(base)")]
-pub async fn zero(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn zero(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let arg = arg.read();
     let num: &Number = arg.as_ref().try_into()?;
     Ok(vec![Gc::new(Value::Boolean(num.is_zero()))])
 }
 
 #[bridge(name = "even?", lib = "(base)")]
-pub async fn even(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn even(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let arg = arg.read();
     let num: &Number = arg.as_ref().try_into()?;
     Ok(vec![Gc::new(Value::Boolean(num.is_even()))])
 }
 
 #[bridge(name = "odd?", lib = "(base)")]
-pub async fn odd(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn odd(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let arg = arg.read();
     let num: &Number = arg.as_ref().try_into()?;
     Ok(vec![Gc::new(Value::Boolean(num.is_odd()))])
 }
 
 #[bridge(name = "+", lib = "(base)")]
-pub async fn add_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn add_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
     Ok(vec![Gc::new(Value::Number(add(args)?))])
 }
 
-pub(crate) fn add(vals: &[Gc<Value>]) -> Result<Number, Exception> {
+pub(crate) fn add(vals: &[Gc<Value>]) -> Result<Number, Condition> {
     let mut result = Number::FixedInteger(0);
     for val in vals {
         let val = val.read();
@@ -515,11 +515,11 @@ pub(crate) fn add(vals: &[Gc<Value>]) -> Result<Number, Exception> {
 pub async fn sub_builtin(
     arg1: &Gc<Value>,
     args: &[Gc<Value>],
-) -> Result<Vec<Gc<Value>>, Exception> {
+) -> Result<Vec<Gc<Value>>, Condition> {
     Ok(vec![Gc::new(Value::Number(sub(arg1, args)?))])
 }
 
-pub(crate) fn sub(val1: &Gc<Value>, vals: &[Gc<Value>]) -> Result<Number, Exception> {
+pub(crate) fn sub(val1: &Gc<Value>, vals: &[Gc<Value>]) -> Result<Number, Condition> {
     let val1 = val1.read();
     let val1: &Number = val1.as_ref().try_into()?;
     let mut val1 = val1.clone();
@@ -536,11 +536,11 @@ pub(crate) fn sub(val1: &Gc<Value>, vals: &[Gc<Value>]) -> Result<Number, Except
 }
 
 #[bridge(name = "*", lib = "(base)")]
-pub async fn mul_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn mul_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
     Ok(vec![Gc::new(Value::Number(mul(args)?))])
 }
 
-pub(crate) fn mul(vals: &[Gc<Value>]) -> Result<Number, Exception> {
+pub(crate) fn mul(vals: &[Gc<Value>]) -> Result<Number, Condition> {
     let mut result = Number::FixedInteger(1);
     for val in vals {
         let val = val.read();
@@ -554,11 +554,11 @@ pub(crate) fn mul(vals: &[Gc<Value>]) -> Result<Number, Exception> {
 pub async fn div_builtin(
     arg1: &Gc<Value>,
     args: &[Gc<Value>],
-) -> Result<Vec<Gc<Value>>, Exception> {
+) -> Result<Vec<Gc<Value>>, Condition> {
     Ok(vec![Gc::new(Value::Number(div(arg1, args)?))])
 }
 
-pub(crate) fn div(val1: &Gc<Value>, vals: &[Gc<Value>]) -> Result<Number, Exception> {
+pub(crate) fn div(val1: &Gc<Value>, vals: &[Gc<Value>]) -> Result<Number, Condition> {
     let val1 = val1.read();
     let val1: &Number = val1.as_ref().try_into()?;
     if vals.is_empty() {
@@ -574,11 +574,11 @@ pub(crate) fn div(val1: &Gc<Value>, vals: &[Gc<Value>]) -> Result<Number, Except
 }
 
 #[bridge(name = "=", lib = "(base)")]
-pub async fn equal_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn equal_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
     Ok(vec![Gc::new(Value::Boolean(equal(args)?))])
 }
 
-pub(crate) fn equal(vals: &[Gc<Value>]) -> Result<bool, Exception> {
+pub(crate) fn equal(vals: &[Gc<Value>]) -> Result<bool, Condition> {
     if let Some((first, rest)) = vals.split_first() {
         let first = first.read();
         let first: &Number = first.as_ref().try_into()?;
@@ -594,11 +594,11 @@ pub(crate) fn equal(vals: &[Gc<Value>]) -> Result<bool, Exception> {
 }
 
 #[bridge(name = ">", lib = "(base)")]
-pub async fn greater_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn greater_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
     Ok(vec![Gc::new(Value::Boolean(greater(args)?))])
 }
 
-pub(crate) fn greater(vals: &[Gc<Value>]) -> Result<bool, Exception> {
+pub(crate) fn greater(vals: &[Gc<Value>]) -> Result<bool, Condition> {
     if let Some((head, rest)) = vals.split_first() {
         let mut prev = head.clone();
         for next in rest {
@@ -610,10 +610,10 @@ pub(crate) fn greater(vals: &[Gc<Value>]) -> Result<bool, Exception> {
                 // This is somewhat less efficient for small numbers but avoids
                 // cloning big ones
                 if prev.is_complex() {
-                    return Err(Exception::invalid_type("number", "complex"));
+                    return Err(Condition::invalid_type("number", "complex"));
                 }
                 if next.is_complex() {
-                    return Err(Exception::invalid_type("number", "complex"));
+                    return Err(Condition::invalid_type("number", "complex"));
                 }
                 if prev <= next {
                     return Ok(false);
@@ -626,11 +626,11 @@ pub(crate) fn greater(vals: &[Gc<Value>]) -> Result<bool, Exception> {
 }
 
 #[bridge(name = ">=", lib = "(base)")]
-pub async fn greater_equal_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn greater_equal_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
     Ok(vec![Gc::new(Value::Boolean(greater_equal(args)?))])
 }
 
-pub(crate) fn greater_equal(vals: &[Gc<Value>]) -> Result<bool, Exception> {
+pub(crate) fn greater_equal(vals: &[Gc<Value>]) -> Result<bool, Condition> {
     if let Some((head, rest)) = vals.split_first() {
         let mut prev = head.clone();
         for next in rest {
@@ -640,10 +640,10 @@ pub(crate) fn greater_equal(vals: &[Gc<Value>]) -> Result<bool, Exception> {
                 let prev: &Number = prev.as_ref().try_into()?;
                 let next: &Number = next.as_ref().try_into()?;
                 if prev.is_complex() {
-                    return Err(Exception::invalid_type("number", "complex"));
+                    return Err(Condition::invalid_type("number", "complex"));
                 }
                 if next.is_complex() {
-                    return Err(Exception::invalid_type("number", "complex"));
+                    return Err(Condition::invalid_type("number", "complex"));
                 }
                 if prev < next {
                     return Ok(false);
@@ -656,11 +656,11 @@ pub(crate) fn greater_equal(vals: &[Gc<Value>]) -> Result<bool, Exception> {
 }
 
 #[bridge(name = "<", lib = "(base)")]
-pub async fn lesser_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn lesser_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
     Ok(vec![Gc::new(Value::Boolean(lesser(args)?))])
 }
 
-pub(crate) fn lesser(vals: &[Gc<Value>]) -> Result<bool, Exception> {
+pub(crate) fn lesser(vals: &[Gc<Value>]) -> Result<bool, Condition> {
     if let Some((head, rest)) = vals.split_first() {
         let mut prev = head.clone();
         for next in rest {
@@ -670,10 +670,10 @@ pub(crate) fn lesser(vals: &[Gc<Value>]) -> Result<bool, Exception> {
                 let prev: &Number = prev.as_ref().try_into()?;
                 let next: &Number = next.as_ref().try_into()?;
                 if prev.is_complex() {
-                    return Err(Exception::invalid_type("number", "complex"));
+                    return Err(Condition::invalid_type("number", "complex"));
                 }
                 if next.is_complex() {
-                    return Err(Exception::invalid_type("number", "complex"));
+                    return Err(Condition::invalid_type("number", "complex"));
                 }
                 if prev >= next {
                     return Ok(false);
@@ -686,11 +686,11 @@ pub(crate) fn lesser(vals: &[Gc<Value>]) -> Result<bool, Exception> {
 }
 
 #[bridge(name = "<=", lib = "(base)")]
-pub async fn lesser_equal_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn lesser_equal_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
     Ok(vec![Gc::new(Value::Boolean(lesser_equal(args)?))])
 }
 
-pub(crate) fn lesser_equal(vals: &[Gc<Value>]) -> Result<bool, Exception> {
+pub(crate) fn lesser_equal(vals: &[Gc<Value>]) -> Result<bool, Condition> {
     if let Some((head, rest)) = vals.split_first() {
         let mut prev = head.clone();
         for next in rest {
@@ -700,10 +700,10 @@ pub(crate) fn lesser_equal(vals: &[Gc<Value>]) -> Result<bool, Exception> {
                 let prev: &Number = prev.as_ref().try_into()?;
                 let next: &Number = next.as_ref().try_into()?;
                 if prev.is_complex() {
-                    return Err(Exception::invalid_type("number", "complex"));
+                    return Err(Condition::invalid_type("number", "complex"));
                 }
                 if next.is_complex() {
-                    return Err(Exception::invalid_type("number", "complex"));
+                    return Err(Condition::invalid_type("number", "complex"));
                 }
                 if prev > next {
                     return Ok(false);
@@ -716,7 +716,7 @@ pub(crate) fn lesser_equal(vals: &[Gc<Value>]) -> Result<bool, Exception> {
 }
 
 #[bridge(name = "number?", lib = "(base)")]
-pub async fn is_number(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn is_number(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let arg = arg.read();
     Ok(vec![Gc::new(Value::Boolean(matches!(
         &*arg,
@@ -725,7 +725,7 @@ pub async fn is_number(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
 }
 
 #[bridge(name = "integer?", lib = "(base)")]
-pub async fn is_integer(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn is_integer(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let arg = arg.read();
     Ok(vec![Gc::new(Value::Boolean(matches!(
         &*arg,
@@ -734,7 +734,7 @@ pub async fn is_integer(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
 }
 
 #[bridge(name = "rational?", lib = "(base)")]
-pub async fn is_rational(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn is_rational(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let arg = arg.read();
     Ok(vec![Gc::new(Value::Boolean(matches!(
         &*arg,
@@ -743,7 +743,7 @@ pub async fn is_rational(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
 }
 
 #[bridge(name = "real?", lib = "(base)")]
-pub async fn is_real(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn is_real(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let arg = arg.read();
     Ok(vec![Gc::new(Value::Boolean(matches!(
         &*arg,
@@ -752,7 +752,7 @@ pub async fn is_real(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
 }
 
 #[bridge(name = "complex?", lib = "(base)")]
-pub async fn is_complex(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn is_complex(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let arg = arg.read();
     Ok(vec![Gc::new(Value::Boolean(matches!(
         &*arg,

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -113,14 +113,14 @@ impl Closure {
     }
 
     pub async fn call(&self, args: &[Gc<Value>]) -> Result<Record, Exception> {
-        unsafe extern "C" fn just_return(
+        unsafe extern "C" fn halt(
             _runtime: *mut GcInner<Runtime>,
             _env: *const *mut GcInner<Value>,
             _globals: *const *mut GcInner<Value>,
             args: *const *mut GcInner<Value>,
             _exception_handler: *mut GcInner<ExceptionHandler>,
         ) -> *mut Application {
-            crate::runtime::make_return_values(args.read())
+            crate::runtime::halt(args.read())
         }
 
         let mut args = args.to_vec();
@@ -130,7 +130,7 @@ impl Closure {
             self.runtime.clone(),
             Vec::new(),
             Vec::new(),
-            FuncPtr::Continuation(just_return),
+            FuncPtr::Continuation(halt),
             0,
             true,
             true,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -4,7 +4,6 @@ use crate::{
     ast::{DefinitionBody, Literal, ParseAstError},
     cps::Compile,
     env::{Environment, Top},
-    exception::{Condition, Exception},
     gc::Gc,
     parse::ParseSyntaxError,
     proc::{BridgePtr, Closure, FuncPtr},
@@ -97,9 +96,7 @@ impl Version {
                             ..
                         } = subvers
                         {
-                            num.try_into()
-                                .map_err(Condition::from)
-                                .map_err(ParseAstError::Condition)
+                            num.try_into().map_err(ParseAstError::ExpectedInteger)
                         } else {
                             Err(ParseAstError::ExpectedNumber(subvers.span().clone()))
                         }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -180,7 +180,7 @@ impl Registry {
                     FuncPtr::Bridge(bridge_fn.wrapper),
                     bridge_fn.num_args,
                     bridge_fn.variadic,
-                    false,
+                    Some(todo!()),
                 )),
             );
         }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -4,7 +4,7 @@ use crate::{
     ast::{DefinitionBody, Literal, ParseAstError},
     cps::Compile,
     env::{Environment, Top},
-    exception::Exception,
+    exception::{Condition, Exception},
     gc::Gc,
     parse::ParseSyntaxError,
     proc::{BridgePtr, Closure, FuncPtr},
@@ -98,8 +98,8 @@ impl Version {
                         } = subvers
                         {
                             num.try_into()
-                                .map_err(Exception::from)
-                                .map_err(ParseAstError::Exception)
+                                .map_err(Condition::from)
+                                .map_err(ParseAstError::Condition)
                         } else {
                             Err(ParseAstError::ExpectedNumber(subvers.span().clone()))
                         }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -8,7 +8,7 @@ use crate::{
     gc::Gc,
     parse::ParseSyntaxError,
     proc::{BridgePtr, Closure, FuncPtr},
-    runtime::Runtime,
+    runtime::{Runtime, IGNORE_FUNCTION},
     syntax::{Identifier, Span, Syntax},
     value::Value,
 };
@@ -180,7 +180,7 @@ impl Registry {
                     FuncPtr::Bridge(bridge_fn.wrapper),
                     bridge_fn.num_args,
                     bridge_fn.variadic,
-                    Some(todo!()),
+                    Some(IGNORE_FUNCTION), // TODO: add debug info to bridge functions
                 )),
             );
         }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,7 +1,7 @@
 use crate::{
     ast::Literal,
     env::{Environment, Macro},
-    exception::Exception,
+    exception::{Condition, Exception},
     gc::{Gc, Trace},
     lex::{InputSpan, Token},
     lists::list_to_vec_with_null,
@@ -206,7 +206,7 @@ impl Syntax {
         env: &Environment,
         mac: Macro,
         // cont: &Closure,
-    ) -> Result<Expansion, Exception> {
+    ) -> Result<Expansion, Condition> {
         // Create a new mark for the expansion context
         let new_mark = Mark::new();
 
@@ -221,7 +221,10 @@ impl Syntax {
         let transformer_output = mac
             .transformer
             .call(&[Gc::new(Value::Syntax(input))])
-            .await?;
+            .await
+            .map_err(|_err| -> Condition {
+                todo!()
+            })?;
         let transformer_output = transformer_output[0].read();
 
         // Output must be syntax:
@@ -240,7 +243,7 @@ impl Syntax {
         &'a self,
         env: &'a Environment,
         // cont: &Closure,
-    ) -> BoxFuture<'a, Result<Expansion, Exception>> {
+    ) -> BoxFuture<'a, Result<Expansion, Condition>> {
         Box::pin(async move {
             match self {
                 Self::List { list, .. } => {
@@ -288,7 +291,7 @@ impl Syntax {
         mut self,
         env: &Environment,
         // cont: &Closure,
-    ) -> Result<FullyExpanded, Exception> {
+    ) -> Result<FullyExpanded, Condition> {
         let mut curr_env = env.clone();
         loop {
             match self.expand_once(&curr_env).await? {
@@ -580,13 +583,13 @@ pub async fn syntax_to_datum(
 pub async fn datum_to_syntax(
     template_id: &Gc<Value>,
     datum: &Gc<Value>,
-) -> Result<Vec<Gc<Value>>, Exception> {
+) -> Result<Vec<Gc<Value>>, Condition> {
     let template_id = template_id.read();
     let Value::Syntax(Syntax::Identifier {
         ident: template_id, ..
     }) = &*template_id
     else {
-        return Err(Exception::invalid_type("syntax", template_id.type_name()));
+        return Err(Condition::invalid_type("syntax", template_id.type_name()));
     };
     Ok(vec![Gc::new(Value::Syntax(Syntax::from_datum(
         &template_id.marks,

--- a/src/value.rs
+++ b/src/value.rs
@@ -13,7 +13,7 @@ use crate::{
 use futures::future::{BoxFuture, Shared};
 use std::{fmt, io::Write};
 
-type Future = Shared<BoxFuture<'static, Result<Vec<Gc<Value>>, Exception>>>;
+type Future = Shared<BoxFuture<'static, Result<Vec<Gc<Value>>, Gc<Value>>>>;
 
 /// A Scheme value
 #[derive(Trace)]
@@ -233,7 +233,7 @@ impl fmt::Debug for Value {
             Self::Character(c) => write!(f, "#\\{c}"),
             Self::ByteVector(v) => display_vec("#u8(", v, f),
             Self::Syntax(syntax) => write!(f, "{:?}", syntax),
-            Self::Closure(_) => write!(f, "<procedure>"),
+            Self::Closure(proc) => write!(f, "#<procedure {proc:?}>"),
             Self::Future(_) => write!(f, "<future>"),
             Self::Record(record) => write!(f, "<{record:?}>"),
             Self::RecordType(record_type) => write!(f, "<{record_type:?}>"),
@@ -249,6 +249,20 @@ impl fmt::Debug for Value {
 impl From<bool> for Value {
     fn from(b: bool) -> Value {
         Value::Boolean(b)
+    }
+}
+
+impl From<Condition> for Gc<Value> {
+    fn from(cond: Condition) -> Gc<Value> {
+        Gc::new(Value::Condition(cond))
+    }
+}
+
+impl From<Exception> for Gc<Value> {
+    fn from(exception: Exception) -> Gc<Value> {
+        // Until we can decide on a good method for including the stack trace with
+        // the new condition, just return the object.
+        exception.obj
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -58,6 +58,10 @@ pub enum Value {
 }
 
 impl Value {
+    pub fn is_undefined(&self) -> bool {
+        !matches!(self, Self::Undefined)
+    }
+
     /// #f is false, everything else is true
     pub fn is_true(&self) -> bool {
         !matches!(self, Self::Boolean(x) if !x)

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,7 +1,7 @@
 use crate::{
     ast,
     env::CapturedEnv,
-    exception::Exception,
+    exception::{Condition, Exception},
     expand::Transformer,
     gc::{Gc, Trace},
     num::Number,
@@ -21,32 +21,40 @@ pub enum Value {
     /// The value is undefined. Variables before they are initialized are undefined.
     /// Any attempt to set a variable after creation to undefined results in an error.
     Undefined,
-    /// An empty list.
+    /// An empty list:
     Null,
-    /// Combination of two values. Has a head (car) and a tail (cdr)
+    /// Combination of two values. Has a head (car) and a tail (cdr):
     Pair(Gc<Value>, Gc<Value>),
-    /// Value that is either True (#t) or False (#f)
+    /// Value that is either True (#t) or False (#f):
     Boolean(bool),
-    /// Numeric value.
+    /// Numeric value:
     Number(Number),
-    /// Unicode code point.
+    /// Unicode code point:
     Character(char),
-    /// List of unicode code points.
+    /// Vector of unicode code points:
     String(String),
-    /// Atom of an S-Expression
+    /// Atom of an S-Expression:
     Symbol(String),
+    /// Vector of values:
     Vector(Vec<Value>),
+    /// Vector of bytes:
     ByteVector(Vec<u8>),
+    /// A wrapped syntax object:
     Syntax(Syntax),
-    /// A procedure.
+    /// A procedure:
     Closure(Closure),
+    /// A collection of named values:
     Record(Record),
+    /// The type of a collection of named values:
     RecordType(Gc<RecordType>),
+    /// A condition (which is also a type of record):
+    Condition(Condition),
+    /// A value that will exist in the future:
     Future(Future),
+    /// A procedure that that transforms syntax objects:
     Transformer(Transformer),
-    /// A captured lexical environment.
+    /// A captured lexical environment:
     CapturedEnv(CapturedEnv),
-    // ExceptionHandler(Option<Gc<ExceptionHandler>>),
 }
 
 impl Value {
@@ -108,7 +116,7 @@ impl Value {
             Self::Syntax(_) => "syntax",
             Self::Closure(_) => "procedure",
             Self::Future(_) => "future",
-            Self::Record(_) => "record",
+            Self::Record(_) | Self::Condition(_) => "record",
             Self::RecordType(_) => "record-type",
             Self::Undefined => "undefined",
             Self::Transformer(_) => "transformer",
@@ -158,6 +166,7 @@ impl Clone for Value {
             Self::Undefined => Self::Undefined,
             Self::Transformer(trans) => Self::Transformer(trans.clone()),
             Self::CapturedEnv(cap) => Self::CapturedEnv(cap.clone()),
+            Self::Condition(cond) => Self::Condition(cond.clone()),
             // Self::ExceptionHandler(eh) => Self::ExceptionHandler(eh.clone()),
         }
     }
@@ -204,6 +213,7 @@ impl fmt::Display for Value {
             Self::Undefined => write!(f, "<undefined>"),
             Self::Transformer(_) => write!(f, "<transformer>"),
             Self::CapturedEnv(_) => write!(f, "<environment>"),
+            Self::Condition(cond) => write!(f, "<{cond:?}>"),
             // Self::ExceptionHandler(_) => write!(f, "<exception-handler>"),
         }
     }
@@ -230,6 +240,7 @@ impl fmt::Debug for Value {
             Self::Undefined => write!(f, "<undefined>"),
             Self::Transformer(_) => write!(f, "<transformer>"),
             Self::CapturedEnv(_) => write!(f, "<environment>"),
+            Self::Condition(cond) => write!(f, "<{cond:?}>"),
             // Self::ExceptionHandler(_) => write!(f, "<exception-handler>"),
         }
     }
@@ -257,29 +268,29 @@ impl From<Vec<Gc<Value>>> for Value {
 macro_rules! impl_try_from_value_for {
     ($ty:ty, $enum_variant:ident, $type_name:literal) => {
         impl TryFrom<Value> for $ty {
-            type Error = Exception;
+            type Error = Condition;
             fn try_from(v: Value) -> Result<$ty, Self::Error> {
                 match v {
                     Value::$enum_variant(i) => Ok(i),
-                    e => Err(Exception::invalid_type($type_name, e.type_name())),
+                    e => Err(Condition::invalid_type($type_name, e.type_name())),
                 }
             }
         }
         impl<'a> TryFrom<&'a mut Value> for &'a mut $ty {
-            type Error = Exception;
+            type Error = Condition;
             fn try_from(v: &'a mut Value) -> Result<&'a mut $ty, Self::Error> {
                 match v {
                     Value::$enum_variant(i) => Ok(i),
-                    e => Err(Exception::invalid_type($type_name, e.type_name())),
+                    e => Err(Condition::invalid_type($type_name, e.type_name())),
                 }
             }
         }
         impl<'a> TryFrom<&'a Value> for &'a $ty {
-            type Error = Exception;
+            type Error = Condition;
             fn try_from(v: &'a Value) -> Result<&'a $ty, Self::Error> {
                 match v {
                     Value::$enum_variant(i) => Ok(i),
-                    e => Err(Exception::invalid_type($type_name, e.type_name())),
+                    e => Err(Condition::invalid_type($type_name, e.type_name())),
                 }
             }
         }
@@ -287,11 +298,11 @@ macro_rules! impl_try_from_value_for {
     ($ty:ty, $enum_variant:ident, $type_name:literal, copy) => {
         impl_try_from_value_for!($ty, $enum_variant, $type_name);
         impl TryFrom<&Value> for $ty {
-            type Error = Exception;
+            type Error = Condition;
             fn try_from(v: &Value) -> Result<$ty, Self::Error> {
                 match v {
                     Value::$enum_variant(i) => Ok(*i),
-                    e => Err(Exception::invalid_type($type_name, e.type_name())),
+                    e => Err(Condition::invalid_type($type_name, e.type_name())),
                 }
             }
         }
@@ -317,7 +328,7 @@ pub fn eqv(a: &Gc<Value>, b: &Gc<Value>) -> bool {
 }
 
 #[bridge(name = "not", lib = "(base)")]
-pub async fn not(a: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn not(a: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let a = a.read();
     Ok(vec![Gc::new(Value::Boolean(matches!(
         &*a,
@@ -326,17 +337,17 @@ pub async fn not(a: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
 }
 
 #[bridge(name = "eq?", lib = "(base)")]
-pub async fn eq_pred(a: &Gc<Value>, b: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn eq_pred(a: &Gc<Value>, b: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     Ok(vec![Gc::new(Value::Boolean(a == b))])
 }
 
 #[bridge(name = "eqv?", lib = "(base)")]
-pub async fn eqv_pred(a: &Gc<Value>, b: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn eqv_pred(a: &Gc<Value>, b: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     Ok(vec![Gc::new(Value::Boolean(eqv(a, b)))])
 }
 
 #[bridge(name = "boolean?", lib = "(base)")]
-pub async fn boolean_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn boolean_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let arg = arg.read();
     Ok(vec![Gc::new(Value::Boolean(matches!(
         &*arg,
@@ -348,7 +359,7 @@ pub async fn boolean_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> 
 pub async fn boolean_eq_pred(
     a: &Gc<Value>,
     args: &[Gc<Value>],
-) -> Result<Vec<Gc<Value>>, Exception> {
+) -> Result<Vec<Gc<Value>>, Condition> {
     let a_val = &*a.read();
 
     let result = match a_val {
@@ -362,7 +373,7 @@ pub async fn boolean_eq_pred(
 }
 
 #[bridge(name = "symbol?", lib = "(base)")]
-pub async fn symbol_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn symbol_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let arg = arg.read();
     Ok(vec![Gc::new(Value::Boolean(matches!(
         &*arg,
@@ -371,7 +382,7 @@ pub async fn symbol_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
 }
 
 #[bridge(name = "char?", lib = "(base)")]
-pub async fn char_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn char_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let arg = arg.read();
     Ok(vec![Gc::new(Value::Boolean(matches!(
         &*arg,
@@ -380,7 +391,7 @@ pub async fn char_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
 }
 
 #[bridge(name = "vector?", lib = "(base)")]
-pub async fn vector_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn vector_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let arg = arg.read();
     Ok(vec![Gc::new(Value::Boolean(matches!(
         &*arg,
@@ -389,13 +400,13 @@ pub async fn vector_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
 }
 
 #[bridge(name = "null?", lib = "(base)")]
-pub async fn null_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn null_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let arg = arg.read();
     Ok(vec![Gc::new(Value::Boolean(matches!(&*arg, Value::Null)))])
 }
 
 #[bridge(name = "pair?", lib = "(base)")]
-pub async fn pair_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn pair_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let arg = arg.read();
     Ok(vec![Gc::new(Value::Boolean(matches!(
         &*arg,
@@ -404,7 +415,7 @@ pub async fn pair_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
 }
 
 #[bridge(name = "string?", lib = "(base)")]
-pub async fn string_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn string_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let arg = arg.read();
     Ok(vec![Gc::new(Value::Boolean(matches!(
         &*arg,
@@ -413,7 +424,7 @@ pub async fn string_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
 }
 
 #[bridge(name = "procedure?", lib = "(base)")]
-pub async fn procedure_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn procedure_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let arg = arg.read();
     Ok(vec![Gc::new(Value::Boolean(matches!(
         &*arg,
@@ -422,7 +433,7 @@ pub async fn procedure_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception
 }
 
 #[bridge(name = "future?", lib = "(base)")]
-pub async fn future_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn future_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let arg = arg.read();
     Ok(vec![Gc::new(Value::Boolean(matches!(
         &*arg,
@@ -431,7 +442,7 @@ pub async fn future_pred(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
 }
 
 #[bridge(name = "display", lib = "(base)")]
-pub async fn display(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn display(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     print!("{}", arg);
     let _ = std::io::stdout().flush();
     Ok(Vec::new())

--- a/src/vectors.rs
+++ b/src/vectors.rs
@@ -1,5 +1,5 @@
 use crate::{
-    exception::Exception,
+    exception::Condition,
     gc::Gc,
     lists::slice_to_list,
     num::{Number, NumberToUsizeError},
@@ -9,9 +9,9 @@ use crate::{
 use malachite::Integer;
 use std::{clone::Clone, ops::Range};
 
-fn try_make_range(start: usize, end: usize) -> Result<Range<usize>, Exception> {
+fn try_make_range(start: usize, end: usize) -> Result<Range<usize>, Condition> {
     if end < start {
-        Err(Exception::error(format!(
+        Err(Condition::error(format!(
             "Range end {} cannot be less than start {}",
             end, start
         )))
@@ -19,10 +19,10 @@ fn try_make_range(start: usize, end: usize) -> Result<Range<usize>, Exception> {
         Ok(start..end)
     }
 }
-fn try_to_usize(n: &Gc<Value>) -> Result<usize, Exception> {
+fn try_to_usize(n: &Gc<Value>) -> Result<usize, Condition> {
     n.read().as_ref().try_into().and_then(|n: &Number| {
         n.try_into()
-            .map_err(<NumberToUsizeError as Into<Exception>>::into)
+            .map_err(<NumberToUsizeError as Into<Condition>>::into)
     })
 }
 
@@ -31,9 +31,9 @@ trait Indexer {
 
     fn get_len(&self, _: &Self::Collection) -> usize;
     fn get_range(&self, _: &Self::Collection, _: Range<usize>) -> Self::Collection;
-    fn try_get<'a>(&self, _: &'a Value) -> Result<&'a Self::Collection, Exception>;
+    fn try_get<'a>(&self, _: &'a Value) -> Result<&'a Self::Collection, Condition>;
 
-    fn index(&self, from: &Gc<Value>, range: &[Gc<Value>]) -> Result<Self::Collection, Exception> {
+    fn index(&self, from: &Gc<Value>, range: &[Gc<Value>]) -> Result<Self::Collection, Condition> {
         let from = from.read();
         let collection = self.try_get(&from)?;
         let len = self.get_len(collection);
@@ -43,7 +43,7 @@ trait Indexer {
 
         let range = try_make_range(start, end)?;
         if range.end > len {
-            return Err(Exception::invalid_range(range, len));
+            return Err(Condition::invalid_range(range, len));
         }
 
         Ok(self.get_range(collection, range))
@@ -64,7 +64,7 @@ impl Indexer for StringIndexer {
             .take(range.end - range.start)
             .collect()
     }
-    fn try_get<'a>(&self, val: &'a Value) -> Result<&'a String, Exception> {
+    fn try_get<'a>(&self, val: &'a Value) -> Result<&'a String, Condition> {
         val.try_into()
     }
 }
@@ -82,13 +82,13 @@ impl Indexer for VectorIndexer {
             .cloned()
             .collect()
     }
-    fn try_get<'a>(&self, val: &'a Value) -> Result<&'a Vec<Value>, Exception> {
+    fn try_get<'a>(&self, val: &'a Value) -> Result<&'a Vec<Value>, Condition> {
         val.try_into()
     }
 }
 
 #[bridge(name = "make-vector", lib = "(base)")]
-pub async fn make_vector(n: &Gc<Value>, with: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn make_vector(n: &Gc<Value>, with: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
     let n = n.read();
     let n: &Number = n.as_ref().try_into()?;
     let n: usize = n.try_into()?;
@@ -108,7 +108,7 @@ pub async fn make_vector(n: &Gc<Value>, with: &[Gc<Value>]) -> Result<Vec<Gc<Val
 }
 
 #[bridge(name = "vector", lib = "(base)")]
-pub async fn vector(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn vector(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
     Ok(vec![Gc::new(Value::Vector(
         args.iter()
             .map(Gc::read)
@@ -118,7 +118,7 @@ pub async fn vector(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
 }
 
 #[bridge(name = "vector-ref", lib = "(base)")]
-pub async fn vector_ref(vec: &Gc<Value>, index: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn vector_ref(vec: &Gc<Value>, index: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let vec = vec.read();
     let vec: &Vec<Value> = vec.as_ref().try_into()?;
 
@@ -126,13 +126,13 @@ pub async fn vector_ref(vec: &Gc<Value>, index: &Gc<Value>) -> Result<Vec<Gc<Val
 
     Ok(vec![Gc::new(
         vec.get(index)
-            .ok_or_else(|| Exception::invalid_index(index, vec.len()))?
+            .ok_or_else(|| Condition::invalid_index(index, vec.len()))?
             .clone(),
     )])
 }
 
 #[bridge(name = "vector-length", lib = "(base)")]
-pub async fn vector_len(vec: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn vector_len(vec: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let vec = vec.read();
     let vec: &Vec<Value> = vec.as_ref().try_into()?;
 
@@ -149,7 +149,7 @@ pub async fn vector_set(
     vec: &Gc<Value>,
     index: &Gc<Value>,
     with: &Gc<Value>,
-) -> Result<Vec<Gc<Value>>, Exception> {
+) -> Result<Vec<Gc<Value>>, Condition> {
     let mut vec = vec.write();
     let vec: &mut Vec<Value> = vec.as_mut().try_into()?;
     let vec_len = vec.len();
@@ -160,7 +160,7 @@ pub async fn vector_set(
 
     let index = vec
         .get_mut(index)
-        .ok_or_else(|| Exception::invalid_index(index, vec_len))?;
+        .ok_or_else(|| Condition::invalid_index(index, vec_len))?;
     *index = with.read().clone();
 
     Ok(vec![])
@@ -170,7 +170,7 @@ pub async fn vector_set(
 pub async fn vector_to_list(
     from: &Gc<Value>,
     range: &[Gc<Value>],
-) -> Result<Vec<Gc<Value>>, Exception> {
+) -> Result<Vec<Gc<Value>>, Condition> {
     let vec: Vec<Gc<Value>> = VectorIndexer
         .index(from, range)?
         .into_iter()
@@ -183,7 +183,7 @@ pub async fn vector_to_list(
 pub async fn vector_to_string(
     from: &Gc<Value>,
     range: &[Gc<Value>],
-) -> Result<Vec<Gc<Value>>, Exception> {
+) -> Result<Vec<Gc<Value>>, Condition> {
     Ok(vec![Gc::new(Value::String(
         VectorIndexer
             .index(from, range)?
@@ -197,7 +197,7 @@ pub async fn vector_to_string(
 pub async fn string_to_vector(
     from: &Gc<Value>,
     range: &[Gc<Value>],
-) -> Result<Vec<Gc<Value>>, Exception> {
+) -> Result<Vec<Gc<Value>>, Condition> {
     Ok(vec![Gc::new(Value::Vector(
         StringIndexer
             .index(from, range)?
@@ -211,7 +211,7 @@ pub async fn string_to_vector(
 pub async fn vector_copy(
     from: &Gc<Value>,
     range: &[Gc<Value>],
-) -> Result<Vec<Gc<Value>>, Exception> {
+) -> Result<Vec<Gc<Value>>, Condition> {
     Ok(vec![Gc::new(Value::Vector(
         VectorIndexer.index(from, range)?,
     ))])
@@ -223,19 +223,19 @@ pub async fn vector_copy_to(
     at: &Gc<Value>,
     from: &Gc<Value>,
     range: &[Gc<Value>],
-) -> Result<Vec<Gc<Value>>, Exception> {
+) -> Result<Vec<Gc<Value>>, Condition> {
     let mut to = to.write();
     let to: &mut Vec<Value> = to.as_mut().try_into()?;
 
     let at: usize = try_to_usize(at)?;
 
     if at >= to.len() {
-        return Err(Exception::invalid_index(at, to.len()));
+        return Err(Condition::invalid_index(at, to.len()));
     }
 
     let copies = VectorIndexer.index(from, range)?;
     if copies.len() + at >= to.len() {
-        return Err(Exception::invalid_range(at..at + copies.len(), to.len()));
+        return Err(Condition::invalid_range(at..at + copies.len(), to.len()));
     }
 
     copies
@@ -252,9 +252,9 @@ pub async fn vector_copy_to(
 }
 
 #[bridge(name = "vector-append", lib = "(base)")]
-pub async fn vector_append(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn vector_append(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
     if args.is_empty() {
-        return Err(Exception::wrong_num_of_variadic_args(1..usize::MAX, 0));
+        return Err(Condition::wrong_num_of_variadic_args(1..usize::MAX, 0));
     }
 
     Ok(vec![Gc::new(Value::Vector(
@@ -276,7 +276,7 @@ pub async fn vector_fill(
     with: &Gc<Value>,
     start: &Gc<Value>,
     end: &[Gc<Value>],
-) -> Result<Vec<Gc<Value>>, Exception> {
+) -> Result<Vec<Gc<Value>>, Condition> {
     let mut vector = vector.write();
     let vector: &mut Vec<Value> = vector.as_mut().try_into()?;
 
@@ -288,7 +288,7 @@ pub async fn vector_fill(
 
     let range = try_make_range(start, end)?;
     if range.end > vector.len() {
-        return Err(Exception::invalid_range(range, vector.len()));
+        return Err(Condition::invalid_range(range, vector.len()));
     }
 
     range.for_each(|i| {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,7 +6,7 @@ use scheme_rs::{
     ast::DefinitionBody,
     cps::Compile,
     env::{Environment, Top},
-    exception::Exception,
+    exception::Condition,
     gc::Gc,
     registry::{bridge, Registry},
     runtime::Runtime,
@@ -59,11 +59,11 @@ impl TestRuntime {
 }
 
 #[bridge(name = "assert-eq", lib = "(base)")]
-pub async fn test_assert(arg1: &Gc<Value>, arg2: &Gc<Value>) -> Result<Vec<Gc<Value>>, Exception> {
+pub async fn test_assert(arg1: &Gc<Value>, arg2: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     if !eqv(arg1, arg2) {
         let arg1 = format!("{arg1:?}");
         let arg2 = format!("{arg2:?}");
-        Err(Exception::assert_eq_failed(&arg2, &arg1))
+        Err(Condition::assert_eq_failed(&arg2, &arg1))
     } else {
         Ok(vec![])
     }


### PR DESCRIPTION
This PR adds stack traces and better error handling to scheme-rs.
The end result of this PR should be:
- No more panics _anywhere_ in the code.
- Beautiful error messages on exceptions that bubble up to the REPL.
- Stack traces that are full of information.
- More debug information given when procedures are returned to the top level, including their name, argument, and definition location. 