### PR TITLE
Tagged pointer value types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ inkwell = { version = "0.5.0", features = ["llvm18-0"] }
 nom = "7"
 nom_locate = "4"
 num = "0.4"
+ordered-float = "5"
 scheme-rs-macros = { version = "0.1.0-alpha.1", path = "proc-macros" }
 rand = "0.8"
 thiserror = "1"

--- a/README.md
+++ b/README.md
@@ -67,14 +67,17 @@ $1 = (1 2 3 4 5 6 7 8 9 10)
 
 ### Creating Builtin Functions:
 
-Scheme-rs provides a `bridge` function attribute macro to allow you to easily define builtins. For example,
-here is the definition of the `number?` builtin in the source code. Notice that this function is async:
+Scheme-rs provides a `bridge` function attribute macro to allow you to easily define builtins. Here is 
+an example of a function that reads a file into a string using tokio's `read_to_string` function:
 
 ```rust
-#[bridge(name = "number?", lib = "(base)")]
-pub async fn is_number(arg: &Gc<Value>) -> Result<Gc<Value>, Exception> {
-    let arg = arg.read();
-    Ok(Gc::new(Value::Boolean(matches!(&*arg, Value::Number(_)))))
+#[bridge(name = "read-file-to-string", lib = "(base)")]
+pub async fn read_file(file: &Value) -> Result<Vec<Value>, Condition> {
+    let file = file.to_string();
+    let contents = tokio::fs::read_to_string(&file)
+        .await
+        .map_err(|err| Condition::error(format!("failed to read file {file}: {err:?}")))?;
+    Ok(vec![Value::from(contents)])
 }
 ```
 

--- a/benches/fib.rs
+++ b/benches/fib.rs
@@ -10,7 +10,7 @@ use scheme_rs::{
 
 use criterion::*;
 
-async fn fib_fn() -> scheme_rs::proc::Closure {
+async fn fib_fn() -> Gc<scheme_rs::proc::Closure> {
     let runtime = Gc::new(Runtime::new());
     let registry = Registry::new(&runtime).await;
     let base = registry.import("(base)").unwrap();
@@ -36,7 +36,10 @@ fn fib_benchmark(c: &mut Criterion) {
 
     c.bench_function("fib 10000", |b| {
         b.to_async(&runtime)
-            .iter(|| async { closure.call(&[]).await })
+            .iter(|| {
+                let val = closure.clone();
+                async move { val.call(&[]).await }
+            })
     });
 }
 

--- a/benches/fib.rs
+++ b/benches/fib.rs
@@ -35,11 +35,10 @@ fn fib_benchmark(c: &mut Criterion) {
     let closure = runtime.block_on(async move { fib_fn().await });
 
     c.bench_function("fib 10000", |b| {
-        b.to_async(&runtime)
-            .iter(|| {
-                let val = closure.clone();
-                async move { val.call(&[]).await }
-            })
+        b.to_async(&runtime).iter(|| {
+            let val = closure.clone();
+            async move { val.call(&[]).await }
+        })
     });
 }
 

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -67,6 +67,7 @@ pub fn bridge(args: TokenStream, item: TokenStream) -> TokenStream {
                 args: &'a [::scheme_rs::value::Value],
                 rest_args: &'a [::scheme_rs::value::Value],
                 cont: &'a ::scheme_rs::value::Value,
+                _env: &'a [::scheme_rs::gc::Gc<::scheme_rs::value::Value>],
                 exception_handler: &'a Option<::scheme_rs::gc::Gc<::scheme_rs::exception::ExceptionHandler>>,
                 dynamic_wind: &'a ::scheme_rs::proc::DynamicWind,
             ) -> futures::future::BoxFuture<'a, Result<scheme_rs::proc::Application, ::scheme_rs::value::Value>> {
@@ -93,6 +94,7 @@ pub fn bridge(args: TokenStream, item: TokenStream) -> TokenStream {
                 args: &'a [::scheme_rs::value::Value],
                 rest_args: &'a [::scheme_rs::value::Value],
                 cont: &'a ::scheme_rs::value::Value,
+                _env: &'a [::scheme_rs::gc::Gc<::scheme_rs::value::Value>],
                 exception_handler: &'a Option<::scheme_rs::gc::Gc<::scheme_rs::exception::ExceptionHandler>>,
                 dynamic_wind: &'a ::scheme_rs::proc::DynamicWind,
             ) -> futures::future::BoxFuture<'a, Result<scheme_rs::proc::Application, ::scheme_rs::value::Value>> {

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -72,7 +72,7 @@ pub fn bridge(args: TokenStream, item: TokenStream) -> TokenStream {
             ) -> futures::future::BoxFuture<'a, Result<scheme_rs::proc::Application, ::scheme_rs::value::Value>> {
                 Box::pin(
                     async move {
-                        let cont = cont.try_into()?;
+                        let cont = cont.clone().try_into()?;
                         Ok(::scheme_rs::proc::Application::new(
                             cont,
                             #impl_name(
@@ -98,7 +98,7 @@ pub fn bridge(args: TokenStream, item: TokenStream) -> TokenStream {
             ) -> futures::future::BoxFuture<'a, Result<scheme_rs::proc::Application, ::scheme_rs::value::Value>> {
                 Box::pin(
                     async move {
-                        let cont = cont.try_into()?;
+                        let cont = cont.clone().try_into()?;
                         Ok(::scheme_rs::proc::Application::new(
                             cont,
                             #impl_name(

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -241,7 +241,6 @@ pub(super) async fn define_syntax(
     env: &Environment,
     // cont: &Closure
 ) -> Result<(), ParseAstError> {
-    /*
     let FullyExpanded {
         expanded,
         expansion_env,
@@ -255,11 +254,9 @@ pub(super) async fn define_syntax(
         .call(&[])
         .await
         .map_err(|err| ParseAstError::RaisedValue(err.into()))?;
-    let mac_read = mac[0].read();
-    let transformer: &Closure = mac_read.as_ref().try_into().unwrap();
-    env.def_macro(ident, transformer.clone());
-     */
-    todo!();
+    let transformer: Gc<Closure> = mac[0].clone().try_into().unwrap();
+    env.def_macro(ident, transformer);
+
     Ok(())
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -315,7 +315,9 @@ impl Expression {
                         .or_else(|| {
                             let top = env.fetch_top();
                             let is_repl = { top.read().is_repl() };
-                            is_repl.then(||Var::Global(top.write().def_var(ident.clone(), Value::undefined())))
+                            is_repl.then(|| {
+                                Var::Global(top.write().def_var(ident.clone(), Value::undefined()))
+                            })
                         })
                         .ok_or_else(|| ParseAstError::UndefinedVariable(ident.clone()))?,
                 )),
@@ -436,7 +438,7 @@ impl Expression {
 
         if let Expression::Var(Var::Global(global)) = self {
             let val = global.value_ref().read().clone();
-            let val: Gc<Closure>  = val.try_into().ok()?;
+            let val: Gc<Closure> = val.try_into().ok()?;
             let val_read = val.read();
             match val_read.func {
                 Bridge(ptr) if ptr == add_builtin_wrapper => Some(PrimOp::Add),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -428,7 +428,6 @@ impl Expression {
     // they are returned from a store.
     #[allow(unpredictable_function_pointer_comparisons)]
     pub fn to_primop(&self) -> Option<PrimOp> {
-        /*
         use crate::{
             num::{
                 add_builtin_wrapper, div_builtin_wrapper, equal_builtin_wrapper,
@@ -439,9 +438,10 @@ impl Expression {
         };
 
         if let Expression::Var(Var::Global(global)) = self {
-            let val_ref = global.value_ref().read();
-            let val: &Closure = val_ref.as_ref().try_into().ok()?;
-            match val.func {
+            let val = global.value_ref().read().clone();
+            let val: Gc<Closure>  = val.try_into().ok()?;
+            let val_read = val.read();
+            match val_read.func {
                 Bridge(ptr) if ptr == add_builtin_wrapper => Some(PrimOp::Add),
                 Bridge(ptr) if ptr == sub_builtin_wrapper => Some(PrimOp::Sub),
                 Bridge(ptr) if ptr == mul_builtin_wrapper => Some(PrimOp::Mul),
@@ -455,9 +455,7 @@ impl Expression {
             }
         } else {
             None
-    }
-         */
-        None
+        }
     }
 }
 

--- a/src/character.rs
+++ b/src/character.rs
@@ -1,8 +1,10 @@
-use crate::{exception::Condition, gc::Gc, num::Number, registry::bridge, value::Value};
+use std::sync::Arc;
+
+use crate::{exception::Condition, num::Number, registry::bridge, value::Value};
 use unicode_categories::UnicodeCategories;
 
-// mod unicode;
-// use unicode::*;
+mod unicode;
+use unicode::*;
 
 fn char_switch_case<I: Iterator<Item = char> + ExactSizeIterator>(
     ch: char,
@@ -17,33 +19,27 @@ fn char_switch_case<I: Iterator<Item = char> + ExactSizeIterator>(
     }
 }
 
-/*
-
 #[bridge(name = "char->integer", lib = "(base)")]
-pub async fn char_to_integer(ch: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
-    let ch = ch.read();
-    let ch: char = ch.as_ref().try_into()?;
+pub async fn char_to_integer(ch: &Value) -> Result<Vec<Value>, Condition> {
+    let ch: char = ch.clone().try_into()?;
 
-    Ok(vec![Gc::new(Value::Number(Number::FixedInteger(
+    Ok(vec![Value::from(Number::FixedInteger(
         <char as Into<u32>>::into(ch).into(),
-    )))])
+    ))])
 }
 
 #[bridge(name = "integer->char", lib = "(base)")]
-pub async fn integer_to_char(int: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
-    let int = int.read();
-    let int: &Number = int.as_ref().try_into()?;
-    let int: usize = int.try_into()?;
+pub async fn integer_to_char(int: &Value) -> Result<Vec<Value>, Condition> {
+    let int: Arc<Number> = int.clone().try_into()?;
+    let int: usize = int.as_ref().try_into()?;
     if let Ok(int) = <usize as TryInto<u32>>::try_into(int) {
         if let Some(ch) = char::from_u32(int) {
-            return Ok(vec![Gc::new(Value::Character(ch))]);
+            return Ok(vec![Value::from(ch)]);
         }
     }
 
     // char->integer returns a number larger than 0x10FFFF if integer is not an unicode scalar
-    Ok(vec![Gc::new(Value::Number(Number::FixedInteger(
-        0x10FFFF + 1,
-    )))])
+    Ok(vec![Value::from(Number::FixedInteger(0x10FFFF + 1))])
 }
 
 macro_rules! impl_char_operator {
@@ -53,13 +49,12 @@ macro_rules! impl_char_operator {
         $cmp_function:ident)),* $(,)?
     ) => {
         $(#[bridge(name = $bridge_name, lib = "(base)")]
-        pub async fn $function_name(req_lhs: &Gc<Value>, req_rhs: &Gc<Value>, opt_chars: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
+        pub async fn $function_name(req_lhs: &Value, req_rhs: &Value, opt_chars: &[Value]) -> Result<Vec<Value>, Condition> {
             for window in [req_lhs, req_rhs]
                 .into_iter()
                 .chain(opt_chars)
                 .map(|ch| {
-                    let ch = ch.read();
-                    ch.as_ref().try_into()
+                    ch.clone().try_into()
                 })
                 .collect::<Result<Vec<char>, Condition>>()?
                 .windows(2) {
@@ -68,14 +63,15 @@ macro_rules! impl_char_operator {
                     .and_then(|lhs| Some((lhs, window.get(1)?)))
                     .map(|(lhs, rhs)| lhs.$cmp_function(rhs))
                     .unwrap_or(true) {
-                    return Ok(vec![Gc::new(Value::Boolean(false))]);
+                    return Ok(vec![Value::from(false)]);
                 }
             }
 
-            Ok(vec![Gc::new(Value::Boolean(true))])
+            Ok(vec![Value::from(true)])
         })*
     }
 }
+
 impl_char_operator![
     ("char=?", char_eq, eq),
     ("char<?", char_lt, lt),
@@ -91,14 +87,13 @@ macro_rules! impl_char_ci_operator {
         $cmp_function:ident)),* $(,)?
     ) => {
         $(#[bridge(name = $bridge_name, lib = "(base)")]
-        pub async fn $function_name(req_lhs: &Gc<Value>, req_rhs: &Gc<Value>, opt_chars: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
+        pub async fn $function_name(req_lhs: &Value, req_rhs: &Value, opt_chars: &[Value]) -> Result<Vec<Value>, Condition> {
             for window in [req_lhs, req_rhs]
                 .into_iter()
                 .chain(opt_chars)
                 .map(|ch| {
-                    let ch = ch.read();
-                    <&Value as TryInto<char>>::try_into(ch.as_ref())
-                        .and_then(|c| char_switch_case(c, to_foldcase))
+                    let ch: char = ch.clone().try_into()?;
+                    char_switch_case(ch, to_foldcase)
                 })
                 .collect::<Result<Vec<char>, Condition>>()?
                 .windows(2) {
@@ -107,14 +102,15 @@ macro_rules! impl_char_ci_operator {
                     .and_then(|lhs| Some((lhs, window.get(1)?)))
                     .map(|(lhs, rhs)| lhs.$cmp_function(rhs))
                     .unwrap_or(true) {
-                    return Ok(vec![Gc::new(Value::Boolean(false))]);
+                    return Ok(vec![Value::from(false)]);
                 }
             }
 
-            Ok(vec![Gc::new(Value::Boolean(true))])
+            Ok(vec![Value::from(true)])
         })*
     }
 }
+
 impl_char_ci_operator![
     ("char-ci-=?", char_ci_eq, eq),
     ("char-ci-<?", char_ci_lt, lt),
@@ -126,13 +122,13 @@ impl_char_ci_operator![
 macro_rules! impl_char_predicate {
     ($(($bridge_name:literal, $function_name:ident, $predicate:ident)),* $(,)?) => {
         $(#[bridge(name = $bridge_name, lib = "(base)")]
-        pub async fn $function_name(ch: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
-            let ch = ch.read();
-            let ch: char = ch.as_ref().try_into()?;
-            Ok(vec![Gc::new(Value::Boolean(ch.$predicate()))])
+        pub async fn $function_name(ch: &Value) -> Result<Vec<Value>, Condition> {
+            let ch: char = ch.clone().try_into()?;
+            Ok(vec![Value::from(ch.$predicate())])
         })*
     }
 }
+
 impl_char_predicate![
     ("char-alphabetic?", char_is_alphabetic, is_ascii_alphabetic),
     ("char-numeric?", char_is_numeric, is_number_decimal_digit),
@@ -142,42 +138,35 @@ impl_char_predicate![
 ];
 
 #[bridge(name = "digit-value", lib = "(base)")]
-pub async fn digit_value(ch: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
-    let ch = ch.read();
-    let ch: char = ch.as_ref().try_into()?;
+pub async fn digit_value(ch: &Value) -> Result<Vec<Value>, Condition> {
+    let ch: char = ch.clone().try_into()?;
 
-    Ok(vec![Gc::new(
-        digit_to_num(ch)
-            .map(<u32 as Into<i64>>::into)
-            .map(Number::FixedInteger)
-            .map(Value::Number)
-            .unwrap_or(Value::Boolean(false)),
-    )])
+    Ok(vec![digit_to_num(ch)
+        .map(<u32 as Into<i64>>::into)
+        .map(Number::FixedInteger)
+        .map(Value::from)
+        .unwrap_or(Value::from(false))])
 }
 
 macro_rules! impl_char_case_converter {
     ($(($bridge_name:literal, $function_name:ident, $converter:expr)),* $(,)?) => {
         $(#[bridge(name = $bridge_name, lib = "(base)")]
-        pub async fn $function_name(ch: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
-            let ch = ch.read();
-            let ch: char = ch.as_ref().try_into()?;
-            Ok(vec![Gc::new(Value::Character(char_switch_case(ch, $converter)?))])
+        pub async fn $function_name(ch: &Value) -> Result<Vec<Value>, Condition> {
+            let ch: char = ch.clone().try_into()?;
+            Ok(vec![Value::from(char_switch_case(ch, $converter)?)])
         })*
     }
 }
+
 impl_char_case_converter![
     ("char-upcase", char_upcase, char::to_uppercase),
     ("char-downcase", char_downcase, char::to_lowercase),
 ];
 
 #[bridge(name = "char-foldcase", lib = "(base)")]
-pub async fn char_foldcase(ch: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
-    let ch = ch.read();
-    let ch: char = ch.as_ref().try_into()?;
-    Ok(vec![Gc::new(Value::Character(char_switch_case(
-        ch,
-        to_foldcase,
-    )?))])
+pub async fn char_foldcase(ch: &Value) -> Result<Vec<Value>, Condition> {
+    let ch: char = ch.clone().try_into()?;
+    Ok(vec![Value::from(char_switch_case(ch, to_foldcase)?)])
 }
 
 #[cfg(test)]
@@ -192,4 +181,3 @@ mod tests {
             .for_each(|d| assert!(d.is_some()));
     }
 }
-*/

--- a/src/character.rs
+++ b/src/character.rs
@@ -1,8 +1,8 @@
 use crate::{exception::Condition, gc::Gc, num::Number, registry::bridge, value::Value};
 use unicode_categories::UnicodeCategories;
 
-mod unicode;
-use unicode::*;
+// mod unicode;
+// use unicode::*;
 
 fn char_switch_case<I: Iterator<Item = char> + ExactSizeIterator>(
     ch: char,
@@ -16,6 +16,8 @@ fn char_switch_case<I: Iterator<Item = char> + ExactSizeIterator>(
         Err(Condition::wrong_num_of_unicode_chars(1, len))
     }
 }
+
+/*
 
 #[bridge(name = "char->integer", lib = "(base)")]
 pub async fn char_to_integer(ch: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
@@ -190,3 +192,4 @@ mod tests {
             .for_each(|d| assert!(d.is_some()));
     }
 }
+*/

--- a/src/cps/analysis.rs
+++ b/src/cps/analysis.rs
@@ -23,7 +23,7 @@ impl Cps {
     // TODO: Have this function return a Cow<'_, HashSet<Local>>
     pub(super) fn free_variables(&self) -> HashSet<Local> {
         match self {
-            Cps::AllocCell(ref bind, cexpr) => {
+            Cps::PrimOp(PrimOp::AllocCell, _, ref bind, cexpr) => {
                 let mut free = cexpr.free_variables();
                 free.remove(bind);
                 free
@@ -74,7 +74,7 @@ impl Cps {
     // TODO: Have this function return a Cow<'_, HashSet<Local>>
     pub(super) fn globals(&self) -> HashSet<Global> {
         match self {
-            Cps::AllocCell(_, cexpr) => cexpr.globals(),
+            Cps::PrimOp(PrimOp::AllocCell, _, s_, cexpr) => cexpr.globals(),
             Cps::PrimOp(_, args, _, cexpr) => cexpr
                 .globals()
                 .union(&values_to_globals(args))
@@ -111,7 +111,7 @@ impl Cps {
         uses_cache: &mut HashMap<Local, HashMap<Local, usize>>,
     ) -> HashMap<Local, usize> {
         match self {
-            Cps::AllocCell(_, cexpr) => cexpr.uses(uses_cache).clone(),
+            // Cps::AllocCell(_, cexpr) => cexpr.uses(uses_cache).clone(),
             Cps::PrimOp(_, args, _, cexpr) => {
                 merge_uses(values_to_uses(args), cexpr.uses(uses_cache))
             }

--- a/src/cps/analysis.rs
+++ b/src/cps/analysis.rs
@@ -74,7 +74,7 @@ impl Cps {
     // TODO: Have this function return a Cow<'_, HashSet<Local>>
     pub(super) fn globals(&self) -> HashSet<Global> {
         match self {
-            Cps::PrimOp(PrimOp::AllocCell, _, s_, cexpr) => cexpr.globals(),
+            Cps::PrimOp(PrimOp::AllocCell, _, _, cexpr) => cexpr.globals(),
             Cps::PrimOp(_, args, _, cexpr) => cexpr
                 .globals()
                 .union(&values_to_globals(args))

--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -6,8 +6,8 @@ use inkwell::{
     context::Context,
     execution_engine::ExecutionEngine,
     module::Module,
-    values::{BasicValueEnum, FunctionValue, PointerValue},
-    AddressSpace,
+    values::{BasicValueEnum, FunctionValue, IntValue, PointerValue},
+    AddressSpace, IntPredicate,
 };
 use std::{collections::HashMap, rc::Rc};
 
@@ -15,21 +15,21 @@ use crate::{
     gc::Gc,
     proc::{Closure, ContinuationPtr, FuncPtr},
     runtime::{Runtime, IGNORE_CALL_SITE, IGNORE_FUNCTION},
-    value::Value as SchemeValue,
+    value::{ReflexiveValue, Value as SchemeValue},
 };
 
 use super::*;
 
 struct Rebinds<'ctx> {
-    rebinds: HashMap<Var, PointerValue<'ctx>>,
+    rebinds: HashMap<Var, BasicValueEnum<'ctx>>,
 }
 
 impl<'ctx> Rebinds<'ctx> {
-    fn rebind(&mut self, old_var: Var, new_var: PointerValue<'ctx>) {
+    fn rebind(&mut self, old_var: Var, new_var: BasicValueEnum<'ctx>) {
         self.rebinds.insert(old_var, new_var);
     }
 
-    fn fetch_bind(&self, var: &Var) -> &PointerValue<'ctx> {
+    fn fetch_bind(&self, var: &Var) -> &BasicValueEnum<'ctx> {
         self.rebinds
             .get(var)
             .unwrap_or_else(|| panic!("could not find {var:?}"))
@@ -44,19 +44,35 @@ impl<'ctx> Rebinds<'ctx> {
 
 struct Allocs<'ctx> {
     prev_alloc: Option<Rc<Allocs<'ctx>>>,
-    value: PointerValue<'ctx>,
+    value: BasicValueEnum<'ctx>// PointerValue<'ctx>,
 }
 
 impl<'ctx> Allocs<'ctx> {
     fn new(
         prev_alloc: Option<Rc<Allocs<'ctx>>>,
-        value: PointerValue<'ctx>,
+        value: BasicValueEnum<'ctx>,
     ) -> Option<Rc<Allocs<'ctx>>> {
         Some(Rc::new(Allocs { prev_alloc, value }))
     }
 
-    fn to_values(&self) -> Vec<PointerValue<'ctx>> {
-        let mut allocs = vec![self.value];
+    fn to_cells(&self) -> Vec<PointerValue<'ctx>> {
+        let mut allocs = match self.value {
+            BasicValueEnum::PointerValue(value) => vec![value],
+            _ => Vec::new(),
+        };
+
+        if let Some(ref prev_alloc) = self.prev_alloc {
+            allocs.extend(prev_alloc.to_cells());
+        }
+
+        allocs
+    }
+
+    fn to_values(&self) -> Vec<IntValue<'ctx>> {
+        let mut allocs = match self.value {
+            BasicValueEnum::IntValue(value) => vec![value],
+            _ => Vec::new(),
+        };
 
         if let Some(ref prev_alloc) = self.prev_alloc {
             allocs.extend(prev_alloc.to_values());
@@ -99,7 +115,7 @@ impl Cps {
         let fn_name = fn_value.to_func_name();
         let function = module.add_function(&fn_name, fn_type, None);
 
-        let mut cu = CompilationUnit::new(ctx, module, builder, function);
+        let mut cu = CompilationUnit::new(runtime.clone(), ctx, module, builder, function);
         let entry = ctx.append_basic_block(function, "entry");
         builder.position_at_end(entry);
 
@@ -119,8 +135,7 @@ impl Cps {
             collected_env.push(val);
             let res = builder
                 .build_extract_value(env_load, i as u32, "extract_env")
-                .unwrap()
-                .into_pointer_value();
+                .unwrap();
             cu.rebinds.rebind(Var::Local(local), res);
         }
 
@@ -140,8 +155,7 @@ impl Cps {
         for (i, global) in globals.iter().enumerate() {
             let res = builder
                 .build_extract_value(globals_load, i as u32, "extract_global")
-                .unwrap()
-                .into_pointer_value();
+                .unwrap();
             cu.rebinds.rebind(Var::Global(global.clone()), res);
         }
 
@@ -177,6 +191,7 @@ impl Cps {
 }
 
 struct CompilationUnit<'ctx, 'b> {
+    runtime: Gc<Runtime>,
     ctx: &'ctx Context,
     module: &'b Module<'ctx>,
     builder: &'b Builder<'ctx>,
@@ -194,12 +209,14 @@ struct CompilationUnit<'ctx, 'b> {
 
 impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
     fn new(
+        runtime: Gc<Runtime>,
         ctx: &'ctx Context,
         module: &'b Module<'ctx>,
         builder: &'b Builder<'ctx>,
         function: FunctionValue<'ctx>,
     ) -> Self {
         Self {
+            runtime,
             ctx,
             module,
             builder,
@@ -229,6 +246,12 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
             Cps::PrimOp(PrimOp::AllocCell, _, into, cexpr) => {
                 self.alloc_cell_codegen(into, *cexpr, allocs, deferred)?;
             }
+            Cps::PrimOp(PrimOp::ReadCell, args, into, cexpr) => {
+                let [cell] = args.as_slice() else {
+                    unreachable!()
+                };
+                self.read_cell_codegen(cell, into, *cexpr, allocs, deferred)?;
+            }
             Cps::PrimOp(PrimOp::ExtractWinders, _, extract_to, cexpr) => {
                 self.extract_winders_codegen(extract_to, *cexpr, allocs, deferred)?;
             }
@@ -255,6 +278,7 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
                 debug: debug_info_id,
             } => {
                 let bundle = ClosureBundle::new(
+                    self.runtime.clone(),
                     self.ctx,
                     self.module,
                     val,
@@ -269,33 +293,25 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
         Ok(())
     }
 
-    fn clone_codegen(
-        &mut self,
-        value: &Value,
-        clone_into: Local,
-        cexpr: Cps,
-        allocs: Option<Rc<Allocs<'ctx>>>,
-        deferred: &mut Vec<ClosureBundle<'ctx>>,
-    ) -> Result<(), BuilderError> {
-        let value = self.value_codegen(value)?.into_pointer_value();
-        let clone = self.module.get_function("clone").unwrap();
-        let cloned = self
-            .builder
-            .build_call(clone, &[value.into()], "cloned")?
-            .try_as_basic_value()
-            .left()
-            .unwrap()
-            .into_pointer_value();
-        self.rebinds.rebind(Var::Local(clone_into), cloned);
-        let new_alloc = Allocs::new(allocs, cloned);
-        self.cps_codegen(cexpr, new_alloc, deferred)?;
-        Ok(())
-    }
-
-    fn value_codegen(&self, value: &Value) -> Result<BasicValueEnum<'ctx>, BuilderError> {
+    fn value_codegen(&self, value: &Value) -> BasicValueEnum<'ctx> {
         match value {
-            Value::Var(var) => Ok((*self.rebinds.fetch_bind(var)).into()),
-            _ => todo!(),
+            Value::Var(var) => (*self.rebinds.fetch_bind(var)).into(),
+            Value::Value(val) => {
+                let mut runtime_write = self.runtime.write();
+                let reflexive_val = ReflexiveValue(val.clone());
+                if !runtime_write.constants_pool.contains(&reflexive_val) {
+                    runtime_write.constants_pool.insert(reflexive_val.clone());
+                }
+                let raw = SchemeValue::as_raw(
+                    runtime_write
+                        .constants_pool
+                        .get(&reflexive_val)
+                        .unwrap()
+                        .as_ref(),
+                );
+                let i64_type = self.ctx.i64_type();
+                i64_type.const_int(raw, false).into()
+            }
         }
     }
 
@@ -321,8 +337,7 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
             )?
             .try_as_basic_value()
             .left()
-            .unwrap()
-            .into_pointer_value();
+            .unwrap();
 
         self.rebinds.rebind(Var::Local(extract_to), winders);
         let new_alloc = Allocs::new(allocs, winders);
@@ -340,8 +355,8 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
         allocs: Option<Rc<Allocs<'ctx>>>,
         deferred: &mut Vec<ClosureBundle<'ctx>>,
     ) -> Result<(), BuilderError> {
-        let cont = self.value_codegen(cont)?;
-        let winders = self.value_codegen(winders)?;
+        let cont = self.value_codegen(cont);
+        let winders = self.value_codegen(winders);
         let prepare_continuation = self.module.get_function("prepare_continuation").unwrap();
         let prepared = self
             .builder
@@ -360,8 +375,7 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
             )?
             .try_as_basic_value()
             .left()
-            .unwrap()
-            .into_pointer_value();
+            .unwrap();
 
         self.rebinds.rebind(Var::Local(prepare_to), prepared);
         let new_alloc = Allocs::new(allocs, prepared);
@@ -394,7 +408,7 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
                     "vals_elem",
                 )?
             };
-            let val = self.value_codegen(val)?;
+            let val = self.value_codegen(val);
             self.builder.build_store(ep, val)?;
         }
 
@@ -428,18 +442,20 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
             )?
             .try_as_basic_value()
             .left()
-            .unwrap()
-            .into_pointer_value();
+            .unwrap();
 
-        let is_null_bb = self.ctx.append_basic_block(self.function, "is_null");
+        let is_undef_bb = self.ctx.append_basic_block(self.function, "is_undef");
         let success_bb = self.ctx.append_basic_block(self.function, "success");
 
-        let is_null = self.builder.build_is_null(result_val, "is_null")?;
+        let i64_type = self.ctx.i16_type();
+        let undef = i64_type.const_int(0, false);
+        let is_undef = self.builder.build_int_compare(IntPredicate::EQ, result_val.into_int_value(), undef.into(), "is_undef")?;
+        // let is_undef = self.builder.build_is_null(result_val, "is_undef")?;
         self.builder
-            .build_conditional_branch(is_null, is_null_bb, success_bb)?;
+            .build_conditional_branch(is_undef, is_undef_bb, success_bb)?;
 
-        self.builder.position_at_end(is_null_bb);
-        self.drop_values_codegen(allocs.clone())?;
+        self.builder.position_at_end(is_undef_bb);
+        self.drops_codegen(allocs.clone())?;
         let error_val = self
             .builder
             .build_load(ptr_type, error_val, "error_val_load")?;
@@ -463,19 +479,17 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
         deferred: &mut Vec<ClosureBundle<'ctx>>,
     ) -> Result<(), BuilderError> {
         // Get a newly allocated undefined value
-        let gc_alloc_undef_val = self.module.get_function("alloc_undef_val").unwrap();
-        let undef_val = self
+        let alloc_cell = self.module.get_function("alloc_cell").unwrap();
+        let cell = self
             .builder
-            .build_call(gc_alloc_undef_val, &[], "undefined")?
+            .build_call(alloc_cell, &[], "cell")?
             .try_as_basic_value()
             .left()
-            .unwrap()
-            .into_pointer_value();
+            .unwrap();
 
         // Rebind the variable to it
-        self.rebinds.rebind(Var::Local(var), undef_val);
-
-        let new_alloc = Allocs::new(allocs, undef_val);
+        self.rebinds.rebind(Var::Local(var), cell);
+        let new_alloc = Allocs::new(allocs, cell);
 
         // Compile the continuation with the newly allocated value
         self.cps_codegen(cexpr, new_alloc, deferred)?;
@@ -483,8 +497,77 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
         Ok(())
     }
 
-    fn drop_values_codegen(&self, drops: Option<Rc<Allocs<'ctx>>>) -> Result<(), BuilderError> {
+    fn read_cell_codegen(
+        &mut self,
+        cell: &Value,
+        read_into: Local,
+        cexpr: Cps,
+        allocs: Option<Rc<Allocs<'ctx>>>,
+        deferred: &mut Vec<ClosureBundle<'ctx>>,
+    ) -> Result<(), BuilderError> {
+        let cell = self.value_codegen(cell);
+        let read_cell = self.module.get_function("read_cell").unwrap();
+        let value = self
+            .builder
+            .build_call(read_cell, &[cell.into()], "read_value")?
+            .try_as_basic_value()
+            .left()
+            .unwrap();
+        
+        self.rebinds.rebind(Var::Local(read_into), value);
+
+        self.cps_codegen(cexpr, allocs, deferred)?;
+
+        Ok(())
+    }
+
+    fn drops_codegen(&self, drops: Option<Rc<Allocs<'ctx>>>) -> Result<(), BuilderError> {
+        self.drop_values_codgen(drops.clone())?;
+        self.drop_cells_codegen(drops.clone())?;
+        Ok(())
+    }
+
+    fn drop_values_codgen(&self, drops: Option<Rc<Allocs<'ctx>>>) -> Result<(), BuilderError> {
         let drops = drops.as_ref().map_or_else(Vec::new, |x| x.to_values());
+        let num_drops = drops.len();
+
+        if num_drops == 0 {
+            return Ok(());
+        }
+
+        // Put the drops in an array
+        let i64_type = self.ctx.i64_type();
+        let i32_type = self.ctx.i32_type();
+        let array_type = i64_type.array_type(drops.len() as u32);
+        let drops_alloca = self.builder.build_alloca(array_type, "drops")?;
+        for (i, drp) in drops.into_iter().enumerate() {
+            let ep = unsafe {
+                self.builder.build_gep(
+                    i64_type,
+                    drops_alloca,
+                    &[i32_type.const_int(i as u64, false)],
+                    "alloca_elem",
+                )?
+            };
+            self.builder.build_store(ep, drp)?;
+        }
+
+        // Call drop_values
+        let drop_values = self.module.get_function("drop_values").unwrap();
+        self.builder.build_call(
+            drop_values,
+            &[
+                drops_alloca.into(),
+                i32_type.const_int(num_drops as u64, false).into(),
+            ],
+            "drop_values",
+        )?;
+
+        Ok(())
+    }
+
+    fn drop_cells_codegen(&self, drops: Option<Rc<Allocs<'ctx>>>) -> Result<(), BuilderError> {
+        let drops = drops.as_ref().map_or_else(Vec::new, |x| x.to_cells());
         let num_drops = drops.len();
 
         if num_drops == 0 {
@@ -508,15 +591,15 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
             self.builder.build_store(ep, drp)?;
         }
 
-        // Call drop_values
-        let drop_values = self.module.get_function("drop_values").unwrap();
+        // Call drop_cells
+        let drop_cells = self.module.get_function("drop_cells").unwrap();
         self.builder.build_call(
-            drop_values,
+            drop_cells,
             &[
                 drops_alloca.into(),
                 i32_type.const_int(num_drops as u64, false).into(),
             ],
-            "drop_values",
+            "drop_cells",
         )?;
 
         Ok(())
@@ -529,7 +612,7 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
         call_site_id: Option<CallSiteId>,
         allocs: Option<Rc<Allocs<'ctx>>>,
     ) -> Result<(), BuilderError> {
-        let operator = self.value_codegen(operator)?;
+        let operator = self.value_codegen(operator);
 
         // Allocate space for the args to be passed to make_application
         let ptr_type = self.ctx.ptr_type(AddressSpace::default());
@@ -545,7 +628,7 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
                     "alloca_elem",
                 )?
             };
-            let val = self.value_codegen(arg)?;
+            let val = self.value_codegen(arg);
             self.builder.build_store(ep, val)?;
         }
 
@@ -585,7 +668,7 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
 
         // Now that we have created an application, we can reduce the ref counts of
         // all of the Gcs we have allocated in this function:
-        self.drop_values_codegen(allocs)?;
+        self.drops_codegen(allocs)?;
 
         let _ = self.builder.build_return(Some(&app))?;
 
@@ -598,8 +681,8 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
         arg: &Value,
         allocs: Option<Rc<Allocs<'ctx>>>,
     ) -> Result<(), BuilderError> {
-        let operator = self.value_codegen(operator)?;
-        let arg = self.value_codegen(arg)?;
+        let operator = self.value_codegen(operator);
+        let arg = self.value_codegen(arg);
 
         let make_forward = self.module.get_function("forward").unwrap();
         let app = self
@@ -628,7 +711,7 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
 
         // Now that we have created an application, we can reduce the ref counts of
         // all of the Gcs we have allocated in this function:
-        self.drop_values_codegen(allocs)?;
+        self.drops_codegen(allocs)?;
 
         let _ = self.builder.build_return(Some(&app))?;
 
@@ -640,7 +723,7 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
         args: &Value,
         allocs: Option<Rc<Allocs<'ctx>>>,
     ) -> Result<(), BuilderError> {
-        let val = self.value_codegen(args)?;
+        let val = self.value_codegen(args);
         let make_app = self.module.get_function("halt").unwrap();
         let app = self
             .builder
@@ -649,7 +732,7 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
             .left()
             .unwrap();
 
-        self.drop_values_codegen(allocs)?;
+        self.drops_codegen(allocs)?;
 
         let _ = self.builder.build_return(Some(&app))?;
 
@@ -664,7 +747,7 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
         allocs: Option<Rc<Allocs<'ctx>>>,
         deferred: &mut Vec<ClosureBundle<'ctx>>,
     ) -> Result<(), BuilderError> {
-        let cond = self.value_codegen(cond)?;
+        let cond = self.value_codegen(cond);
         let truthy = self.module.get_function("truthy").unwrap();
         let cond = self
             .builder
@@ -691,8 +774,8 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
     }
 
     fn store_codegen(&self, from: &Value, to: &Value) -> Result<(), BuilderError> {
-        let from = self.value_codegen(from)?.into();
-        let to = self.value_codegen(to)?.into();
+        let from = self.value_codegen(from).into();
+        let to = self.value_codegen(to).into();
         let store = self.module.get_function("store").unwrap();
         let _ = self.builder.build_call(store, &[from, to], "")?;
         Ok(())
@@ -714,8 +797,8 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
             )?
             .try_as_basic_value()
             .left()
-            .unwrap()
-            .into_pointer_value();
+            .unwrap();
+
         self.rebinds.rebind(Var::Local(result), expanded);
         Ok(())
     }
@@ -803,8 +886,7 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
             .build_call(make_closure, &args, "make_closure")?
             .try_as_basic_value()
             .left()
-            .unwrap()
-            .into_pointer_value();
+            .unwrap();
 
         self.rebinds.rebind(Var::Local(bundle.val), closure);
 
@@ -818,6 +900,7 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
 
 #[derive(Debug)]
 pub struct ClosureBundle<'ctx> {
+    runtime: Gc<Runtime>,
     val: Local,
     env: Vec<Local>,
     globals: Vec<Global>,
@@ -836,6 +919,7 @@ const CONTINUATION_PARAM: u32 = 6;
 
 impl<'ctx> ClosureBundle<'ctx> {
     fn new(
+        runtime: Gc<Runtime>,
         ctx: &'ctx Context,
         module: &Module<'ctx>,
         val: Local,
@@ -881,6 +965,7 @@ impl<'ctx> ClosureBundle<'ctx> {
         let name = val.to_func_name();
         let function = module.add_function(&name, fn_type, None);
         Self {
+            runtime,
             val,
             env,
             globals,
@@ -902,7 +987,8 @@ impl<'ctx> ClosureBundle<'ctx> {
 
         builder.position_at_end(entry);
 
-        let mut cu = CompilationUnit::new(ctx, module, builder, self.function);
+        let mut cu =
+            CompilationUnit::new(self.runtime.clone(), ctx, module, builder, self.function);
 
         let env_param = self
             .function
@@ -917,8 +1003,7 @@ impl<'ctx> ClosureBundle<'ctx> {
         for (i, env_var) in self.env.iter().enumerate() {
             let res = builder
                 .build_extract_value(env_load, i as u32, "extract_env")
-                .unwrap()
-                .into_pointer_value();
+                .unwrap();
             cu.rebinds.rebind(Var::Local(*env_var), res);
         }
 
@@ -935,8 +1020,7 @@ impl<'ctx> ClosureBundle<'ctx> {
         for (i, global) in self.globals.iter().enumerate() {
             let res = builder
                 .build_extract_value(globals_load, i as u32, "extract_global")
-                .unwrap()
-                .into_pointer_value();
+                .unwrap();
             cu.rebinds.rebind(Var::Global(global.clone()), res);
         }
 
@@ -953,8 +1037,7 @@ impl<'ctx> ClosureBundle<'ctx> {
         for (i, arg_var) in self.args.args.iter().enumerate() {
             let res = builder
                 .build_extract_value(args_load, i as u32, "extract_arg")
-                .unwrap()
-                .into_pointer_value();
+                .unwrap();
             cu.rebinds.rebind(Var::Local(*arg_var), res);
         }
 
@@ -962,8 +1045,7 @@ impl<'ctx> ClosureBundle<'ctx> {
             let cont_param = self
                 .function
                 .get_nth_param(CONTINUATION_PARAM)
-                .unwrap()
-                .into_pointer_value();
+                .unwrap();
             cu.rebinds.rebind(Var::Local(cont), cont_param);
         }
 

--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -215,9 +215,6 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
         deferred: &mut Vec<ClosureBundle<'ctx>>,
     ) -> Result<(), BuilderError> {
         match cps {
-            Cps::AllocCell(into, cexpr) => {
-                self.alloc_cell_codegen(into, *cexpr, allocs, deferred)?;
-            }
             Cps::If(cond, success, failure) => {
                 self.if_codegen(&cond, *success, *failure, allocs, deferred)?
             }
@@ -229,11 +226,8 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
                 self.store_codegen(&args[1], &args[0])?;
                 self.cps_codegen(*cexpr, allocs, deferred)?;
             }
-            Cps::PrimOp(PrimOp::Clone, args, clone_into, cexpr) => {
-                let [to_clone] = args.as_slice() else {
-                    unreachable!()
-                };
-                self.clone_codegen(to_clone, clone_into, *cexpr, allocs, deferred)?;
+            Cps::PrimOp(PrimOp::AllocCell, _, into, cexpr) => {
+                self.alloc_cell_codegen(into, *cexpr, allocs, deferred)?;
             }
             Cps::PrimOp(PrimOp::ExtractWinders, _, extract_to, cexpr) => {
                 self.extract_winders_codegen(extract_to, *cexpr, allocs, deferred)?;

--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -246,14 +246,6 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
             Cps::PrimOp(PrimOp::AllocCell, _, into, cexpr) => {
                 self.alloc_cell_codegen(into, *cexpr, allocs, deferred)?;
             }
-            /*
-            Cps::PrimOp(PrimOp::ReadCell, args, into, cexpr) => {
-                let [cell] = args.as_slice() else {
-                    unreachable!()
-                };
-                self.read_cell_codegen(cell, into, *cexpr, allocs, deferred)?;
-            }
-             */
             Cps::PrimOp(PrimOp::ExtractWinders, _, extract_to, cexpr) => {
                 self.extract_winders_codegen(extract_to, *cexpr, allocs, deferred)?;
             }
@@ -265,7 +257,7 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
                     cont, winders, prepare_to, *cexpr, allocs, deferred,
                 )?;
             }
-            Cps::PrimOp(PrimOp::GetCallTransformerFn, _, res, cexpr) => {
+            Cps::PrimOp(PrimOp::GetCallTransformerFn, env, res, cexpr) => {
                 self.get_call_transformer_codegen(res)?;
                 self.cps_codegen(*cexpr, allocs, deferred)?;
             }
@@ -311,7 +303,7 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
                     .left()
                     .unwrap()
             },
-            Value::Value(val) => {
+            Value::Const(val) => {
                 let mut runtime_write = self.runtime.write();
                 let reflexive_val = ReflexiveValue(val.clone());
                 if !runtime_write.constants_pool.contains(&reflexive_val) {
@@ -790,14 +782,16 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
 
     fn store_codegen(&self, from: &Value, to: &Value) -> Result<(), BuilderError> {
         let from = self.value_codegen(from).into();
-        let Value::Var(to) = to else { unreachable!() }; // self.value_codegen(to).into();
+        let Value::Var(to) = to else { unreachable!() };
         let to = self.rebinds.fetch_bind(to).into_pointer_value().into();
         let store = self.module.get_function("store").unwrap();
         let _ = self.builder.build_call(store, &[from, to], "")?;
         Ok(())
     }
 
-    fn get_call_transformer_codegen(&mut self, result: Local) -> Result<(), BuilderError> {
+    fn get_call_transformer_codegen(&mut self, env: &[Value], result: Local) -> Result<(), BuilderError> {
+        todo!();
+        /*
         let get_call_transformer_fn = self.module.get_function("get_call_transformer_fn").unwrap();
         let expanded = self
             .builder
@@ -816,6 +810,8 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
             .unwrap();
 
         self.rebinds.rebind(Var::Local(result), expanded);
+         */
+        
         Ok(())
     }
 

--- a/src/cps/compile.rs
+++ b/src/cps/compile.rs
@@ -1,7 +1,7 @@
 use std::iter::once;
 
 use super::*;
-use crate::{ast::*, gc::Gc, syntax::Identifier, value::Value as RuntimeValue};
+use crate::{ast::*, value::Value as RuntimeValue};
 use either::Either;
 
 /// There's not too much reason that this is a trait, other than I wanted to
@@ -149,7 +149,6 @@ impl Compile for Var {
     fn compile(&self, mut meta_cont: Box<dyn FnMut(Value) -> Cps + '_>) -> Cps {
         let k1 = Local::gensym();
         let k2 = Local::gensym();
-        let read_into = Local::gensym();
         Cps::Closure {
             args: ClosureArgs::new(vec![k2], false, None),
             body: Box::new(Cps::App(
@@ -157,18 +156,6 @@ impl Compile for Var {
                 vec![Value::from(self.clone())],
                 None,
             )),
-            /*
-            body: Box::new(Cps::PrimOp(
-                PrimOp::ReadCell,
-                vec![Value::from(self.clone())],
-                read_into,
-                Box::new(Cps::App(
-                    Value::from(k2),
-                    vec![Value::from(read_into)],
-                    None,
-                )),
-            )),
-            */
             val: k1,
             cexp: Box::new(meta_cont(Value::from(k1))),
             debug: None,

--- a/src/cps/compile.rs
+++ b/src/cps/compile.rs
@@ -152,6 +152,12 @@ impl Compile for Var {
         let read_into = Local::gensym();
         Cps::Closure {
             args: ClosureArgs::new(vec![k2], false, None),
+            body: Box::new(Cps::App(
+                Value::from(k2),
+                vec![Value::from(self.clone())],
+                None,
+            )),
+            /*
             body: Box::new(Cps::PrimOp(
                 PrimOp::ReadCell,
                 vec![Value::from(self.clone())],
@@ -162,6 +168,7 @@ impl Compile for Var {
                     None,
                 )),
             )),
+            */
             val: k1,
             cexp: Box::new(meta_cont(Value::from(k1))),
             debug: None,

--- a/src/cps/compile.rs
+++ b/src/cps/compile.rs
@@ -791,17 +791,22 @@ impl Compile for SyntaxCase {
                     args: ClosureArgs::new(vec![to_expand], false, None),
                     body: Box::new(Cps::PrimOp(
                         PrimOp::GetCallTransformerFn,
-                        self.captured_env.captured.iter().copied().map(Value::from).collect(),
+                        self.captured_env
+                            .captured
+                            .iter()
+                            .copied()
+                            .map(Value::from)
+                            .collect(),
                         call_transformer,
                         Box::new(Cps::App(
                             Value::from(call_transformer),
                             vec![
-                                Value::from(RuntimeValue::from(self.captured_env.clone())),                         
+                                Value::from(RuntimeValue::from(self.captured_env.clone())),
                                 Value::from(RuntimeValue::from(self.transformer.clone())),
                                 Value::from(to_expand),
                             ]
                             .into_iter()
-                                // .chain(
+                            // .chain(
                             .chain(once(Value::from(k1)))
                             .collect(),
                             None,

--- a/src/cps/compile.rs
+++ b/src/cps/compile.rs
@@ -149,12 +149,18 @@ impl Compile for Var {
     fn compile(&self, mut meta_cont: Box<dyn FnMut(Value) -> Cps + '_>) -> Cps {
         let k1 = Local::gensym();
         let k2 = Local::gensym();
+        let read_into = Local::gensym();
         Cps::Closure {
             args: ClosureArgs::new(vec![k2], false, None),
-            body: Box::new(Cps::App(
-                Value::from(k2),
+            body: Box::new(Cps::PrimOp(
+                PrimOp::ReadCell,
                 vec![Value::from(self.clone())],
-                None,
+                read_into,
+                Box::new(Cps::App(
+                    Value::from(k2),
+                    vec![Value::from(read_into)],
+                    None,
+                )),
             )),
             val: k1,
             cexp: Box::new(meta_cont(Value::from(k1))),

--- a/src/cps/compile.rs
+++ b/src/cps/compile.rs
@@ -791,19 +791,17 @@ impl Compile for SyntaxCase {
                     args: ClosureArgs::new(vec![to_expand], false, None),
                     body: Box::new(Cps::PrimOp(
                         PrimOp::GetCallTransformerFn,
-                        vec![],
+                        self.captured_env.captured.iter().copied().map(Value::from).collect(),
                         call_transformer,
                         Box::new(Cps::App(
                             Value::from(call_transformer),
                             vec![
-                                todo!(),
-                                todo!(),
-                                // Value::from(RuntimeValue::CapturedEnv(self.captured_env.clone())),
-                                // Value::from(RuntimeValue::Transformer(self.transformer.clone())),
+                                Value::from(RuntimeValue::from(self.captured_env.clone())),                         
+                                Value::from(RuntimeValue::from(self.transformer.clone())),
                                 Value::from(to_expand),
                             ]
                             .into_iter()
-                            .chain(self.captured_env.captured.iter().copied().map(Value::from))
+                                // .chain(
                             .chain(once(Value::from(k1)))
                             .collect(),
                             None,

--- a/src/cps/mod.rs
+++ b/src/cps/mod.rs
@@ -93,9 +93,12 @@ pub enum PrimOp {
     /// Set cell value:
     Set,
 
-    /// Read the cell and clone the underlying value:
-    Clone,
-
+    // Cell operations:
+    /// Allocate a cell, returning a Gc<Value>.
+    AllocCell,
+    /// Read a cell (a Gc<Value>), returning a Value.
+    ReadCell,
+    
     // List operators:
     Cons,
 

--- a/src/cps/mod.rs
+++ b/src/cps/mod.rs
@@ -16,7 +16,8 @@ use crate::{
     ast::Literal,
     env::{Global, Local, Var},
     gc::Trace,
-    runtime::{CallSiteId, FunctionDebugInfoId}, value::Value as RuntimeValue,
+    runtime::{CallSiteId, FunctionDebugInfoId},
+    value::Value as RuntimeValue,
 };
 use std::{
     collections::{HashMap, HashSet},

--- a/src/cps/mod.rs
+++ b/src/cps/mod.rs
@@ -13,7 +13,6 @@
 //!   directly to machine code.
 
 use crate::{
-    ast::Literal,
     env::{Global, Local, Var},
     gc::Trace,
     runtime::{CallSiteId, FunctionDebugInfoId},

--- a/src/cps/mod.rs
+++ b/src/cps/mod.rs
@@ -34,7 +34,7 @@ pub use compile::Compile;
 #[derive(Clone, PartialEq)]
 pub enum Value {
     Var(Var),
-    Value(RuntimeValue),
+    Const(RuntimeValue),
 }
 
 impl Value {
@@ -57,7 +57,7 @@ impl Value {
 
 impl From<RuntimeValue> for Value {
     fn from(v: RuntimeValue) -> Self {
-        Self::Value(v)
+        Self::Const(v)
     }
 }
 
@@ -83,7 +83,7 @@ impl fmt::Debug for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Var(var) => var.fmt(f),
-            Self::Value(val) => val.fmt(f),
+            Self::Const(val) => val.fmt(f),
         }
     }
 }
@@ -96,9 +96,7 @@ pub enum PrimOp {
     // Cell operations:
     /// Allocate a cell, returning a Gc<Value>.
     AllocCell,
-    // /// Read a cell (a Gc<Value>), returning a Value.
-    // ReadCell,
-    
+
     // List operators:
     Cons,
 
@@ -167,11 +165,6 @@ impl ClosureArgs {
 
 #[derive(derive_more::Debug, Clone)]
 pub enum Cps {
-    /*
-    /// Generates a cell of type `*const GcInner<Value>`
-    AllocCell(Local, Box<Cps>),
-    */
-
     /// Call to a primitive operator.
     PrimOp(PrimOp, Vec<Value>, Local, Box<Cps>),
 

--- a/src/cps/mod.rs
+++ b/src/cps/mod.rs
@@ -83,8 +83,7 @@ impl fmt::Debug for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Var(var) => var.fmt(f),
-            // Self::Value(val) => val.fmt(f),
-            _ => todo!()
+            Self::Value(val) => val.fmt(f),
         }
     }
 }
@@ -97,8 +96,8 @@ pub enum PrimOp {
     // Cell operations:
     /// Allocate a cell, returning a Gc<Value>.
     AllocCell,
-    /// Read a cell (a Gc<Value>), returning a Value.
-    ReadCell,
+    // /// Read a cell (a Gc<Value>), returning a Value.
+    // ReadCell,
     
     // List operators:
     Cons,

--- a/src/cps/reduce.rs
+++ b/src/cps/reduce.rs
@@ -24,12 +24,6 @@ impl Cps {
         uses_cache: &mut HashMap<Local, HashMap<Local, usize>>,
     ) -> Self {
         match self {
-            /*
-            Cps::AllocCell(cell, cexp) => Cps::AllocCell(
-                cell,
-                Box::new(cexp.beta_reduction(single_use_functions, uses_cache)),
-            ),
-            */
             Cps::PrimOp(prim_op, values, result, cexp) => Cps::PrimOp(
                 prim_op,
                 values,

--- a/src/cps/reduce.rs
+++ b/src/cps/reduce.rs
@@ -71,7 +71,7 @@ impl Cps {
                         body: Box::new(body),
                         val,
                         cexp: Box::new(cexp),
-                        debug
+                        debug,
                     }
                 }
             }

--- a/src/cps/reduce.rs
+++ b/src/cps/reduce.rs
@@ -46,7 +46,7 @@ impl Cps {
                 body,
                 val,
                 cexp,
-                debug: debug_info_id,
+                debug,
             } => {
                 let body = body.beta_reduction(single_use_functions, uses_cache);
                 let cexp = cexp.beta_reduction(single_use_functions, uses_cache);
@@ -54,7 +54,8 @@ impl Cps {
                 let is_recursive = body.uses(uses_cache).contains_key(&val);
                 let uses = cexp.uses(uses_cache).get(&val).copied().unwrap_or(0);
 
-                if !is_recursive && uses == 1 {
+                // TODO: When we get more list primops, allow for variadic substitutions
+                if !args.variadic && !is_recursive && uses == 1 {
                     single_use_functions.insert(val, (args, body));
                     let cexp = cexp.beta_reduction(single_use_functions, uses_cache);
                     if let Some((args, body)) = single_use_functions.remove(&val) {
@@ -64,7 +65,7 @@ impl Cps {
                             body: Box::new(body),
                             val,
                             cexp: Box::new(cexp),
-                            debug: debug_info_id,
+                            debug,
                         }
                     } else {
                         cexp
@@ -76,7 +77,7 @@ impl Cps {
                         body: Box::new(body),
                         val,
                         cexp: Box::new(cexp),
-                        debug: debug_info_id,
+                        debug
                     }
                 }
             }

--- a/src/cps/reduce.rs
+++ b/src/cps/reduce.rs
@@ -24,10 +24,12 @@ impl Cps {
         uses_cache: &mut HashMap<Local, HashMap<Local, usize>>,
     ) -> Self {
         match self {
+            /*
             Cps::AllocCell(cell, cexp) => Cps::AllocCell(
                 cell,
                 Box::new(cexp.beta_reduction(single_use_functions, uses_cache)),
             ),
+            */
             Cps::PrimOp(prim_op, values, result, cexp) => Cps::PrimOp(
                 prim_op,
                 values,

--- a/src/env.rs
+++ b/src/env.rs
@@ -404,6 +404,7 @@ impl Macro {
 }
 
 #[derive(Clone, Trace)]
+#[repr(align(16))]
 pub struct CapturedEnv {
     pub env: Environment,
     pub captured: Vec<Local>,

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,5 +1,8 @@
 use std::{
-    collections::{hash_map::Entry, HashMap}, fmt, hash::{Hash, Hasher}, sync::atomic::{AtomicUsize, Ordering}
+    collections::{hash_map::Entry, HashMap},
+    fmt,
+    hash::{Hash, Hasher},
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
 use crate::{
@@ -77,9 +80,7 @@ impl Top {
     pub fn fetch_var(&mut self, name: &Identifier) -> Option<Global> {
         self.vars
             .get(name)
-            .map(|val| 
-                Global::new(name.clone(), val.clone())
-            )
+            .map(|val| Global::new(name.clone(), val.clone()))
     }
 
     pub fn fetch_macro(&self, name: &Identifier) -> Option<Macro> {

--- a/src/env.rs
+++ b/src/env.rs
@@ -77,7 +77,9 @@ impl Top {
     pub fn fetch_var(&mut self, name: &Identifier) -> Option<Global> {
         self.vars
             .get(name)
-            .map(|val| Global::new(name.clone(), val.clone()))
+            .map(|val| 
+                Global::new(name.clone(), val.clone())
+            )
     }
 
     pub fn fetch_macro(&self, name: &Identifier) -> Option<Macro> {

--- a/src/env.rs
+++ b/src/env.rs
@@ -91,7 +91,7 @@ impl Top {
 pub struct LexicalContour {
     up: Environment,
     vars: HashMap<Identifier, Local>,
-    macros: HashMap<Identifier, Closure>,
+    macros: HashMap<Identifier, Gc<Closure>>,
 }
 
 impl LexicalContour {
@@ -111,7 +111,7 @@ impl LexicalContour {
         local
     }
 
-    pub fn def_macro(&mut self, name: Identifier, closure: Closure) {
+    pub fn def_macro(&mut self, name: Identifier, closure: Gc<Closure>) {
         self.macros.insert(name, closure);
     }
 
@@ -170,7 +170,7 @@ impl MacroExpansion {
         self.up.def_var(name)
     }
 
-    pub fn def_macro(&self, name: Identifier, closure: Closure) {
+    pub fn def_macro(&self, name: Identifier, closure: Gc<Closure>) {
         self.up.def_macro(name, closure);
     }
 
@@ -257,7 +257,7 @@ impl Environment {
         }
     }
 
-    pub fn def_macro(&self, name: Identifier, val: Closure) {
+    pub fn def_macro(&self, name: Identifier, val: Gc<Closure>) {
         match self {
             Self::Top(top) => top.write().def_macro(name, Macro::new(self.clone(), val)),
             Self::LexicalContour(lex) => lex.write().def_macro(name, val),
@@ -410,11 +410,11 @@ impl fmt::Debug for Var {
 #[derive(Clone, Trace)]
 pub struct Macro {
     pub source_env: Environment,
-    pub transformer: Closure,
+    pub transformer: Gc<Closure>,
 }
 
 impl Macro {
-    pub fn new(source_env: Environment, transformer: Closure) -> Self {
+    pub fn new(source_env: Environment, transformer: Gc<Closure>) -> Self {
         Self {
             source_env,
             transformer,

--- a/src/env.rs
+++ b/src/env.rs
@@ -251,7 +251,7 @@ impl Environment {
 
     pub fn def_var(&self, name: Identifier) -> Var {
         match self {
-            Self::Top(top) => Var::Global(top.write().def_var(name, Value::Undefined)),
+            Self::Top(top) => Var::Global(top.write().def_var(name, Value::undefined())),
             Self::LexicalContour(lex) => Var::Local(lex.write().def_var(name)),
             Self::MacroExpansion(me) => me.read().def_var(name),
         }

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,7 +1,5 @@
 use std::{
-    collections::{hash_map::Entry, HashMap},
-    fmt,
-    sync::atomic::{AtomicUsize, Ordering},
+    collections::{hash_map::Entry, HashMap}, fmt, hash::{Hash, Hasher}, sync::atomic::{AtomicUsize, Ordering}
 };
 
 use crate::{
@@ -347,7 +345,8 @@ impl fmt::Debug for Local {
     }
 }
 
-#[derive(Clone, Trace, Hash, PartialEq, Eq)]
+// TODO: Do we need to make this pointer eq?
+#[derive(Clone, Trace)]
 pub struct Global {
     name: Identifier,
     val: Gc<Value>,
@@ -372,6 +371,24 @@ impl fmt::Debug for Global {
         write!(f, "${}", self.name.name)
     }
 }
+
+impl PartialEq for Global {
+    fn eq(&self, rhs: &Self) -> bool {
+        self.name == rhs.name && Gc::ptr_eq(&self.val, &rhs.val)
+    }
+}
+
+impl Hash for Global {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.name.hash(state);
+        Gc::as_ptr(&self.val).hash(state);
+    }
+}
+
+impl Eq for Global {}
 
 #[derive(Clone, Trace, Hash, PartialEq, Eq)]
 pub enum Var {

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -172,7 +172,7 @@ impl fmt::Display for Frame {
 /// any condition that is raised - and the previous handler.
 // TODO: We need to determine include the dynamic extent with the exception handler
 // so that we can call the proper winders.
-#[derive(Clone, Trace)]
+#[derive(Clone, Debug, Trace)]
 pub struct ExceptionHandler {
     /// The previously installed handler. If the previously installed handler is
     /// None, we return the condition as an Error.

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -196,6 +196,7 @@ pub fn with_exception_handler<'a>(
     args: &'a [Value],
     _rest_args: &'a [Value],
     cont: &'a Value,
+    env: &'a [Gc<Value>],
     exception_handler: &'a Option<Gc<ExceptionHandler>>,
     dynamic_wind: &'a DynamicWind,
 ) -> BoxFuture<'a, Result<Application, Value>> {
@@ -251,6 +252,7 @@ pub fn raise<'a>(
     args: &'a [Value],
     _rest_args: &'a [Value],
     cont: &'a Value,
+    _env: &'a [Gc<Value>],
     exception_handler: &'a Option<Gc<ExceptionHandler>>,
     dynamic_wind: &'a DynamicWind,
 ) -> BoxFuture<'a, Result<Application, Value>> {
@@ -350,6 +352,7 @@ pub fn raise_continuable<'a>(
     args: &'a [Value],
     _rest_args: &'a [Value],
     cont: &'a Value,
+    _env: &'a [Gc<Value>],
     exception_handler: &'a Option<Gc<ExceptionHandler>>,
     dynamic_wind: &'a DynamicWind,
 ) -> BoxFuture<'a, Result<Application, Value>> {

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -27,7 +27,6 @@ impl Exception {
 // TODO: This shouldn't be the display impl for Exception, I don' t think.
 impl fmt::Display for Exception {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        /*
         const MAX_BACKTRACE_LEN: usize = 20;
         writeln!(f, "Uncaught exception: {}", self.obj)?;
         if !self.backtrace.is_empty() {
@@ -41,8 +40,6 @@ impl fmt::Display for Exception {
             }
         }
         Ok(())
-         */
-        todo!()
     }
 }
 

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -15,11 +15,11 @@ use std::{error::Error as StdError, fmt, ops::Range};
 #[derive(Debug, Clone, Trace)]
 pub struct Exception {
     pub backtrace: Vec<Frame>,
-    pub obj: Gc<Value>,
+    pub obj: Value,
 }
 
 impl Exception {
-    pub fn new(backtrace: Vec<Frame>, obj: Gc<Value>) -> Self {
+    pub fn new(backtrace: Vec<Frame>, obj: Value) -> Self {
         Self { backtrace, obj }
     }
 }
@@ -27,6 +27,7 @@ impl Exception {
 // TODO: This shouldn't be the display impl for Exception, I don' t think.
 impl fmt::Display for Exception {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        /*
         const MAX_BACKTRACE_LEN: usize = 20;
         writeln!(f, "Uncaught exception: {}", self.obj)?;
         if !self.backtrace.is_empty() {
@@ -40,6 +41,8 @@ impl fmt::Display for Exception {
             }
         }
         Ok(())
+         */
+        todo!()
     }
 }
 
@@ -57,11 +60,11 @@ pub enum Condition {
     NonContinuable,
     ImplementationRestriction,
     Lexical,
-    Syntax { form: Gc<Value>, subform: Gc<Value> },
+    Syntax { form: Value, subform: Value },
     Undefined,
-    Irritants { irritants: Gc<Value> },
-    Who { who: Gc<Value> },
-    CompoundCondition { simple_conditions: Vec<Gc<Value>> },
+    Irritants { irritants: Value },
+    Who { who: Value },
+    CompoundCondition { simple_conditions: Vec<Value> },
 }
 
 impl Condition {
@@ -72,8 +75,8 @@ impl Condition {
     pub fn syntax_error() -> Self {
         // TODO: Expand on these
         Self::Syntax {
-            form: Gc::new(Value::Null),
-            subform: Gc::new(Value::Boolean(false)),
+            form: Value::null(),
+            subform: Value::from(false),
         }
     }
 
@@ -188,17 +191,18 @@ impl ExceptionHandler {
     /// Exception handler must point to a valid Gc'd object.
     pub unsafe fn from_ptr(ptr: *mut GcInner<Self>) -> Option<Gc<Self>> {
         use std::ops::Not;
-        ptr.is_null().not().then(|| unsafe { Gc::from_ptr(ptr) })
+        ptr.is_null().not().then(|| unsafe { Gc::from_raw(ptr) })
     }
 }
 
 pub fn with_exception_handler<'a>(
-    args: &'a [Gc<Value>],
-    _rest_args: &'a [Gc<Value>],
-    cont: &'a Gc<Value>,
+    args: &'a [Value],
+    _rest_args: &'a [Value],
+    cont: &'a Value,
     exception_handler: &'a Option<Gc<ExceptionHandler>>,
     dynamic_wind: &'a DynamicWind,
-) -> BoxFuture<'a, Result<Application, Gc<Value>>> {
+) -> BoxFuture<'a, Result<Application, Value>> {
+    /*
     Box::pin(async move {
         let [handler, thunk] = args else {
             return Err(Condition::wrong_num_of_args(2, args.len()).into());
@@ -224,6 +228,8 @@ pub fn with_exception_handler<'a>(
             None,
         ))
     })
+     */
+    todo!()
 }
 
 inventory::submit! {
@@ -245,12 +251,13 @@ inventory::submit! {
 
 /// Raises a non-continuable exception to the current exception handler.
 pub fn raise<'a>(
-    args: &'a [Gc<Value>],
-    _rest_args: &'a [Gc<Value>],
-    cont: &'a Gc<Value>,
+    args: &'a [Value],
+    _rest_args: &'a [Value],
+    cont: &'a Value,
     exception_handler: &'a Option<Gc<ExceptionHandler>>,
     dynamic_wind: &'a DynamicWind,
-) -> BoxFuture<'a, Result<Application, Gc<Value>>> {
+) -> BoxFuture<'a, Result<Application, Value>> {
+    /*
     Box::pin(async move {
         let [condition] = args else {
             return Err(Condition::wrong_num_of_args(1, args.len()).into());
@@ -282,7 +289,9 @@ pub fn raise<'a>(
             dynamic_wind.clone(),
             None,
         ))
-    })
+})
+     */
+    todo!()
 }
 
 inventory::submit! {
@@ -306,17 +315,18 @@ unsafe extern "C" fn reraise_exception(
     runtime: *mut GcInner<Runtime>,
     env: *const *mut GcInner<Value>,
     _globals: *const *mut GcInner<Value>,
-    _args: *const *mut GcInner<Value>,
+    _args: *const i64,
     exception_handler: *mut GcInner<ExceptionHandler>,
     dynamic_wind: *const DynamicWind,
 ) -> *mut Result<Application, Condition> {
-    let runtime = Gc::from_ptr(runtime);
+    /*
+    let runtime = Gc::from_raw(runtime);
 
     // env[0] is the exception
-    let exception = Gc::from_ptr(env.read());
+    let exception = Gc::from_raw(env.read());
 
     // env[1] is the continuation
-    let cont = Gc::from_ptr(env.add(1).read());
+    let cont = Gc::from_raw(env.add(1).read());
 
     Box::into_raw(Box::new(Ok(Application::new(
         Closure::new(
@@ -332,18 +342,21 @@ unsafe extern "C" fn reraise_exception(
         ExceptionHandler::from_ptr(exception_handler),
         dynamic_wind.as_ref().unwrap().clone(),
         None,
-    ))))
+))))
+     */
+    todo!()
 }
 
 /// Raises an exception to the current exception handler and coninues with the
 /// value returned by the handler.
 pub fn raise_continuable<'a>(
-    args: &'a [Gc<Value>],
-    _rest_args: &'a [Gc<Value>],
-    cont: &'a Gc<Value>,
+    args: &'a [Value],
+    _rest_args: &'a [Value],
+    cont: &'a Value,
     exception_handler: &'a Option<Gc<ExceptionHandler>>,
     dynamic_wind: &'a DynamicWind,
-) -> BoxFuture<'a, Result<Application, Gc<Value>>> {
+) -> BoxFuture<'a, Result<Application, Value>> {
+    /*
     Box::pin(async move {
         let [condition] = args else {
             return Err(Condition::wrong_num_of_args(1, args.len()).into());
@@ -363,6 +376,8 @@ pub fn raise_continuable<'a>(
             None,
         ))
     })
+     */
+    todo!()
 }
 
 inventory::submit! {

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -137,7 +137,8 @@ macro_rules! impl_into_condition_for {
         }
     };
 }
-impl_into_condition_for!(crate::num::ArithmeticError);
+
+impl_into_condition_for!(Box<crate::num::ArithmeticError>);
 impl_into_condition_for!(crate::num::NumberToUsizeError);
 impl_into_condition_for!(std::num::TryFromIntError);
 

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -406,7 +406,6 @@ pub fn call_transformer<'a>(
     exception_handler: &'a Option<Gc<ExceptionHandler>>,
     dynamic_wind: &'a DynamicWind,
 ) -> BoxFuture<'a, Result<Application, Value>> {
-    /*
     Box::pin(async move {
         let [captured_env, trans, arg] = args else {
             panic!("wrong args");
@@ -415,12 +414,9 @@ pub fn call_transformer<'a>(
         // Fetch a runtime from the continuation. It doesn't really matter
         // _which_ runtime we use, in fact we could create a new one, but it
         // behooves us to use one that already exists.
-        let cont = {
-            let cont = cont.read();
-            let cont: &Closure = cont.as_ref().try_into()?;
-            cont.clone()
-        };
+        let cont: Gc<Closure> = cont.clone().try_into()?;
 
+        /*
         let expanded = {
             let trans_read = trans.read();
             let trans: &Transformer = trans_read.as_ref().try_into().unwrap();
@@ -430,13 +426,17 @@ pub fn call_transformer<'a>(
             // Expand the argument:
             trans.expand(&arg).ok_or_else(Condition::syntax_error)?
         };
+        */
 
+        /*
         let captured_env = {
             let captured_env_read = captured_env.read();
             let captured_env: &CapturedEnv = captured_env_read.as_ref().try_into().unwrap();
             captured_env.clone()
         };
+        */
 
+        /*
         let mut collected_env = IndexMap::new();
         for (i, local) in captured_env.captured.into_iter().enumerate() {
             collected_env.insert(local, env[i].clone());
@@ -462,7 +462,7 @@ pub fn call_transformer<'a>(
         );
 
         Ok(application)
+         */
+        Ok(todo!())
     })
-     */
-    todo!()
 }

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -400,12 +400,13 @@ pub async fn make_variable_transformer(
  */
 
 pub fn call_transformer<'a>(
-    args: &'a [Gc<Value>],
-    env: &'a [Gc<Value>],
-    cont: &'a Gc<Value>,
+    args: &'a [Value],
+    env: &'a [Value],
+    cont: &'a Value,
     exception_handler: &'a Option<Gc<ExceptionHandler>>,
     dynamic_wind: &'a DynamicWind,
-) -> BoxFuture<'a, Result<Application, Gc<Value>>> {
+) -> BoxFuture<'a, Result<Application, Value>> {
+    /*
     Box::pin(async move {
         let [captured_env, trans, arg] = args else {
             panic!("wrong args");
@@ -462,4 +463,6 @@ pub fn call_transformer<'a>(
 
         Ok(application)
     })
+     */
+    todo!()
 }

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -1,12 +1,11 @@
 use crate::{
     ast::{Expression, Literal},
     cps::Compile,
-    env::CapturedEnv,
     exception::{Condition, ExceptionHandler},
     gc::{Gc, Trace},
     proc::{Application, Closure, DynamicWind},
     syntax::{Identifier, Span, Syntax},
-    value::Value,
+    value::{OtherData, Value},
 };
 use futures::future::BoxFuture;
 use indexmap::IndexMap;
@@ -401,59 +400,71 @@ pub async fn make_variable_transformer(
 
 pub fn call_transformer<'a>(
     args: &'a [Value],
-    env: &'a [Value],
+    _rest_args: &'a [Value],
     cont: &'a Value,
+    env: &'a [Gc<Value>],
     exception_handler: &'a Option<Gc<ExceptionHandler>>,
     dynamic_wind: &'a DynamicWind,
 ) -> BoxFuture<'a, Result<Application, Value>> {
     Box::pin(async move {
-        let [captured_env, trans, arg] = args else {
+        let [captured_env, transformer, arg] = args else {
             panic!("wrong args");
         };
+
+        let cont: Gc<Closure> = cont.clone().try_into()?;
 
         // Fetch a runtime from the continuation. It doesn't really matter
         // _which_ runtime we use, in fact we could create a new one, but it
         // behooves us to use one that already exists.
-        let cont: Gc<Closure> = cont.clone().try_into()?;
-
-        /*
-        let expanded = {
-            let trans_read = trans.read();
-            let trans: &Transformer = trans_read.as_ref().try_into().unwrap();
-
-            let arg = Syntax::from_datum(&BTreeSet::default(), arg);
-
-            // Expand the argument:
-            trans.expand(&arg).ok_or_else(Condition::syntax_error)?
+        let runtime = {
+            let cont_read = cont.read();
+            cont_read.runtime.clone()
         };
-        */
 
-        /*
         let captured_env = {
+            let captured_env: Gc<OtherData> = captured_env.clone().try_into()?;
             let captured_env_read = captured_env.read();
-            let captured_env: &CapturedEnv = captured_env_read.as_ref().try_into().unwrap();
-            captured_env.clone()
+            let OtherData::CapturedEnv(env) = captured_env_read.as_ref() else {
+                unreachable!()
+            };
+            env.clone()
         };
-        */
 
-        /*
+        let transformer = {
+            let transformer: Gc<OtherData> = transformer.clone().try_into()?;
+            let transformer_read = transformer.read();
+            let OtherData::Transformer(trans) = transformer_read.as_ref() else {
+                unreachable!()
+            };
+            trans.clone()
+        };
+
+        // Expand the input:
+
+        let syn = Syntax::from_datum(&BTreeSet::default(), arg.clone());
+        let expanded = transformer
+            .expand(&syn)
+            .ok_or_else(Condition::syntax_error)?;
+
+        // Collect the environment:
+
         let mut collected_env = IndexMap::new();
         for (i, local) in captured_env.captured.into_iter().enumerate() {
             collected_env.insert(local, env[i].clone());
         }
 
-        // Parse the expression in the captured environment:
-        let parsed = Expression::parse(&cont.runtime, expanded, &captured_env.env)
+        // Parse and compile the expanded input in the captured environment:
+        // TODO: Get rid of these unwraps
+        let parsed = Expression::parse(&runtime, expanded, &captured_env.env)
             .await
             .unwrap();
         let cps_expr = parsed.compile_top_level();
-        let compiled = cont
-            .runtime
+        let compiled = runtime
             .compile_expr_with_env(cps_expr, collected_env)
             .await
             .unwrap();
         let transformer_result = compiled.call(&[]).await?;
-        let application = Application::new(
+        let app = Application::new(
             cont,
             transformer_result,
             exception_handler.clone(),
@@ -461,8 +472,6 @@ pub fn call_transformer<'a>(
             None,
         );
 
-        Ok(application)
-         */
-        Ok(todo!())
+        Ok(app)
     })
 }

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -13,6 +13,7 @@ use indexmap::IndexMap;
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 #[derive(Clone, Trace, Debug)]
+#[repr(align(16))]
 pub struct Transformer {
     pub rules: Vec<SyntaxRule>,
     pub is_variable_transformer: bool,

--- a/src/gc/collection.rs
+++ b/src/gc/collection.rs
@@ -13,7 +13,7 @@ use tokio::{
     task::JoinHandle,
 };
 
-use super::{Color, GcInner, OpaqueGc, OpaqueGcPtr, Trace};
+use super::{Color, OpaqueGc, OpaqueGcPtr, Trace};
 
 #[derive(Copy, Clone, Debug)]
 pub struct Mutation {

--- a/src/gc/collection.rs
+++ b/src/gc/collection.rs
@@ -57,22 +57,22 @@ impl Default for MutationBuffer {
 
 static MUTATION_BUFFER: OnceLock<MutationBuffer> = OnceLock::new();
 
-pub(super) fn inc_rc<T: Trace>(gc: NonNull<GcInner<T>>) {
+pub(super) fn inc_rc(gc: NonNull<OpaqueGc>) {
     // Disregard any send errors. If the receiver was dropped then the process
     // is exiting and we don't care if we leak.
     let _ = MUTATION_BUFFER
         .get_or_init(MutationBuffer::default)
         .mutation_buffer_tx
-        .send(Mutation::new(MutationKind::Inc, gc as NonNull<OpaqueGc>));
+        .send(Mutation::new(MutationKind::Inc, gc));
 }
 
-pub(super) fn dec_rc<T: Trace>(gc: NonNull<GcInner<T>>) {
+pub(super) fn dec_rc(gc: NonNull<OpaqueGc>) {
     // Disregard any send errors. If the receiver was dropped then the process
     // is exiting and we don't care if we leak.
     let _ = MUTATION_BUFFER
         .get_or_init(MutationBuffer::default)
         .mutation_buffer_tx
-        .send(Mutation::new(MutationKind::Dec, gc as NonNull<OpaqueGc>));
+        .send(Mutation::new(MutationKind::Dec, gc));
 }
 
 static COLLECTOR_TASK: OnceLock<JoinHandle<()>> = OnceLock::new();

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -106,7 +106,7 @@ impl<T: Trace> Gc<T> {
         dec_rc(ptr);
     }
 
-    /// Create a new Gc from the raw pointer. Does not decrement the reference
+    /// Create a new Gc from the raw pointer. Does not increment the reference
     /// count.
     pub(crate) unsafe fn from_raw(ptr: *mut GcInner<T>) -> Self {
         let ptr = NonNull::new(ptr).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub mod num;
 pub mod parse;
 pub mod proc;
 pub mod records;
-pub mod syntax;
 pub mod strings;
+pub mod syntax;
 pub mod value;
 pub mod vectors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,5 +17,6 @@ pub mod parse;
 pub mod proc;
 pub mod records;
 pub mod syntax;
+pub mod strings;
 pub mod value;
 pub mod vectors;

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -1,11 +1,12 @@
-use crate::{exception::Condition, gc::{Trace, Gc}, num::Number, registry::bridge, value::{Value2, Value}};
+use crate::{exception::Condition, gc::{Trace, Gc}, num::Number, registry::bridge, value::Value};
 use std::fmt;
 
 /// A pair of scheme values. Has a head and tail.
 #[derive(Trace)]
-pub struct Pair(Gc<Value2>, Gc<Value2>);
+pub struct Pair(Value, Value);
 
-pub fn display_list(car: &Gc<Value>, cdr: &Gc<Value>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+pub fn display_list(car: &Value, cdr: &Value, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    /*
     // TODO(map): If the list is circular, DO NOT print infinitely!
     match &*cdr.read() {
         Value::Pair(_, _) | Value::Null => (),
@@ -37,9 +38,12 @@ pub fn display_list(car: &Gc<Value>, cdr: &Gc<Value>, f: &mut fmt::Formatter<'_>
     }
 
     write!(f, ")")
+     */
+    todo!()
 }
 
-pub fn debug_list(car: &Gc<Value>, cdr: &Gc<Value>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+pub fn debug_list(car: &Value, cdr: &Value, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    /*
     // TODO(map): If the list is circular, DO NOT print infinitely!
     match &*cdr.read() {
         Value::Pair(_, _) | Value::Null => (),
@@ -71,16 +75,22 @@ pub fn debug_list(car: &Gc<Value>, cdr: &Gc<Value>, f: &mut fmt::Formatter<'_>) 
     }
 
     write!(f, ")")
+     */
+    todo!()
 }
 
-pub fn slice_to_list(items: &[Gc<Value>]) -> Value {
+pub fn slice_to_list(items: &[Value]) -> Value {
+    /*
     match items {
-        [] => Value::Null,
-        [head, tail @ ..] => Value::Pair(head.clone(), Gc::new(slice_to_list(tail))),
+        [] => Value::null(),
+        [head, tail @ ..] => Value::new((head.clone(), slice_to_list(tail))),
     }
+     */
+    todo!()
 }
 
-pub fn list_to_vec(curr: &Gc<Value>, out: &mut Vec<Gc<Value>>) {
+pub fn list_to_vec(curr: &Value, out: &mut Vec<Value>) {
+    /*
     let val = curr.read();
     match &*val {
         Value::Pair(a, b) => {
@@ -90,9 +100,11 @@ pub fn list_to_vec(curr: &Gc<Value>, out: &mut Vec<Gc<Value>>) {
         Value::Null => (),
         _ => out.push(curr.clone()),
     }
+     */
 }
 
-pub fn list_to_vec_with_null(curr: &Gc<Value>, out: &mut Vec<Gc<Value>>) {
+pub fn list_to_vec_with_null(curr: &Value, out: &mut Vec<Value>) {
+    /*
     let val = curr.read();
     match &*val {
         Value::Pair(a, b) => {
@@ -101,8 +113,11 @@ pub fn list_to_vec_with_null(curr: &Gc<Value>, out: &mut Vec<Gc<Value>>) {
         }
         _ => out.push(curr.clone()),
     }
+     */
+    todo!()
 }
 
+/*
 #[bridge(name = "list", lib = "(base)")]
 pub async fn list(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
     // Construct the list in reverse
@@ -184,3 +199,4 @@ pub async fn list_to_vector(list: &Gc<Value>) -> Result<Vec<Gc<Value>>, Conditio
         vec.into_iter().map(|i| i.read().as_ref().clone()).collect(),
     ))])
 }
+*/

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -1,5 +1,9 @@
-use crate::{exception::Condition, gc::Gc, num::Number, registry::bridge, value::Value};
+use crate::{exception::Condition, gc::{Trace, Gc}, num::Number, registry::bridge, value::{Value2, Value}};
 use std::fmt;
+
+/// A pair of scheme values. Has a head and tail.
+#[derive(Trace)]
+pub struct Pair(Gc<Value2>, Gc<Value2>);
 
 pub fn display_list(car: &Gc<Value>, cdr: &Gc<Value>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     // TODO(map): If the list is circular, DO NOT print infinitely!

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -197,14 +197,10 @@ pub async fn length(arg: &Value) -> Result<Vec<Value>, Condition> {
     Ok(vec![Value::from(Number::from(length))])
 }
 
-/*
 #[bridge(name = "list->vector", lib = "(base)")]
-pub async fn list_to_vector(list: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
+pub async fn list_to_vector(list: &Value) -> Result<Vec<Value>, Condition> {
     let mut vec = Vec::new();
     list_to_vec(list, &mut vec);
 
-    Ok(vec![Gc::new(Value::Vector(
-        vec.into_iter().map(|i| i.read().as_ref().clone()).collect(),
-    ))])
+    Ok(vec![Value::from(vec)])
 }
-*/

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -1,15 +1,27 @@
-use crate::{exception::Condition, gc::{Trace, Gc}, num::Number, registry::bridge, value::Value};
+use crate::{exception::Condition, gc::{Trace, Gc}, num::Number, registry::bridge, value::{UnpackedValue, Value}};
 use std::fmt;
 
 /// A pair of scheme values. Has a head and tail.
 #[derive(Trace)]
-pub struct Pair(Value, Value);
+pub struct Pair(pub Value, pub Value);
+
+impl Pair {
+    pub fn new(car: Value, cdr: Value) -> Self {
+        Self(car, cdr)
+    }
+}
+
+impl PartialEq for Pair {
+    fn eq(&self, rhs: &Self) -> bool {
+        // TODO: Avoid circular lists causing an infinite loop
+        self.0 == rhs.0 && self.1 == rhs.1
+    }
+}
 
 pub fn display_list(car: &Value, cdr: &Value, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    /*
     // TODO(map): If the list is circular, DO NOT print infinitely!
-    match &*cdr.read() {
-        Value::Pair(_, _) | Value::Null => (),
+    match &*cdr.unpacked_ref() {
+        UnpackedValue::Pair(_) | UnpackedValue::Null => (),
         cdr => {
             // This is not a proper list
             return write!(f, "({car} . {cdr})");
@@ -21,13 +33,15 @@ pub fn display_list(car: &Value, cdr: &Value, f: &mut fmt::Formatter<'_>) -> fmt
     let mut stack = vec![cdr.clone()];
 
     while let Some(head) = stack.pop() {
-        match &*head.read() {
-            Value::Null => {
+        match &*head.unpacked_ref() {
+            UnpackedValue::Null => {
                 if !stack.is_empty() {
                     write!(f, " ()")?;
                 }
             }
-            Value::Pair(car, cdr) => {
+            UnpackedValue::Pair(pair) => {
+                let pair_read = pair.read();
+                let Pair(car, cdr) = pair_read.as_ref();
                 write!(f, " {car}")?;
                 stack.push(cdr.clone());
             }
@@ -38,15 +52,12 @@ pub fn display_list(car: &Value, cdr: &Value, f: &mut fmt::Formatter<'_>) -> fmt
     }
 
     write!(f, ")")
-     */
-    todo!()
 }
 
 pub fn debug_list(car: &Value, cdr: &Value, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    /*
     // TODO(map): If the list is circular, DO NOT print infinitely!
-    match &*cdr.read() {
-        Value::Pair(_, _) | Value::Null => (),
+    match &*cdr.unpacked_ref() {
+        UnpackedValue::Pair(_) | UnpackedValue::Null => (),
         cdr => {
             // This is not a proper list
             return write!(f, "({car:?} . {cdr:?})");
@@ -58,13 +69,15 @@ pub fn debug_list(car: &Value, cdr: &Value, f: &mut fmt::Formatter<'_>) -> fmt::
     let mut stack = vec![cdr.clone()];
 
     while let Some(head) = stack.pop() {
-        match &*head.read() {
-            Value::Null => {
+        match &*head.unpacked_ref() {
+            UnpackedValue::Null => {
                 if !stack.is_empty() {
                     write!(f, " ()")?;
                 }
             }
-            Value::Pair(car, cdr) => {
+            UnpackedValue::Pair(pair) => {
+                let pair_read = pair.read();
+                let Pair(car, cdr) = pair_read.as_ref();
                 write!(f, " {car:?}")?;
                 stack.push(cdr.clone());
             }
@@ -75,121 +88,112 @@ pub fn debug_list(car: &Value, cdr: &Value, f: &mut fmt::Formatter<'_>) -> fmt::
     }
 
     write!(f, ")")
-     */
-    todo!()
 }
 
 pub fn slice_to_list(items: &[Value]) -> Value {
-    /*
     match items {
         [] => Value::null(),
-        [head, tail @ ..] => Value::new((head.clone(), slice_to_list(tail))),
+        [head, tail @ ..] => Value::from(Gc::new(Pair(head.clone(), slice_to_list(tail)))),
     }
-     */
-    todo!()
 }
 
 pub fn list_to_vec(curr: &Value, out: &mut Vec<Value>) {
-    /*
-    let val = curr.read();
-    match &*val {
-        Value::Pair(a, b) => {
-            out.push(a.clone());
-            list_to_vec(b, out);
+    match &*curr.unpacked_ref() {
+        UnpackedValue::Pair(pair) => {
+            let pair_read = pair.read();
+            let Pair(car, cdr) = pair_read.as_ref();
+            out.push(car.clone());
+            list_to_vec(cdr, out);
         }
-        Value::Null => (),
+        UnpackedValue::Null => (),
         _ => out.push(curr.clone()),
     }
-     */
 }
 
 pub fn list_to_vec_with_null(curr: &Value, out: &mut Vec<Value>) {
-    /*
-    let val = curr.read();
-    match &*val {
-        Value::Pair(a, b) => {
-            out.push(a.clone());
-            list_to_vec_with_null(b, out);
+    match &*curr.unpacked_ref() {
+        UnpackedValue::Pair(pair) => {
+            let pair_read = pair.read();
+            let Pair(car, cdr) = pair_read.as_ref();
+            out.push(car.clone());
+            list_to_vec_with_null(cdr, out);
         }
         _ => out.push(curr.clone()),
     }
-     */
-    todo!()
 }
 
-/*
 #[bridge(name = "list", lib = "(base)")]
-pub async fn list(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
+pub async fn list(args: &[Value]) -> Result<Vec<Value>, Condition> {
     // Construct the list in reverse
-    let mut cdr = Gc::new(Value::Null);
+    let mut cdr = Value::null();
     for arg in args.iter().rev() {
-        cdr = Gc::new(Value::Pair(arg.clone(), cdr.clone()));
+        cdr = Value::from(Gc::new(Pair(arg.clone(), cdr)));
     }
     Ok(vec![cdr])
 }
 
 #[bridge(name = "cons", lib = "(base)")]
-pub async fn cons(car: &Gc<Value>, cdr: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
-    let car = Gc::new(car.read().clone());
-    let cdr = Gc::new(cdr.read().clone());
-    Ok(vec![Gc::new(Value::Pair(car, cdr))])
+pub async fn cons(car: &Value, cdr: &Value) -> Result<Vec<Value>, Condition> {
+    Ok(vec![Value::from(Gc::new(Pair(car.clone(), cdr.clone())))])
 }
+
 
 #[bridge(name = "car", lib = "(base)")]
-pub async fn car(val: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
-    let val = val.read();
-    match &*val {
-        Value::Pair(car, _cdr) => Ok(vec![car.clone()]),
-        _ => Err(Condition::invalid_type("pair", val.type_name())),
-    }
+pub async fn car(val: &Value) -> Result<Vec<Value>, Condition> {
+    let pair: Gc<Pair> = val.clone().try_into()?;
+    let pair_read = pair.read();
+    let Pair(car, _) = pair_read.as_ref();
+    Ok(vec![car.clone()])
 }
 
+
 #[bridge(name = "cdr", lib = "(base)")]
-pub async fn cdr(val: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
-    let val = val.read();
-    match &*val {
-        Value::Pair(_car, cdr) => Ok(vec![cdr.clone()]),
-        _ => Err(Condition::invalid_type("pair", val.type_name())),
-    }
+pub async fn cdr(val: &Value) -> Result<Vec<Value>, Condition> {
+    let pair: Gc<Pair> = val.clone().try_into()?;
+    let pair_read = pair.read();
+    let Pair(_, cdr) = pair_read.as_ref();
+    Ok(vec![cdr.clone()])
 }
 
 #[bridge(name = "set-car!", lib = "(base)")]
-pub async fn set_car(var: &Gc<Value>, val: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
-    let mut var = var.write();
-    match &mut *var {
-        Value::Pair(ref mut car, _cdr) => *car = val.clone(),
-        _ => todo!(),
-    }
-    Ok(vec![Gc::new(Value::Null)])
+pub async fn set_car(var: &Value, val: &Value) -> Result<Vec<Value>, Condition> {
+    let pair: Gc<Pair> = var.clone().try_into()?;
+    let mut pair_write = pair.write();
+    let Pair(ref mut car, _) = pair_write.as_mut();
+    *car = val.clone();
+    Ok(Vec::new())
 }
 
 #[bridge(name = "set-cdr!", lib = "(base)")]
-pub async fn set_cdr(var: &Gc<Value>, val: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
-    let mut var = var.write();
-    match &mut *var {
-        Value::Pair(_car, ref mut cdr) => *cdr = val.clone(),
-        _ => todo!(),
-    }
-    Ok(vec![Gc::new(Value::Null)])
+pub async fn set_cdr(var: &Value, val: &Value) -> Result<Vec<Value>, Condition> {
+    let pair: Gc<Pair> = var.clone().try_into()?;
+    let mut pair_write = pair.write();
+    let Pair(_, ref mut cdr) = pair_write.as_mut();
+    *cdr = val.clone();
+    Ok(Vec::new())
 }
 
 #[bridge(name = "length", lib = "(base)")]
-pub async fn length(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
+pub async fn length(arg: &Value) -> Result<Vec<Value>, Condition> {
     let mut length = 0;
     let mut arg = arg.clone();
     loop {
         arg = {
-            let val = arg.read();
-            match &*val {
-                Value::Pair(_, cdr) => cdr.clone(),
+            match &*arg.unpacked_ref() {
+                UnpackedValue::Pair(pair) => {
+                    let pair_read = pair.read();
+                    let Pair(_, cdr) = pair_read.as_ref();
+                    cdr.clone()
+                }
                 _ => break,
             }
         };
         length += 1;
     }
-    Ok(vec![Gc::new(Value::Number(Number::from(length)))])
+    Ok(vec![Value::from(Number::from(length))])
 }
 
+/*
 #[bridge(name = "list->vector", lib = "(base)")]
 pub async fn list_to_vector(list: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let mut vec = Vec::new();

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -1,4 +1,10 @@
-use crate::{exception::Condition, gc::{Trace, Gc}, num::Number, registry::bridge, value::{UnpackedValue, Value}};
+use crate::{
+    exception::Condition,
+    gc::{Gc, Trace},
+    num::Number,
+    registry::bridge,
+    value::{UnpackedValue, Value},
+};
 use std::fmt;
 
 /// A pair of scheme values. Has a head and tail.
@@ -137,7 +143,6 @@ pub async fn cons(car: &Value, cdr: &Value) -> Result<Vec<Value>, Condition> {
     Ok(vec![Value::from(Gc::new(Pair(car.clone(), cdr.clone())))])
 }
 
-
 #[bridge(name = "car", lib = "(base)")]
 pub async fn car(val: &Value) -> Result<Vec<Value>, Condition> {
     let pair: Gc<Pair> = val.clone().try_into()?;
@@ -145,7 +150,6 @@ pub async fn car(val: &Value) -> Result<Vec<Value>, Condition> {
     let Pair(car, _) = pair_read.as_ref();
     Ok(vec![car.clone()])
 }
-
 
 #[bridge(name = "cdr", lib = "(base)")]
 pub async fn cdr(val: &Value) -> Result<Vec<Value>, Condition> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ async fn compile_and_run_str<'e>(
     runtime: &Gc<Runtime>,
     env: &Environment,
     input: &'e str,
-) -> Result<Vec<Gc<Value>>, EvalError<'e>> {
+) -> Result<Vec<Value>, EvalError<'e>> {
     let sexprs = Syntax::from_str(input, None)?;
     let mut output = Vec::new();
     for sexpr in sexprs {

--- a/src/num.rs
+++ b/src/num.rs
@@ -476,6 +476,7 @@ enum NumberToUsizeErrorKind {
     TooLarge,
 }
 
+/*
 #[bridge(name = "zero?", lib = "(base)")]
 pub async fn zero(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
     let arg = arg.read();
@@ -760,3 +761,4 @@ pub async fn is_complex(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
         Value::Number(Number::Complex(_))
     )))])
 }
+*/

--- a/src/num.rs
+++ b/src/num.rs
@@ -23,6 +23,7 @@ use std::{
 };
 
 #[derive(Clone)]
+#[repr(align(16))]
 pub enum Number {
     FixedInteger(i64),
     BigInteger(Integer),

--- a/src/num.rs
+++ b/src/num.rs
@@ -1,8 +1,8 @@
 use crate::{
     exception::Condition,
-    gc::{Gc, Trace},
+    gc::Trace,
     registry::bridge,
-    value::Value,
+    value::{Value, ValueType},
 };
 use malachite::{
     base::{
@@ -15,11 +15,14 @@ use malachite::{
     rational::{conversion::from_primitive_float::RationalFromPrimitiveFloatError, Rational},
     Integer,
 };
-use num::{complex::Complex64, FromPrimitive, Zero};
+use num::{complex::Complex64, Complex, FromPrimitive, Zero};
+use ordered_float::OrderedFloat;
 use std::{
     cmp::Ordering,
     fmt::{self, Display, Formatter},
+    hash::Hash,
     ops::{Add, Mul, Neg, Sub},
+    sync::Arc,
 };
 
 #[derive(Clone)]
@@ -71,6 +74,7 @@ impl Number {
         matches!(self, Self::Complex(_))
     }
 }
+
 impl TryFrom<&Number> for usize {
     type Error = NumberToUsizeError;
 
@@ -423,6 +427,7 @@ pub enum ArithmeticError {
     Overflow(Operation, Number, Number),
     RationalFromPrimitiveFloat(RationalFromPrimitiveFloatError),
 }
+
 impl Display for ArithmeticError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
@@ -434,6 +439,7 @@ impl Display for ArithmeticError {
         }
     }
 }
+
 impl From<RationalFromPrimitiveFloatError> for ArithmeticError {
     fn from(err: RationalFromPrimitiveFloatError) -> Self {
         Self::RationalFromPrimitiveFloat(err)
@@ -445,11 +451,13 @@ pub struct NumberToUsizeError {
     number: Number,
     kind: NumberToUsizeErrorKind,
 }
+
 impl NumberToUsizeError {
     const fn new(number: Number, kind: NumberToUsizeErrorKind) -> Self {
         Self { number, kind }
     }
 }
+
 impl Display for NumberToUsizeError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self.kind {
@@ -476,117 +484,138 @@ enum NumberToUsizeErrorKind {
     TooLarge,
 }
 
-/*
+pub(crate) struct ReflexiveNumber(pub(crate) Arc<Number>);
+
+impl PartialEq for ReflexiveNumber {
+    fn eq(&self, rhs: &Self) -> bool {
+        match (self.0.as_ref(), rhs.0.as_ref()) {
+            (Number::FixedInteger(lhs), Number::FixedInteger(rhs)) => lhs == rhs,
+            (Number::BigInteger(lhs), Number::BigInteger(rhs)) => lhs == rhs,
+            (Number::Rational(lhs), Number::Rational(rhs)) => lhs == rhs,
+            (Number::Real(lhs), Number::Real(rhs)) => OrderedFloat(*lhs) == OrderedFloat(*rhs),
+            (Number::Complex(lhs), Number::Complex(rhs)) => {
+                let Complex { im, re } = *lhs;
+                let lhs = Complex::new(OrderedFloat(im), OrderedFloat(re));
+                let Complex { im, re } = *rhs;
+                let rhs = Complex::new(OrderedFloat(im), OrderedFloat(re));
+                lhs == rhs
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Eq for ReflexiveNumber {}
+
+impl Hash for ReflexiveNumber {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self.0.as_ref()).hash(state);
+        match self.0.as_ref() {
+            Number::FixedInteger(i) => i.hash(state),
+            Number::BigInteger(i) => i.hash(state),
+            Number::Rational(r) => r.hash(state),
+            Number::Real(r) => OrderedFloat(*r).hash(state),
+            Number::Complex(c) => {
+                let Complex { im, re } = *c;
+                Complex::new(OrderedFloat(im), OrderedFloat(re)).hash(state);
+            }
+        }
+    }
+}
+
 #[bridge(name = "zero?", lib = "(base)")]
-pub async fn zero(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
-    let arg = arg.read();
-    let num: &Number = arg.as_ref().try_into()?;
-    Ok(vec![Gc::new(Value::Boolean(num.is_zero()))])
+pub async fn zero(arg: &Value) -> Result<Vec<Value>, Condition> {
+    let num: Arc<Number> = arg.clone().try_into()?;
+    Ok(vec![Value::from(num.is_zero())])
 }
 
 #[bridge(name = "even?", lib = "(base)")]
-pub async fn even(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
-    let arg = arg.read();
-    let num: &Number = arg.as_ref().try_into()?;
-    Ok(vec![Gc::new(Value::Boolean(num.is_even()))])
+pub async fn even(arg: &Value) -> Result<Vec<Value>, Condition> {
+    let num: Arc<Number> = arg.clone().try_into()?;
+    Ok(vec![Value::from(num.is_even())])
 }
 
 #[bridge(name = "odd?", lib = "(base)")]
-pub async fn odd(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
-    let arg = arg.read();
-    let num: &Number = arg.as_ref().try_into()?;
-    Ok(vec![Gc::new(Value::Boolean(num.is_odd()))])
+pub async fn odd(arg: &Value) -> Result<Vec<Value>, Condition> {
+    let num: Arc<Number> = arg.clone().try_into()?;
+    Ok(vec![Value::from(num.is_odd())])
 }
 
 #[bridge(name = "+", lib = "(base)")]
-pub async fn add_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
-    Ok(vec![Gc::new(Value::Number(add(args)?))])
+pub async fn add_builtin(args: &[Value]) -> Result<Vec<Value>, Condition> {
+    Ok(vec![Value::from(add(args)?)])
 }
 
-pub(crate) fn add(vals: &[Gc<Value>]) -> Result<Number, Condition> {
+pub(crate) fn add(vals: &[Value]) -> Result<Number, Condition> {
     let mut result = Number::FixedInteger(0);
     for val in vals {
-        let val = val.read();
-        let num: &Number = val.as_ref().try_into()?;
-        result = result.checked_add(num)?;
+        let num: Arc<Number> = val.clone().try_into()?;
+        result = result.checked_add(&num)?;
     }
     Ok(result)
 }
 
 #[bridge(name = "-", lib = "(base)")]
-pub async fn sub_builtin(
-    arg1: &Gc<Value>,
-    args: &[Gc<Value>],
-) -> Result<Vec<Gc<Value>>, Condition> {
-    Ok(vec![Gc::new(Value::Number(sub(arg1, args)?))])
+pub async fn sub_builtin(arg1: &Value, args: &[Value]) -> Result<Vec<Value>, Condition> {
+    Ok(vec![Value::from(sub(arg1, args)?)])
 }
 
-pub(crate) fn sub(val1: &Gc<Value>, vals: &[Gc<Value>]) -> Result<Number, Condition> {
-    let val1 = val1.read();
-    let val1: &Number = val1.as_ref().try_into()?;
-    let mut val1 = val1.clone();
+pub(crate) fn sub(val1: &Value, vals: &[Value]) -> Result<Number, Condition> {
+    let val1: Arc<Number> = val1.clone().try_into()?;
+    let mut val1 = val1.as_ref().clone();
     if vals.is_empty() {
         Ok(-val1)
     } else {
         for val in vals {
-            let val = val.read();
-            let num: &Number = val.as_ref().try_into()?;
-            val1 = val1.checked_sub(num)?;
+            let num: Arc<Number> = val.clone().try_into()?;
+            val1 = val1.checked_sub(&num)?;
         }
         Ok(val1)
     }
 }
 
 #[bridge(name = "*", lib = "(base)")]
-pub async fn mul_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
-    Ok(vec![Gc::new(Value::Number(mul(args)?))])
+pub async fn mul_builtin(args: &[Value]) -> Result<Vec<Value>, Condition> {
+    Ok(vec![Value::from(mul(args)?)])
 }
 
-pub(crate) fn mul(vals: &[Gc<Value>]) -> Result<Number, Condition> {
+pub(crate) fn mul(vals: &[Value]) -> Result<Number, Condition> {
     let mut result = Number::FixedInteger(1);
     for val in vals {
-        let val = val.read();
-        let num: &Number = val.as_ref().try_into()?;
-        result = result.checked_mul(num)?;
+        let num: Arc<Number> = val.clone().try_into()?;
+        result = result.checked_mul(&num)?;
     }
     Ok(result)
 }
 
 #[bridge(name = "/", lib = "(base)")]
-pub async fn div_builtin(
-    arg1: &Gc<Value>,
-    args: &[Gc<Value>],
-) -> Result<Vec<Gc<Value>>, Condition> {
-    Ok(vec![Gc::new(Value::Number(div(arg1, args)?))])
+pub async fn div_builtin(arg1: &Value, args: &[Value]) -> Result<Vec<Value>, Condition> {
+    Ok(vec![Value::from(div(arg1, args)?)])
 }
 
-pub(crate) fn div(val1: &Gc<Value>, vals: &[Gc<Value>]) -> Result<Number, Condition> {
-    let val1 = val1.read();
-    let val1: &Number = val1.as_ref().try_into()?;
+pub(crate) fn div(val1: &Value, vals: &[Value]) -> Result<Number, Condition> {
+    let val1: Arc<Number> = val1.clone().try_into()?;
     if vals.is_empty() {
-        return Ok(Number::FixedInteger(1).checked_div(val1)?);
+        return Ok(Number::FixedInteger(1).checked_div(&val1)?);
     }
-    let mut result = val1.clone();
+    let mut result = val1.as_ref().clone();
     for val in vals {
-        let val = val.read();
-        let num: &Number = val.as_ref().try_into()?;
-        result = result.checked_div(num)?;
+        let num: Arc<Number> = val.clone().try_into()?;
+        result = result.checked_div(&num)?;
     }
     Ok(result)
 }
 
 #[bridge(name = "=", lib = "(base)")]
-pub async fn equal_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
-    Ok(vec![Gc::new(Value::Boolean(equal(args)?))])
+pub async fn equal_builtin(args: &[Value]) -> Result<Vec<Value>, Condition> {
+    Ok(vec![Value::from(equal(args)?)])
 }
 
-pub(crate) fn equal(vals: &[Gc<Value>]) -> Result<bool, Condition> {
+pub(crate) fn equal(vals: &[Value]) -> Result<bool, Condition> {
     if let Some((first, rest)) = vals.split_first() {
-        let first = first.read();
-        let first: &Number = first.as_ref().try_into()?;
+        let first: Arc<Number> = first.clone().try_into()?;
         for next in rest {
-            let next = next.read();
-            let next: &Number = next.as_ref().try_into()?;
+            let next: Arc<Number> = next.clone().try_into()?;
             if first != next {
                 return Ok(false);
             }
@@ -596,19 +625,17 @@ pub(crate) fn equal(vals: &[Gc<Value>]) -> Result<bool, Condition> {
 }
 
 #[bridge(name = ">", lib = "(base)")]
-pub async fn greater_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
-    Ok(vec![Gc::new(Value::Boolean(greater(args)?))])
+pub async fn greater_builtin(args: &[Value]) -> Result<Vec<Value>, Condition> {
+    Ok(vec![Value::from(greater(args)?)])
 }
 
-pub(crate) fn greater(vals: &[Gc<Value>]) -> Result<bool, Condition> {
+pub(crate) fn greater(vals: &[Value]) -> Result<bool, Condition> {
     if let Some((head, rest)) = vals.split_first() {
         let mut prev = head.clone();
         for next in rest {
             {
-                let prev = prev.read();
-                let next = next.read();
-                let prev: &Number = prev.as_ref().try_into()?;
-                let next: &Number = next.as_ref().try_into()?;
+                let prev: Arc<Number> = prev.clone().try_into()?;
+                let next: Arc<Number> = next.clone().try_into()?;
                 // This is somewhat less efficient for small numbers but avoids
                 // cloning big ones
                 if prev.is_complex() {
@@ -628,19 +655,17 @@ pub(crate) fn greater(vals: &[Gc<Value>]) -> Result<bool, Condition> {
 }
 
 #[bridge(name = ">=", lib = "(base)")]
-pub async fn greater_equal_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
-    Ok(vec![Gc::new(Value::Boolean(greater_equal(args)?))])
+pub async fn greater_equal_builtin(args: &[Value]) -> Result<Vec<Value>, Condition> {
+    Ok(vec![Value::from(greater_equal(args)?)])
 }
 
-pub(crate) fn greater_equal(vals: &[Gc<Value>]) -> Result<bool, Condition> {
+pub(crate) fn greater_equal(vals: &[Value]) -> Result<bool, Condition> {
     if let Some((head, rest)) = vals.split_first() {
         let mut prev = head.clone();
         for next in rest {
             {
-                let prev = prev.read();
-                let next = next.read();
-                let prev: &Number = prev.as_ref().try_into()?;
-                let next: &Number = next.as_ref().try_into()?;
+                let prev: Arc<Number> = prev.clone().try_into()?;
+                let next: Arc<Number> = next.clone().try_into()?;
                 if prev.is_complex() {
                     return Err(Condition::invalid_type("number", "complex"));
                 }
@@ -658,19 +683,17 @@ pub(crate) fn greater_equal(vals: &[Gc<Value>]) -> Result<bool, Condition> {
 }
 
 #[bridge(name = "<", lib = "(base)")]
-pub async fn lesser_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
-    Ok(vec![Gc::new(Value::Boolean(lesser(args)?))])
+pub async fn lesser_builtin(args: &[Value]) -> Result<Vec<Value>, Condition> {
+    Ok(vec![Value::from(lesser(args)?)])
 }
 
-pub(crate) fn lesser(vals: &[Gc<Value>]) -> Result<bool, Condition> {
+pub(crate) fn lesser(vals: &[Value]) -> Result<bool, Condition> {
     if let Some((head, rest)) = vals.split_first() {
         let mut prev = head.clone();
         for next in rest {
             {
-                let prev = prev.read();
-                let next = next.read();
-                let prev: &Number = prev.as_ref().try_into()?;
-                let next: &Number = next.as_ref().try_into()?;
+                let prev: Arc<Number> = prev.clone().try_into()?;
+                let next: Arc<Number> = next.clone().try_into()?;
                 if prev.is_complex() {
                     return Err(Condition::invalid_type("number", "complex"));
                 }
@@ -688,19 +711,17 @@ pub(crate) fn lesser(vals: &[Gc<Value>]) -> Result<bool, Condition> {
 }
 
 #[bridge(name = "<=", lib = "(base)")]
-pub async fn lesser_equal_builtin(args: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
-    Ok(vec![Gc::new(Value::Boolean(lesser_equal(args)?))])
+pub async fn lesser_equal_builtin(args: &[Value]) -> Result<Vec<Value>, Condition> {
+    Ok(vec![Value::from(lesser_equal(args)?)])
 }
 
-pub(crate) fn lesser_equal(vals: &[Gc<Value>]) -> Result<bool, Condition> {
+pub(crate) fn lesser_equal(vals: &[Value]) -> Result<bool, Condition> {
     if let Some((head, rest)) = vals.split_first() {
         let mut prev = head.clone();
         for next in rest {
             {
-                let prev = prev.read();
-                let next = next.read();
-                let prev: &Number = prev.as_ref().try_into()?;
-                let next: &Number = next.as_ref().try_into()?;
+                let prev: Arc<Number> = prev.clone().try_into()?;
+                let next: Arc<Number> = next.clone().try_into()?;
                 if prev.is_complex() {
                     return Err(Condition::invalid_type("number", "complex"));
                 }
@@ -718,47 +739,51 @@ pub(crate) fn lesser_equal(vals: &[Gc<Value>]) -> Result<bool, Condition> {
 }
 
 #[bridge(name = "number?", lib = "(base)")]
-pub async fn is_number(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
-    let arg = arg.read();
-    Ok(vec![Gc::new(Value::Boolean(matches!(
-        &*arg,
-        Value::Number(_)
-    )))])
+pub async fn is_number(arg: &Value) -> Result<Vec<Value>, Condition> {
+    Ok(vec![Value::from(arg.type_of() == ValueType::Number)])
 }
 
 #[bridge(name = "integer?", lib = "(base)")]
-pub async fn is_integer(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
-    let arg = arg.read();
-    Ok(vec![Gc::new(Value::Boolean(matches!(
-        &*arg,
-        Value::Number(Number::FixedInteger(_)) | Value::Number(Number::BigInteger(_))
-    )))])
+pub async fn is_integer(arg: &Value) -> Result<Vec<Value>, Condition> {
+    let arg: Arc<Number> = match arg.clone().try_into() {
+        Ok(arg) => arg,
+        Err(_) => return Ok(vec![Value::from(false)]),
+    };
+    Ok(vec![Value::from(matches!(
+        arg.as_ref(),
+        Number::FixedInteger(_) | Number::BigInteger(_)
+    ))])
 }
 
 #[bridge(name = "rational?", lib = "(base)")]
-pub async fn is_rational(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
-    let arg = arg.read();
-    Ok(vec![Gc::new(Value::Boolean(matches!(
-        &*arg,
-        Value::Number(Number::Rational(_))
-    )))])
+pub async fn is_rational(arg: &Value) -> Result<Vec<Value>, Condition> {
+    let arg: Arc<Number> = match arg.clone().try_into() {
+        Ok(arg) => arg,
+        Err(_) => return Ok(vec![Value::from(false)]),
+    };
+    Ok(vec![Value::from(matches!(
+        arg.as_ref(),
+        Number::Rational(_)
+    ))])
 }
 
 #[bridge(name = "real?", lib = "(base)")]
-pub async fn is_real(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
-    let arg = arg.read();
-    Ok(vec![Gc::new(Value::Boolean(matches!(
-        &*arg,
-        Value::Number(Number::Real(_))
-    )))])
+pub async fn is_real(arg: &Value) -> Result<Vec<Value>, Condition> {
+    let arg: Arc<Number> = match arg.clone().try_into() {
+        Ok(arg) => arg,
+        Err(_) => return Ok(vec![Value::from(false)]),
+    };
+    Ok(vec![Value::from(matches!(arg.as_ref(), Number::Real(_)))])
 }
 
 #[bridge(name = "complex?", lib = "(base)")]
-pub async fn is_complex(arg: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
-    let arg = arg.read();
-    Ok(vec![Gc::new(Value::Boolean(matches!(
-        &*arg,
-        Value::Number(Number::Complex(_))
-    )))])
+pub async fn is_complex(arg: &Value) -> Result<Vec<Value>, Condition> {
+    let arg: Arc<Number> = match arg.clone().try_into() {
+        Ok(arg) => arg,
+        Err(_) => return Ok(vec![Value::from(false)]),
+    };
+    Ok(vec![Value::from(matches!(
+        arg.as_ref(),
+        Number::Complex(_)
+    ))])
 }
-*/

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -63,6 +63,7 @@ unsafe impl Trace for FuncPtr {
 /// environmental variables used in the body, along with a function pointer to
 /// the body of the closure.
 #[derive(Clone, Trace, PartialEq)]
+#[repr(align(16))]
 pub struct Closure {
     /// The runtime the Closure is defined in. This is necessary to ensure that
     /// dropping the runtime does not de-allocate the function pointer for this

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -301,6 +301,7 @@ fn values_to_vec_of_cells(vals: &[Value]) -> Vec<Gc<Value>> {
 }
 
 /// An application of a function to a given set of values.
+#[derive(Debug)]
 pub struct Application {
     /// The operator being applied to. If None, we return the values to the Rust
     /// caller.
@@ -493,13 +494,11 @@ pub fn apply<'a>(
     exception_handler: &'a Option<Gc<ExceptionHandler>>,
     dynamic_wind: &'a DynamicWind,
 ) -> BoxFuture<'a, Result<Application, Value>> {
-    /*
     Box::pin(async move {
         if rest_args.is_empty() {
             return Err(Condition::wrong_num_of_args(2, args.len()).into());
         }
-        let op = args[0].read();
-        let op: &Closure = op.as_ref().try_into()?;
+        let op: Gc<Closure> = args[0].clone().try_into()?;
         let (last, args) = rest_args.split_last().unwrap();
         let mut args = args.to_vec();
         list_to_vec(last, &mut args);
@@ -512,8 +511,6 @@ pub fn apply<'a>(
             None,
         ))
     })
-     */
-    todo!()
 }
 
 inventory::submit! {
@@ -525,7 +522,7 @@ inventory::submit! {
         apply,
         BridgeFnDebugInfo::new(
             "proc.rs",
-            468,
+            490,
             7,
             0,
             &[ "arg1", "args" ],
@@ -679,7 +676,7 @@ inventory::submit! {
     )
 }
 
-#[derive(Clone, Default, Trace)]
+#[derive(Clone, Debug, Default, Trace)]
 pub struct DynamicWind {
     pub(crate) winders: Vec<(Closure, Closure)>,
 }

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -656,10 +656,7 @@ pub fn call_with_values<'a>(
 
         let call_consumer_closure = Closure::new(
             producer.read().runtime.clone(),
-            vec![
-                Gc::new(Value::from(consumer)),
-                Gc::new(Value::from(cont.clone())),
-            ],
+            vec![Gc::new(Value::from(consumer)), Gc::new(cont.clone())],
             Vec::new(),
             FuncPtr::Continuation(call_consumer_with_values),
             num_required_args,

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -62,7 +62,7 @@ unsafe impl Trace for FuncPtr {
 /// or a continuation. Contains a reference to all of the globals and
 /// environmental variables used in the body, along with a function pointer to
 /// the body of the closure.
-#[derive(Clone, Trace, PartialEq)]
+#[derive(Clone, Trace)]
 #[repr(align(16))]
 pub struct Closure {
     /// The runtime the Closure is defined in. This is necessary to ensure that
@@ -193,7 +193,7 @@ impl Closure {
             let app = match self.func {
                 FuncPtr::Continuation(sync_fn) => unsafe {
                     let app = (sync_fn)(
-                        self.runtime.as_ptr(),
+                        Gc::as_ptr(&self.runtime),
                         env.as_ptr(),
                         globals.as_ptr(),
                         args.as_ptr(),
@@ -204,7 +204,7 @@ impl Closure {
                 },
                 FuncPtr::Closure(sync_fn) => unsafe {
                     let app = (sync_fn)(
-                        self.runtime.as_ptr(),
+                        Gc::as_ptr(&self.runtime),
                         env.as_ptr(),
                         globals.as_ptr(),
                         args.as_ptr(),

--- a/src/records.rs
+++ b/src/records.rs
@@ -1,6 +1,6 @@
 //! Rudimentary structure support. CPS will probably make a lot of this redundant.
 
-use std::{sync::Arc, collections::HashMap};
+use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     ast::ParseAstError,

--- a/src/records.rs
+++ b/src/records.rs
@@ -12,6 +12,7 @@ use crate::{
 
 /// Type declaration for a record.
 #[derive(Debug, Trace, Clone)]
+#[repr(align(16))]
 pub struct RecordType {
     name: String,
     /// Parent is most recently inserted record type, if one exists.
@@ -39,6 +40,7 @@ fn is_subtype_of(lhs: &Gc<RecordType>, rhs: &Gc<RecordType>) -> bool {
 */
 
 #[derive(Debug, Trace, Clone)]
+#[repr(align(16))]
 pub struct Record {
     record_type: Gc<RecordType>,
     fields: Vec<Gc<Value>>,

--- a/src/records.rs
+++ b/src/records.rs
@@ -1,6 +1,6 @@
 //! Rudimentary structure support. CPS will probably make a lot of this redundant.
 
-use std::collections::HashMap;
+use std::{sync::Arc, collections::HashMap};
 
 use crate::{
     ast::ParseAstError,
@@ -11,12 +11,12 @@ use crate::{
 };
 
 /// Type declaration for a record.
-#[derive(Debug, Trace, Clone)]
+#[derive(Debug, Clone)]
 #[repr(align(16))]
 pub struct RecordType {
     name: String,
     /// Parent is most recently inserted record type, if one exists.
-    inherits: indexmap::IndexSet<Gc<RecordType>>,
+    inherits: indexmap::IndexSet<Arc<RecordType>>,
     fields: Vec<Identifier>,
 }
 
@@ -42,7 +42,7 @@ fn is_subtype_of(lhs: &Gc<RecordType>, rhs: &Gc<RecordType>) -> bool {
 #[derive(Debug, Trace, Clone)]
 #[repr(align(16))]
 pub struct Record {
-    record_type: Gc<RecordType>,
+    record_type: Arc<RecordType>,
     fields: Vec<Gc<Value>>,
 }
 

--- a/src/records.rs
+++ b/src/records.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// Type declaration for a record.
-#[derive(Debug, Clone)]
+#[derive(Debug, Trace, Clone)]
 #[repr(align(16))]
 pub struct RecordType {
     name: String,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -206,7 +206,7 @@ impl Registry {
             let mut lib = lib.write();
             lib.def_var(
                 Identifier::new(bridge_fn.name.to_string()),
-                Value::Closure(Closure::new(
+                Value::from(Closure::new(
                     runtime.clone(),
                     Vec::new(),
                     Vec::new(),

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -218,7 +218,6 @@ impl Registry {
             );
         }
 
-        /*
         // Import the stdlib:
         let base_lib = libs
             .entry(LibraryName::from_str("(base)", None).unwrap())
@@ -231,7 +230,6 @@ impl Registry {
         let compiled = base.compile_top_level();
         let closure = runtime.compile_expr(compiled).await.unwrap();
         closure.call(&[]).await.unwrap();
-         */
 
         Self { libs }
     }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -218,6 +218,7 @@ impl Registry {
             );
         }
 
+        /*
         // Import the stdlib:
         let base_lib = libs
             .entry(LibraryName::from_str("(base)", None).unwrap())
@@ -230,6 +231,7 @@ impl Registry {
         let compiled = base.compile_top_level();
         let closure = runtime.compile_expr(compiled).await.unwrap();
         closure.call(&[]).await.unwrap();
+         */
 
         Self { libs }
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -26,7 +26,6 @@ use inkwell::{
 use std::{
     collections::{HashMap, HashSet},
     mem::ManuallyDrop,
-    ptr::null_mut,
 };
 use tokio::sync::{mpsc, oneshot};
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -564,17 +564,23 @@ unsafe extern "C" fn make_closure(
         FuncPtr::Closure(fn_ptr),
         num_required_args as usize,
         variadic,
-        // Some(debug_info_id),
-        None,
+        Some(debug_info_id),
     );
 
-    let raw = Gc::into_raw(Gc::new(Value::from(closure)));
-    raw
+    Gc::into_raw(Gc::new(Value::from(closure)))
 }
 
 /// Call a transformer with the given argument and return the expansion
-unsafe extern "C" fn get_call_transformer_fn(runtime: *mut GcInner<Runtime>) -> i64 {
-    /*
+unsafe extern "C" fn get_call_transformer_fn(
+    runtime: *mut GcInner<Runtime>,
+    env: *const *mut GcInner<Value>,
+    num_envs: u32,
+) -> *mut GcInner<Value> {
+    // Collect the environment:
+    let env: Vec<_> = (0..num_envs)
+        .map(|i| Gc::from_raw_inc_rc(env.add(i as usize).read()))
+        .collect();
+
     let closure = Closure::new(
         Gc::from_raw(runtime),
         Vec::new(),
@@ -584,9 +590,8 @@ unsafe extern "C" fn get_call_transformer_fn(runtime: *mut GcInner<Runtime>) -> 
         true,
         Some(IGNORE_FUNCTION),
     );
-    ManuallyDrop::new(Gc::new(Value::Closure(closure))).as_ptr()
-     */
-    todo!()
+
+    Gc::into_raw(Gc::new(Value::from(closure)))
 }
 
 /*

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -198,10 +198,10 @@ fn install_runtime<'ctx>(ctx: &'ctx Context, module: &Module<'ctx>, ee: &Executi
     let void_type = ctx.void_type();
     let ptr_type = ctx.ptr_type(AddressSpace::default());
 
-    // alloc_undef_val:
+    // alloc_cell:
     let sig = ptr_type.fn_type(&[], false);
-    let f = module.add_function("alloc_undef_val", sig, None);
-    ee.add_global_mapping(&f, alloc_undef_val as usize);
+    let f = module.add_function("alloc_cell", sig, None);
+    ee.add_global_mapping(&f, alloc_cell as usize);
 
     // clone:
     let sig = ptr_type.fn_type(&[ptr_type.into()], false);
@@ -354,7 +354,7 @@ fn install_runtime<'ctx>(ctx: &'ctx Context, module: &Module<'ctx>, ee: &Executi
 }
 
 /// Allocate a new Gc with a value of undefined
-unsafe extern "C" fn alloc_undef_val() -> *mut GcInner<Value> {
+unsafe extern "C" fn alloc_cell() -> *mut GcInner<Value> {
     ManuallyDrop::new(Gc::new(Value::Undefined)).as_ptr()
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -213,7 +213,7 @@ fn install_runtime<'ctx>(ctx: &'ctx Context, module: &Module<'ctx>, ee: &Executi
     ee.add_global_mapping(&f, drop_cells as usize);
 
     // drop_values:
-    let sig = void_type.fn_type(&[i64_type.into(), i32_type.into()], false);
+    let sig = void_type.fn_type(&[ptr_type.into(), i32_type.into()], false);
     let f = module.add_function("drop_values", sig, None);
     ee.add_global_mapping(&f, drop_values as usize);
 
@@ -246,33 +246,32 @@ fn install_runtime<'ctx>(ctx: &'ctx Context, module: &Module<'ctx>, ee: &Executi
     let f = module.add_function("forward", sig, None);
     ee.add_global_mapping(&f, forward as usize);
 
-    /*
     // halt:
-    let sig = ptr_type.fn_type(&[ptr_type.into()], false);
+    let sig = ptr_type.fn_type(&[i64_type.into()], false);
     let f = module.add_function("halt", sig, None);
     ee.add_global_mapping(&f, halt as usize);
 
     // truthy:
-    let sig = bool_type.fn_type(&[ptr_type.into()], false);
+    let sig = bool_type.fn_type(&[i64_type.into()], false);
     let f = module.add_function("truthy", sig, None);
     ee.add_global_mapping(&f, truthy as usize);
 
     // store:
-    let sig = void_type.fn_type(&[ptr_type.into(), ptr_type.into()], false);
+    let sig = void_type.fn_type(&[i64_type.into(), ptr_type.into()], false);
     let f = module.add_function("store", sig, None);
     ee.add_global_mapping(&f, store as usize);
 
     // make_continuation
     let sig = ptr_type.fn_type(
         &[
-            ptr_type.into(),
-            ptr_type.into(),
-            ptr_type.into(),
-            i32_type.into(),
-            ptr_type.into(),
-            i32_type.into(),
-            i32_type.into(),
-            bool_type.into(),
+            ptr_type.into(), // Runtime
+            ptr_type.into(), // Continuation Ptr
+            ptr_type.into(), // Env
+            i32_type.into(), // Num envs
+            ptr_type.into(), // Globals
+            i32_type.into(), // Num globals
+            i32_type.into(), // Num required args
+            bool_type.into(), // Variadic?
         ],
         false,
     );
@@ -282,21 +281,22 @@ fn install_runtime<'ctx>(ctx: &'ctx Context, module: &Module<'ctx>, ee: &Executi
     // make_closure:
     let sig = ptr_type.fn_type(
         &[
-            ptr_type.into(),
-            ptr_type.into(),
-            ptr_type.into(),
-            i32_type.into(),
-            ptr_type.into(),
-            i32_type.into(),
-            i32_type.into(),
-            bool_type.into(),
-            i32_type.into(),
+            ptr_type.into(), // Runtime
+            ptr_type.into(), // Closure Ptr
+            ptr_type.into(), // Env
+            i32_type.into(), // Num envs
+            ptr_type.into(), // Globals
+            i32_type.into(), // Num globals
+            i32_type.into(), // Num required args
+            bool_type.into(), // Variadic?
+            i32_type.into(), // Debug info 
         ],
         false,
     );
     let f = module.add_function("make_closure", sig, None);
     ee.add_global_mapping(&f, make_closure as usize);
 
+    /*
     // get_call_transformer_fn:
     let sig = ptr_type.fn_type(&[ptr_type.into()], false);
     let f = module.add_function("get_call_transformer_fn", sig, None);
@@ -311,52 +311,52 @@ fn install_runtime<'ctx>(ctx: &'ctx Context, module: &Module<'ctx>, ee: &Executi
     let sig = ptr_type.fn_type(&[ptr_type.into(), ptr_type.into(), ptr_type.into()], false);
     let f = module.add_function("prepare_continuation", sig, None);
     ee.add_global_mapping(&f, prepare_continuation as usize);
+    */
 
     // add:
-    let sig = ptr_type.fn_type(&[ptr_type.into(), i32_type.into(), ptr_type.into()], false);
+    let sig = i64_type.fn_type(&[ptr_type.into(), i32_type.into(), ptr_type.into()], false);
     let f = module.add_function("add", sig, None);
     ee.add_global_mapping(&f, add as usize);
 
     // sub:
-    let sig = ptr_type.fn_type(&[ptr_type.into(), i32_type.into(), ptr_type.into()], false);
+    let sig = i64_type.fn_type(&[ptr_type.into(), i32_type.into(), ptr_type.into()], false);
     let f = module.add_function("sub", sig, None);
     ee.add_global_mapping(&f, sub as usize);
 
     // mul:
-    let sig = ptr_type.fn_type(&[ptr_type.into(), i32_type.into(), ptr_type.into()], false);
+    let sig = i64_type.fn_type(&[ptr_type.into(), i32_type.into(), ptr_type.into()], false);
     let f = module.add_function("mul", sig, None);
     ee.add_global_mapping(&f, mul as usize);
 
     // div:
-    let sig = ptr_type.fn_type(&[ptr_type.into(), i32_type.into(), ptr_type.into()], false);
+    let sig = i64_type.fn_type(&[ptr_type.into(), i32_type.into(), ptr_type.into()], false);
     let f = module.add_function("div", sig, None);
     ee.add_global_mapping(&f, div as usize);
 
     // equal:
-    let sig = ptr_type.fn_type(&[ptr_type.into(), i32_type.into(), ptr_type.into()], false);
+    let sig = i64_type.fn_type(&[ptr_type.into(), i32_type.into(), ptr_type.into()], false);
     let f = module.add_function("equal", sig, None);
     ee.add_global_mapping(&f, equal as usize);
 
     // greater:
-    let sig = ptr_type.fn_type(&[ptr_type.into(), i32_type.into(), ptr_type.into()], false);
+    let sig = i64_type.fn_type(&[ptr_type.into(), i32_type.into(), ptr_type.into()], false);
     let f = module.add_function("greater", sig, None);
     ee.add_global_mapping(&f, greater as usize);
 
     // greater_equal:
-    let sig = ptr_type.fn_type(&[ptr_type.into(), i32_type.into(), ptr_type.into()], false);
+    let sig = i64_type.fn_type(&[ptr_type.into(), i32_type.into(), ptr_type.into()], false);
     let f = module.add_function("greater_equal", sig, None);
     ee.add_global_mapping(&f, greater_equal as usize);
 
     // lesser:
-    let sig = ptr_type.fn_type(&[ptr_type.into(), i32_type.into(), ptr_type.into()], false);
+    let sig = i64_type.fn_type(&[ptr_type.into(), i32_type.into(), ptr_type.into()], false);
     let f = module.add_function("lesser", sig, None);
     ee.add_global_mapping(&f, lesser as usize);
 
     // lesser_equal:
-    let sig = ptr_type.fn_type(&[ptr_type.into(), i32_type.into(), ptr_type.into()], false);
+    let sig = i64_type.fn_type(&[ptr_type.into(), i32_type.into(), ptr_type.into()], false);
     let f = module.add_function("lesser_equal", sig, None);
     ee.add_global_mapping(&f, lesser_equal as usize);
-    */
 }
 
 /// Allocate a new Gc with a value of undefined
@@ -370,7 +370,8 @@ unsafe extern "C" fn read_cell(cell: *mut GcInner<Value>) -> i64 {
     // be decremented at the end of this function.
     let cell = ManuallyDrop::new(Gc::from_raw(cell));
     let cell_read = cell.read();
-    Value::as_raw(&cell_read) as i64
+    let raw = Value::as_raw(&cell_read);
+    raw as i64
 }
 
 /// Decrement the reference count of all of the cells
@@ -399,8 +400,11 @@ unsafe extern "C" fn apply(
     dynamic_wind: *const DynamicWind,
     call_site_id: u32,
 ) -> *mut Result<Application, Condition> {
+    
     let args: Vec<_> = (0..num_args)
-        .map(|i| Value::from_raw_inc_rc(args.add(i as usize).read() as u64))
+        .map(|i|
+            Value::from_raw_inc_rc(args.add(i as usize).read() as u64)
+        )
         .collect();
 
     let op = match Value::from_raw_inc_rc(op as u64).unpack() {
@@ -412,6 +416,7 @@ unsafe extern "C" fn apply(
         }
     };
 
+    /*
     let call_site = (call_site_id != u32::MAX).then(|| {
         // No need to increment the ref count for runtime here, it is dropped
         // immediately.
@@ -419,13 +424,15 @@ unsafe extern "C" fn apply(
         let runtime_read = runtime.read();
         runtime_read.debug_info.call_sites[call_site_id as usize].clone()
     });
+     */
 
     let app = Application::new(
         op,
         args,
         ExceptionHandler::from_ptr(exception_handler),
         dynamic_wind.as_ref().unwrap().clone(),
-        call_site,
+        // call_site,
+        None
     );
 
     Box::into_raw(Box::new(Ok(app)))
@@ -500,7 +507,7 @@ unsafe extern "C" fn make_continuation(
     num_globals: u32,
     num_required_args: u32,
     variadic: bool,
-) -> i64 {
+) -> *mut GcInner<Value> {
     // Collect the environment:
     let env: Vec<_> = (0..num_envs)
         .map(|i| Gc::from_raw_inc_rc(env.add(i as usize).read()))
@@ -524,7 +531,7 @@ unsafe extern "C" fn make_continuation(
         None,
     );
 
-    Value::into_raw(Value::from(closure)) as i64
+    Gc::into_raw(Gc::new(Value::from(closure)))
 }
 
 /// Allocate a closure for a function that takes a continuation
@@ -538,7 +545,7 @@ unsafe extern "C" fn make_closure(
     num_required_args: u32,
     variadic: bool,
     debug_info_id: u32,
-) -> i64 {
+) -> *mut GcInner<Value> {
     // Collect the environment:
     let env: Vec<_> = (0..num_envs)
         .map(|i| Gc::from_raw_inc_rc(env.add(i as usize).read()))
@@ -559,10 +566,12 @@ unsafe extern "C" fn make_closure(
         FuncPtr::Closure(fn_ptr),
         num_required_args as usize,
         variadic,
-        Some(debug_info_id),
+        // Some(debug_info_id),
+        None
     );
 
-    Value::into_raw(Value::from(closure)) as i64
+    let raw = Gc::into_raw(Gc::new(Value::from(closure)));
+    raw  
 }
 
 /// Call a transformer with the given argument and return the expansion

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -22,7 +22,11 @@ use inkwell::{
     targets::{InitializationConfig, Target},
     AddressSpace, OptimizationLevel,
 };
-use std::{collections::{HashMap, HashSet}, mem::ManuallyDrop, ptr::null_mut};
+use std::{
+    collections::{HashMap, HashSet},
+    mem::ManuallyDrop,
+    ptr::null_mut,
+};
 use tokio::sync::{mpsc, oneshot};
 
 /// Scheme-rs Runtime
@@ -264,13 +268,13 @@ fn install_runtime<'ctx>(ctx: &'ctx Context, module: &Module<'ctx>, ee: &Executi
     // make_continuation
     let sig = ptr_type.fn_type(
         &[
-            ptr_type.into(), // Runtime
-            ptr_type.into(), // Continuation Ptr
-            ptr_type.into(), // Env
-            i32_type.into(), // Num envs
-            ptr_type.into(), // Globals
-            i32_type.into(), // Num globals
-            i32_type.into(), // Num required args
+            ptr_type.into(),  // Runtime
+            ptr_type.into(),  // Continuation Ptr
+            ptr_type.into(),  // Env
+            i32_type.into(),  // Num envs
+            ptr_type.into(),  // Globals
+            i32_type.into(),  // Num globals
+            i32_type.into(),  // Num required args
             bool_type.into(), // Variadic?
         ],
         false,
@@ -281,15 +285,15 @@ fn install_runtime<'ctx>(ctx: &'ctx Context, module: &Module<'ctx>, ee: &Executi
     // make_closure:
     let sig = ptr_type.fn_type(
         &[
-            ptr_type.into(), // Runtime
-            ptr_type.into(), // Closure Ptr
-            ptr_type.into(), // Env
-            i32_type.into(), // Num envs
-            ptr_type.into(), // Globals
-            i32_type.into(), // Num globals
-            i32_type.into(), // Num required args
+            ptr_type.into(),  // Runtime
+            ptr_type.into(),  // Closure Ptr
+            ptr_type.into(),  // Env
+            i32_type.into(),  // Num envs
+            ptr_type.into(),  // Globals
+            i32_type.into(),  // Num globals
+            i32_type.into(),  // Num required args
             bool_type.into(), // Variadic?
-            i32_type.into(), // Debug info 
+            i32_type.into(),  // Debug info
         ],
         false,
     );
@@ -400,11 +404,8 @@ unsafe extern "C" fn apply(
     dynamic_wind: *const DynamicWind,
     call_site_id: u32,
 ) -> *mut Result<Application, Condition> {
-    
     let args: Vec<_> = (0..num_args)
-        .map(|i|
-            Value::from_raw_inc_rc(args.add(i as usize).read() as u64)
-        )
+        .map(|i| Value::from_raw_inc_rc(args.add(i as usize).read() as u64))
         .collect();
 
     let op = match Value::from_raw_inc_rc(op as u64).unpack() {
@@ -416,7 +417,6 @@ unsafe extern "C" fn apply(
         }
     };
 
-    /*
     let call_site = (call_site_id != u32::MAX).then(|| {
         // No need to increment the ref count for runtime here, it is dropped
         // immediately.
@@ -424,15 +424,13 @@ unsafe extern "C" fn apply(
         let runtime_read = runtime.read();
         runtime_read.debug_info.call_sites[call_site_id as usize].clone()
     });
-     */
 
     let app = Application::new(
         op,
         args,
         ExceptionHandler::from_ptr(exception_handler),
         dynamic_wind.as_ref().unwrap().clone(),
-        // call_site,
-        None
+        call_site,
     );
 
     Box::into_raw(Box::new(Ok(app)))
@@ -567,11 +565,11 @@ unsafe extern "C" fn make_closure(
         num_required_args as usize,
         variadic,
         // Some(debug_info_id),
-        None
+        None,
     );
 
     let raw = Gc::into_raw(Gc::new(Value::from(closure)));
-    raw  
+    raw
 }
 
 /// Call a transformer with the given argument and return the expansion
@@ -859,7 +857,7 @@ unsafe extern "C" fn sub(
             error.write(Box::into_raw(Box::new(Err(condition))));
             Value::into_raw(Value::undefined()) as i64
         }
-    } 
+    }
 }
 
 unsafe extern "C" fn mul(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3,7 +3,6 @@ use crate::{
     env::Local,
     exception::{Condition, ExceptionHandler},
     expand,
-    vectors,
     gc::{init_gc, Gc, GcInner, Trace},
     lists::{self, list_to_vec},
     num,
@@ -13,6 +12,7 @@ use crate::{
     },
     syntax::Span,
     value::{ReflexiveValue, UnpackedValue, Value},
+    vectors,
 };
 use indexmap::IndexMap;
 use inkwell::{
@@ -646,7 +646,11 @@ unsafe extern "C" fn prepare_continuation(
 
     let (runtime, req_args, variadic) = {
         let cont_read = cont.read();
-        (cont_read.runtime.clone(), cont_read.num_required_args, cont_read.variadic)
+        (
+            cont_read.runtime.clone(),
+            cont_read.num_required_args,
+            cont_read.variadic,
+        )
     };
 
     Value::into_raw(Value::from(Closure::new(
@@ -742,10 +746,7 @@ unsafe extern "C" fn call_thunks(
         for i in (0..num_args).rev() {
             let arg = Gc::from_raw_inc_rc(args.add(i).read());
             let arg_read = arg.read();
-            collected_args = Value::from((
-                arg_read.clone(),
-                collected_args,
-            ));
+            collected_args = Value::from((arg_read.clone(), collected_args));
         }
 
         collected_args

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -1,0 +1,50 @@
+//! String builtins and data types
+
+use std::{fmt, ops::{Deref, DerefMut}};
+
+#[repr(align(16))]
+pub struct AlignedString(pub String);
+
+impl AlignedString {
+    pub fn new(str: String) -> Self {
+        AlignedString(str)
+    }
+}
+
+impl Deref for AlignedString {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for AlignedString {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl PartialEq<str> for AlignedString {
+    fn eq(&self, rhs: &str) -> bool {
+        self.0 == rhs
+    }
+}
+
+impl PartialEq for AlignedString {
+    fn eq(&self, rhs: &Self) -> bool {
+        self.0 == rhs.0
+    }
+}
+
+impl fmt::Display for AlignedString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::Debug for AlignedString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -1,6 +1,9 @@
 //! String builtins and data types
 
-use std::{fmt, ops::{Deref, DerefMut}};
+use std::{
+    fmt,
+    ops::{Deref, DerefMut},
+};
 
 #[repr(align(16))]
 pub struct AlignedString(pub String);

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -53,6 +53,7 @@ impl From<InputSpan<'_>> for Span {
 }
 
 #[derive(Clone, derive_more::Debug, Trace)]
+#[repr(align(16))]
 // TODO: Make cloning this struct as fast as possible.
 pub enum Syntax {
     /// An empty list.

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -144,10 +144,10 @@ impl Syntax {
         }
     }
 
-    pub fn from_datum(marks: &BTreeSet<Mark>, datum: &Gc<Value>) -> Self {
-        let datum = datum.read();
+    pub fn from_datum(marks: &BTreeSet<Mark>, datum: Value) -> Self {
         // TODO: conjure up better values for Span
-        match &*datum {
+        /*
+        match datum {
             Value::Null => Syntax::new_null(Span::default()),
             Value::Pair(lhs, rhs) => {
                 let mut list = Vec::new();
@@ -178,6 +178,8 @@ impl Syntax {
             }
             _ => unimplemented!(),
         }
+         */
+        todo!()
     }
 
     pub fn resolve_bindings(&mut self, env: &Environment) {
@@ -207,7 +209,8 @@ impl Syntax {
         env: &Environment,
         mac: Macro,
         // cont: &Closure,
-    ) -> Result<Expansion, Gc<Value>> {
+    ) -> Result<Expansion, Value> {
+        /*
         // Create a new mark for the expansion context
         let new_mark = Mark::new();
 
@@ -235,13 +238,15 @@ impl Syntax {
         let new_env = env.new_macro_expansion(new_mark, mac.source_env.clone());
 
         Ok(Expansion::new_expanded(new_env, output))
+         */
+        todo!()
     }
 
     fn expand_once<'a>(
         &'a self,
         env: &'a Environment,
         // cont: &Closure,
-    ) -> BoxFuture<'a, Result<Expansion, Gc<Value>>> {
+    ) -> BoxFuture<'a, Result<Expansion, Value>> {
         Box::pin(async move {
             match self {
                 Self::List { list, .. } => {
@@ -289,7 +294,7 @@ impl Syntax {
         mut self,
         env: &Environment,
         // cont: &Closure,
-    ) -> Result<FullyExpanded, Gc<Value>> {
+    ) -> Result<FullyExpanded, Value> {
         let mut curr_env = env.clone();
         loop {
             match self.expand_once(&curr_env).await? {
@@ -579,9 +584,10 @@ pub async fn syntax_to_datum(
 
 #[bridge(name = "datum->syntax", lib = "(base)")]
 pub async fn datum_to_syntax(
-    template_id: &Gc<Value>,
-    datum: &Gc<Value>,
-) -> Result<Vec<Gc<Value>>, Condition> {
+    template_id: &Value,
+    datum: &Value,
+) -> Result<Vec<Value>, Condition> {
+    /*
     let template_id = template_id.read();
     let Value::Syntax(Syntax::Identifier {
         ident: template_id, ..
@@ -593,4 +599,6 @@ pub async fn datum_to_syntax(
         &template_id.marks,
         datum,
     )))])
+     */
+    todo!()
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -52,7 +52,7 @@ impl From<InputSpan<'_>> for Span {
     }
 }
 
-#[derive(Clone, derive_more::Debug, Trace)]
+#[derive(Clone, derive_more::Debug, Trace, PartialEq)]
 #[repr(align(16))]
 // TODO: Make cloning this struct as fast as possible.
 pub enum Syntax {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -213,17 +213,12 @@ impl Syntax {
         let new_mark = Mark::new();
 
         // Apply the new mark to the input and resolve any bindings
-        // TODO: Figure out a better way to do this without cloning so much
         let mut input = self.clone();
         input.resolve_bindings(env);
         input.mark(new_mark);
 
         // Call the transformer with the input:
-
-        let transformer_output = mac
-            .transformer
-            .call(&[Value::from(input)])
-            .await?;
+        let transformer_output = mac.transformer.call(&[Value::from(input)]).await?;
 
         // Output must be syntax:
         let output: Arc<Syntax> = transformer_output[0].clone().try_into()?;
@@ -551,13 +546,16 @@ pub async fn syntax_to_datum(
 */
 
 #[bridge(name = "datum->syntax", lib = "(base)")]
-pub async fn datum_to_syntax(
-    template_id: &Value,
-    datum: &Value,
-) -> Result<Vec<Value>, Condition> {
+pub async fn datum_to_syntax(template_id: &Value, datum: &Value) -> Result<Vec<Value>, Condition> {
     let syntax: Arc<Syntax> = template_id.clone().try_into()?;
-    let Syntax::Identifier { ident: template_id, .. } = syntax.as_ref() else {
+    let Syntax::Identifier {
+        ident: template_id, ..
+    } = syntax.as_ref()
+    else {
         return Err(Condition::invalid_type("template_id", "syntax"));
     };
-    Ok(vec![Value::from(Syntax::from_datum(&template_id.marks, datum.clone()))])
+    Ok(vec![Value::from(Syntax::from_datum(
+        &template_id.marks,
+        datum.clone(),
+    ))])
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -115,7 +115,24 @@ impl Value {
     }
 
     pub fn datum_from_syntax(syntax: &Syntax) -> Self {
-        todo!()
+        match syntax {
+            Syntax::Null { .. } => Self::null(),
+            Syntax::List { list, .. } => {
+                let mut curr = Self::datum_from_syntax(list.last().unwrap());
+                for item in list[..list.len() - 1].iter().rev() {
+                    curr = Self::from(Gc::new(lists::Pair(Self::datum_from_syntax(item), curr)));
+                }
+                curr
+            }
+            Syntax::Vector { vector, .. } => {
+                Self::from(vector.iter().map(Self::datum_from_syntax).collect::<Vec<_>>())
+            }
+            Syntax::ByteVector { vector, .. } => Self::from(vector.clone()),
+            Syntax::Literal { literal, .. } => Self::from(literal.clone()),
+            Syntax::Identifier { ident, .. } => {
+                Self::new(UnpackedValue::Symbol(Arc::new(AlignedString(ident.name.clone()))))
+            }
+        }
     }
 
     pub fn type_of(&self) -> ValueType {
@@ -455,7 +472,7 @@ impl fmt::Display for UnpackedValue {
             Self::Condition(cond) => write!(f, "<{cond:?}>"),
             // Self::ExceptionHandler(_) => write!(f, "<exception-handler>"),
             */
-            _ => todo!(),
+            x => todo!("{}", x.type_name()),
         }
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -13,7 +13,7 @@ use crate::{
     syntax::Syntax,
     vectors,
 };
-use futures::future::{BoxFuture, Shared};
+// use futures::future::{BoxFuture, Shared};
 use std::{
     fmt, hash::Hash, io::Write, marker::PhantomData, mem::ManuallyDrop, ops::Deref, sync::Arc,
 };
@@ -238,7 +238,7 @@ impl Value {
 
 impl PartialEq for Value {
     fn eq(&self, rhs: &Self) -> bool {
-        &*self.unpacked_ref() == &*rhs.unpacked_ref()
+        *self.unpacked_ref() == *rhs.unpacked_ref()
     }
 }
 
@@ -744,24 +744,15 @@ pub async fn boolean_pred(arg: &Value) -> Result<Vec<Value>, Condition> {
     Ok(vec![Value::from(arg.type_of() == ValueType::Boolean)])
 }
 
-/*
 #[bridge(name = "boolean=?", lib = "(base)")]
-pub async fn boolean_eq_pred(
-    a: &Gc<Value>,
-    args: &[Gc<Value>],
-) -> Result<Vec<Gc<Value>>, Condition> {
-    let a_val = &*a.read();
-
-    let result = match a_val {
-        Value::Boolean(_) => {
-            let a_bool = a_val;
-            args.iter().all(|arg| a_bool.eqv(&arg.read()))
-        }
-        _ => false,
+pub async fn boolean_eq_pred(a: &Value, args: &[Value]) -> Result<Vec<Value>, Condition> {
+    let res = if a.type_of() == ValueType::Boolean {
+        args.iter().all(|arg| arg == a)
+    } else {
+        false
     };
-    Ok(vec![Gc::new(Value::Boolean(result))])
+    Ok(vec![Value::from(res)])
 }
-*/
 
 #[bridge(name = "symbol?", lib = "(base)")]
 pub async fn symbol_pred(arg: &Value) -> Result<Vec<Value>, Condition> {

--- a/src/value.rs
+++ b/src/value.rs
@@ -460,19 +460,9 @@ impl fmt::Display for UnpackedValue {
             }
             Self::ByteVector(v) => vectors::display_vec("#u8(", v, f),
             Self::Closure(_) => write!(f, "<procedure>"),
-            /*
-            // TODO: This shouldn't be debug output.
-            Self::Syntax(syntax) => write!(f, "{:?}", syntax),
-            Self::Future(_) => write!(f, "<future>"),
-            // TODO: These two shouldn't be debug output either.
-            Self::Record(record) => write!(f, "<{record:?}>"),
-            Self::RecordType(record_type) => write!(f, "<{record_type:?}>"),
-            Self::Transformer(_) => write!(f, "<transformer>"),
-            Self::CapturedEnv(_) => write!(f, "<environment>"),
             Self::Condition(cond) => write!(f, "<{cond:?}>"),
-            // Self::ExceptionHandler(_) => write!(f, "<exception-handler>"),
-            */
-            x => todo!("{}", x.type_name()),
+            Self::Record(record) => write!(f, "<{record:?}>"),
+            Self::Syntax(syntax) => write!(f, "{:?}", syntax),
         }
     }
 }
@@ -500,12 +490,8 @@ impl fmt::Debug for UnpackedValue {
             Self::ByteVector(v) => vectors::display_vec("#u8(", v, f),
             Self::Syntax(syntax) => write!(f, "{:?}", syntax),
             Self::Closure(proc) => write!(f, "#<procedure {proc:?}>"),
-            // Self::Record(record) => write!(f, "<{record:?}>"),
-            // Self::Transformer(_) => write!(f, "<transformer>"),
-            // Self::CapturedEnv(_) => write!(f, "<environment>"),
-            // Self::Condition(cond) => write!(f, "<{cond:?}>"),
-            // Self::ExceptionHandler(_) => write!(f, "<exception-handler>"),
-            _ => todo!(),
+            Self::Condition(cond) => write!(f, "<{cond:?}>"),
+            Self::Record(record) => write!(f, "<{record:?}>"),
         }
     }
 }
@@ -645,6 +631,7 @@ impl Hash for ReflexiveValue {
             UnpackedValue::Record(r) => Gc::as_ptr(r).hash(state),
             UnpackedValue::Condition(c) => Gc::as_ptr(c).hash(state),
             // TODO: We can make this better by checking the list for equivalence reflexively.
+            // But if we do that, we need to make sure that constants cannot be set.
             UnpackedValue::Pair(p) => Gc::as_ptr(p).hash(state),
             // UnpackedValue::Cls
             _ => (),

--- a/src/value.rs
+++ b/src/value.rs
@@ -145,6 +145,24 @@ impl Value {
         ValueType::from(self.0 & TAG)
     }
 
+    pub fn type_name(&self) -> &'static str {
+        match self.type_of() {
+            ValueType::Undefined => "undefined",
+            ValueType::Null => "null",
+            ValueType::Boolean => "bool",
+            ValueType::Number => "number",
+            ValueType::Character => "character",
+            ValueType::String => "string",
+            ValueType::Symbol => "symbol",
+            ValueType::Pair => "pair",
+            ValueType::Vector => "vector",
+            ValueType::ByteVector => "byte vector",
+            ValueType::Syntax => "syntax",
+            ValueType::Closure => "procedure",
+            _ => "record",
+        }
+    }
+
     pub fn unpack(self) -> UnpackedValue {
         let raw = ManuallyDrop::new(self).0;
         let tag = ValueType::from(raw & TAG);
@@ -641,21 +659,25 @@ impl Hash for ReflexiveValue {
             UnpackedValue::Number(n) => ReflexiveNumber(n.clone()).hash(state),
             UnpackedValue::String(s) => s.hash(state),
             UnpackedValue::Symbol(s) => s.hash(state),
+            /*
             UnpackedValue::Vector(v) => {
                 let v_read = v.read();
                 for val in v_read.as_ref().iter() {
                     ReflexiveValue(val.clone()).hash(state);
                 }
             }
+            */
             UnpackedValue::ByteVector(v) => v.hash(state),
             UnpackedValue::Syntax(s) => Arc::as_ptr(s).hash(state),
             UnpackedValue::Closure(c) => Gc::as_ptr(c).hash(state),
             UnpackedValue::Record(r) => Gc::as_ptr(r).hash(state),
             UnpackedValue::Condition(c) => Gc::as_ptr(c).hash(state),
             UnpackedValue::OtherData(o) => Gc::as_ptr(o).hash(state),
-            // TODO: We can make this better by checking the list for equivalence reflexively.
-            // But if we do that, we need to make sure that constants cannot be set.
+            // TODO: We can make this better by checking the vectors and list
+            // for equivalence reflexively. But if we do that, we need to make
+            // sure that constants cannot be set.
             UnpackedValue::Pair(p) => Gc::as_ptr(p).hash(state),
+            UnpackedValue::Vector(v) => Gc::as_ptr(v).hash(state),
         }
     }
 }
@@ -674,7 +696,10 @@ impl PartialEq for ReflexiveValue {
             (UnpackedValue::Character(a), UnpackedValue::Character(b)) => a == b,
             (UnpackedValue::String(a), UnpackedValue::String(b)) => a == b,
             (UnpackedValue::Symbol(a), UnpackedValue::Symbol(b)) => a == b,
+            // See comment above in hash function
             (UnpackedValue::Pair(a), UnpackedValue::Pair(b)) => Gc::ptr_eq(a, b),
+            (UnpackedValue::Vector(a), UnpackedValue::Vector(b)) => Gc::ptr_eq(a, b),
+            /*
             (UnpackedValue::Vector(a), UnpackedValue::Vector(b)) => {
                 let a_read = a.read();
                 let b_read = b.read();
@@ -685,6 +710,7 @@ impl PartialEq for ReflexiveValue {
                         .zip(b_read.as_ref().iter())
                         .any(|(l, r)| ReflexiveValue(l.clone()) != ReflexiveValue(r.clone()))
             }
+            */
             (UnpackedValue::ByteVector(a), UnpackedValue::ByteVector(b)) => a == b,
             (UnpackedValue::Syntax(a), UnpackedValue::Syntax(b)) => Arc::ptr_eq(a, b),
             (UnpackedValue::Closure(a), UnpackedValue::Closure(b)) => Gc::ptr_eq(a, b),
@@ -697,372 +723,6 @@ impl PartialEq for ReflexiveValue {
 }
 
 impl Eq for ReflexiveValue {}
-
-/*
-/// A Scheme value
-#[derive(Trace)]
-pub enum Value {
-    /// The value is undefined. Variables before they are initialized are undefined.
-    /// Any attempt to set a variable after creation to undefined results in an error.
-    Undefined,
-    /// An empty list:
-    Null,
-    /// Combination of two values. Has a head (car) and a tail (cdr):
-    Pair(Gc<Value>, Gc<Value>),
-    /// Value that is either True (#t) or False (#f):
-    Boolean(bool),
-    /// Numeric value:
-    Number(Number),
-    /// Unicode code point:
-    Character(char),
-    /// Vector of unicode code points:
-    String(String),
-    /// Atom of an S-Expression:
-    Symbol(String),
-    /// Vector of values:
-    Vector(Vec<Value>),
-    /// Vector of bytes:
-    ByteVector(Vec<u8>),
-    /// A wrapped syntax object:
-    Syntax(Syntax),
-    /// A procedure:
-    Closure(Closure),
-    /// A collection of named values:
-    Record(Record),
-    /// The type of a collection of named values:
-    RecordType(()),
-    /// A condition (which is also a type of record):
-    Condition(Condition),
-    /// A value that will exist in the future:
-    Future(Future),
-    /// A procedure that that transforms syntax objects:
-    Transformer(Transformer),
-    /// A captured lexical environment:
-    CapturedEnv(CapturedEnv),
-}
-
-impl Value {
-    pub fn is_undefined(&self) -> bool {
-        !matches!(self, Self::Undefined)
-    }
-
-    /// #f is false, everything else is true
-    pub fn is_true(&self) -> bool {
-        !matches!(self, Self::Boolean(x) if !x)
-    }
-
-    pub fn is_variable_transformer(&self) -> bool {
-        /*
-        match self {
-            Self::Procedure(ref proc) => proc.is_variable_transformer,
-            // Self::Transformer(ref trans) => trans.is_variable_transformer,
-            _ => false,
-        }
-         */
-        todo!()
-    }
-
-    pub fn from_literal(literal: &ast::Literal) -> Self {
-        match literal {
-            ast::Literal::Number(n) => Value::Number(n.clone()),
-            ast::Literal::Boolean(b) => Value::Boolean(*b),
-            ast::Literal::String(s) => Value::String(s.clone()),
-            ast::Literal::Character(c) => Value::Character(*c),
-            _ => todo!("Literal evaluation not implemented"),
-        }
-    }
-
-    pub fn from_syntax(syntax: &Syntax) -> Self {
-        match syntax {
-            Syntax::Null { .. } => Self::Null,
-            Syntax::List { list, .. } => {
-                let mut curr = Self::from_syntax(list.last().unwrap());
-                for item in list[..list.len() - 1].iter().rev() {
-                    curr = Self::Pair(Gc::new(Self::from_syntax(item)), Gc::new(curr));
-                }
-                curr
-            }
-            Syntax::Vector { vector, .. } => {
-                Self::Vector(vector.iter().map(Self::from_syntax).collect())
-            }
-            Syntax::ByteVector { vector, .. } => Self::ByteVector(vector.clone()),
-            Syntax::Literal { literal, .. } => Self::from_literal(literal),
-            Syntax::Identifier { ident, .. } => Self::Symbol(ident.name.clone()),
-        }
-    }
-
-    pub fn type_name(&self) -> &'static str {
-        match self {
-            Self::Boolean(_) => "bool",
-            Self::Number(_) => "number",
-            Self::Character(_) => "character",
-            Self::String(_) => "string",
-            Self::Symbol(_) => "symbol",
-            Self::Pair(_, _) | Self::Null => "pair",
-            Self::Vector(_) => "vector",
-            Self::ByteVector(_) => "byte vector",
-            Self::Syntax(_) => "syntax",
-            Self::Closure(_) => "procedure",
-            Self::Future(_) => "future",
-            Self::Record(_) | Self::Condition(_) => "record",
-            Self::RecordType(_) => "record-type",
-            Self::Undefined => "undefined",
-            Self::Transformer(_) => "transformer",
-            Self::CapturedEnv(_) => "captured-env",
-            // Self::ExceptionHandler(_) => "exception-handler",
-        }
-    }
-
-    pub fn eqv(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Null, Self::Null) => true,
-            (Self::Boolean(a), Self::Boolean(b)) => a == b,
-            (Self::Number(a), Self::Number(b)) => a == b,
-            (Self::Character(a), Self::Character(b)) => a == b,
-            (Self::Symbol(a), Self::Symbol(b)) => a == b,
-            (Self::Pair(a1, a2), Self::Pair(b1, b2)) => eqv(a1, b1) && eqv(a2, b2),
-            (Self::Vector(a), Self::Vector(b)) => {
-                a.len() == b.len() && !a.iter().zip(b.iter()).any(|(l, r)| !l.eqv(r))
-            }
-            (Self::ByteVector(a), Self::ByteVector(b)) => a == b,
-            (Self::String(a), Self::String(b)) => a == b,
-            // TODO: Syntax
-            _ => false,
-        }
-    }
-}
-
-impl Clone for Value {
-    fn clone(&self) -> Self {
-        match self {
-            Self::Null => Self::Null,
-            Self::Boolean(b) => Self::Boolean(*b),
-            Self::Number(n) => Self::Number(n.clone()),
-            Self::Character(c) => Self::Character(*c),
-            Self::String(s) => Self::String(s.clone()),
-            Self::Symbol(s) => Self::Symbol(s.clone()),
-            Self::Pair(car, cdr) => {
-                Self::Pair(Gc::new(car.read().clone()), Gc::new(cdr.read().clone()))
-            }
-            Self::Vector(vec) => Self::Vector(vec.clone()),
-            Self::ByteVector(bvec) => Self::ByteVector(bvec.clone()),
-            Self::Syntax(syn) => Self::Syntax(syn.clone()),
-            Self::Closure(proc) => Self::Closure(proc.clone()),
-            Self::Future(fut) => Self::Future(fut.clone()),
-            Self::Record(record) => Self::Record(record.clone()),
-            Self::RecordType(rt) => Self::RecordType(rt.clone()),
-            Self::Undefined => Self::Undefined,
-            Self::Transformer(trans) => Self::Transformer(trans.clone()),
-            Self::CapturedEnv(cap) => Self::CapturedEnv(cap.clone()),
-            Self::Condition(cond) => Self::Condition(cond.clone()),
-            // Self::ExceptionHandler(eh) => Self::ExceptionHandler(eh.clone()),
-        }
-    }
-}
-
-impl fmt::Display for Value {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Boolean(true) => write!(f, "#t"),
-            Self::Boolean(false) => write!(f, "#f"),
-            Self::Number(number) => write!(f, "{number}"),
-            Self::String(string) => write!(f, "{string}"),
-            Self::Symbol(symbol) => write!(f, "{symbol}"),
-            Self::Pair(car, cdr) => crate::lists::display_list(car, cdr, f),
-            Self::Vector(v) => display_vec("#(", v, f),
-            Self::Null => write!(f, "()"),
-            Self::Character(c) => write!(f, "#\\{c}"),
-            Self::ByteVector(v) => display_vec("#u8(", v, f),
-            // TODO: This shouldn't be debug output.
-            Self::Syntax(syntax) => write!(f, "{:?}", syntax),
-            Self::Closure(_) => write!(f, "<procedure>"),
-            Self::Future(_) => write!(f, "<future>"),
-            // TODO: These two shouldn't be debug output either.
-            Self::Record(record) => write!(f, "<{record:?}>"),
-            Self::RecordType(record_type) => write!(f, "<{record_type:?}>"),
-            Self::Undefined => write!(f, "<undefined>"),
-            Self::Transformer(_) => write!(f, "<transformer>"),
-            Self::CapturedEnv(_) => write!(f, "<environment>"),
-            Self::Condition(cond) => write!(f, "<{cond:?}>"),
-            // Self::ExceptionHandler(_) => write!(f, "<exception-handler>"),
-        }
-    }
-}
-
-impl fmt::Debug for Value {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Boolean(true) => write!(f, "#t"),
-            Self::Boolean(false) => write!(f, "#f"),
-            Self::Number(number) => write!(f, "{number:?}"),
-            Self::String(string) => write!(f, "{string:?}"),
-            Self::Symbol(symbol) => write!(f, "{symbol}"),
-            Self::Pair(car, cdr) => crate::lists::debug_list(car, cdr, f),
-            Self::Vector(v) => display_vec("#(", v, f),
-            Self::Null => write!(f, "()"),
-            Self::Character(c) => write!(f, "#\\{c}"),
-            Self::ByteVector(v) => display_vec("#u8(", v, f),
-            Self::Syntax(syntax) => write!(f, "{:?}", syntax),
-            Self::Closure(proc) => write!(f, "#<procedure {proc:?}>"),
-            Self::Future(_) => write!(f, "<future>"),
-            Self::Record(record) => write!(f, "<{record:?}>"),
-            Self::RecordType(record_type) => write!(f, "<{record_type:?}>"),
-            Self::Undefined => write!(f, "<undefined>"),
-            Self::Transformer(_) => write!(f, "<transformer>"),
-            Self::CapturedEnv(_) => write!(f, "<environment>"),
-            Self::Condition(cond) => write!(f, "<{cond:?}>"),
-            // Self::ExceptionHandler(_) => write!(f, "<exception-handler>"),
-        }
-    }
-}
-*/
-
-/*
-impl From<bool> for Value {
-    fn from(b: bool) -> Value {
-        Value::Boolean(b)
-    }
-}
-
-impl From<Condition> for Gc<Value> {
-    fn from(cond: Condition) -> Gc<Value> {
-        Gc::new(Value::Condition(cond))
-    }
-}
-*/
-
-/*
-
-/// Create a proper list from a vector of values
-impl From<Vec<Gc<Value>>> for Value {
-    fn from(mut vec: Vec<Gc<Value>>) -> Value {
-        if vec.is_empty() {
-            Value::Null
-        } else {
-            // I'm not spending too much time thinking about a better way to do this
-            let tail = vec.split_off(1);
-            Value::Pair(vec.pop().unwrap(), Gc::new(Value::from(tail)))
-        }
-    }
-}
-
-impl TryFrom<Value> for (Gc<Value>, Gc<Value>) {
-    type Error = Condition;
-
-    fn try_from(v: Value) -> Result<(Gc<Value>, Gc<Value>), Self::Error> {
-        match v {
-            Value::Pair(head, tail) => Ok((head, tail)),
-            e => Err(Condition::invalid_type("pair", e.type_name())),
-        }
-    }
-}
-
-impl<'a> TryFrom<&'a Value> for (Gc<Value>, Gc<Value>) {
-    type Error = Condition;
-
-    fn try_from(v: &'a Value) -> Result<(Gc<Value>, Gc<Value>), Self::Error> {
-        match v {
-            Value::Pair(head, tail) => Ok((head.clone(), tail.clone())),
-            e => Err(Condition::invalid_type("pair", e.type_name())),
-        }
-    }
-}
-
-impl TryFrom<Gc<Value>> for Closure {
-    type Error = Condition;
-
-    fn try_from(v: Gc<Value>) -> Result<Self, Self::Error> {
-        let read = v.read();
-        match &*read {
-            Value::Closure(clos) => Ok(clos.clone()),
-            e => Err(Condition::invalid_type("procedure", e.type_name())),
-        }
-    }
-}
-
-impl TryFrom<Gc<Value>> for Vec<Value> {
-    type Error = Condition;
-
-    fn try_from(v: Gc<Value>) -> Result<Self, Self::Error> {
-        let read = v.read();
-        match &*read {
-            Value::Vector(vec) => Ok(vec.clone()),
-            e => Err(Condition::invalid_type("procedure", e.type_name())),
-        }
-    }
-}
-
-macro_rules! impl_try_from_value_for {
-    ($ty:ty, $enum_variant:ident, $type_name:literal) => {
-        impl TryFrom<Value> for $ty {
-            type Error = Condition;
-
-            fn try_from(v: Value) -> Result<$ty, Self::Error> {
-                match v {
-                    Value::$enum_variant(i) => Ok(i),
-                    e => Err(Condition::invalid_type($type_name, e.type_name())),
-                }
-            }
-        }
-
-        impl<'a> TryFrom<&'a mut Value> for &'a mut $ty {
-            type Error = Condition;
-
-            fn try_from(v: &'a mut Value) -> Result<&'a mut $ty, Self::Error> {
-                match v {
-                    Value::$enum_variant(i) => Ok(i),
-                    e => Err(Condition::invalid_type($type_name, e.type_name())),
-                }
-            }
-        }
-
-        impl<'a> TryFrom<&'a Value> for &'a $ty {
-            type Error = Condition;
-
-            fn try_from(v: &'a Value) -> Result<&'a $ty, Self::Error> {
-                match v {
-                    Value::$enum_variant(i) => Ok(i),
-                    e => Err(Condition::invalid_type($type_name, e.type_name())),
-                }
-            }
-        }
-    };
-
-    ($ty:ty, $enum_variant:ident, $type_name:literal, copy) => {
-        impl_try_from_value_for!($ty, $enum_variant, $type_name);
-
-        impl TryFrom<&Value> for $ty {
-            type Error = Condition;
-            fn try_from(v: &Value) -> Result<$ty, Self::Error> {
-                match v {
-                    Value::$enum_variant(i) => Ok(*i),
-                    e => Err(Condition::invalid_type($type_name, e.type_name())),
-                }
-            }
-        }
-    };
-}
-
-impl_try_from_value_for!(bool, Boolean, "bool", copy);
-impl_try_from_value_for!(Number, Number, "number");
-impl_try_from_value_for!(Closure, Closure, "procedure");
-impl_try_from_value_for!(Record, Record, "record");
-impl_try_from_value_for!(Gc<RecordType>, RecordType, "record-type");
-impl_try_from_value_for!(Transformer, Transformer, "transformer");
-impl_try_from_value_for!(CapturedEnv, CapturedEnv, "environment");
-impl_try_from_value_for!(Syntax, Syntax, "syntax");
-impl_try_from_value_for!(Vec<Value>, Vector, "vector");
-impl_try_from_value_for!(char, Character, "char", copy);
-impl_try_from_value_for!(String, String, "string");
-*/
-
-/*
-pub fn eqv(a: &Gc<Value>, b: &Gc<Value>) -> bool {
-    let a = a.read();
-    let b = b.read();
-    a.eqv(&b)
-}
-*/
 
 #[bridge(name = "not", lib = "(base)")]
 pub async fn not(a: &Value) -> Result<Vec<Value>, Condition> {

--- a/src/vectors.rs
+++ b/src/vectors.rs
@@ -7,13 +7,43 @@ use crate::{
     value::Value,
 };
 use malachite::Integer;
-use std::{clone::Clone, ops::Range};
+use std::{clone::Clone, ops::{Deref, DerefMut, Range}, fmt};
 
 /// A vector aligned to 16 bytes.
 #[derive(Trace)]
 #[repr(align(16))]
 pub struct AlignedVector<T: Trace>(pub Vec<T>);
 
+
+impl<T: Trace> Deref for AlignedVector<T> {
+    type Target = Vec<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+
+fn display_vec<T: fmt::Display>(
+    head: &str,
+    v: &[T],
+    f: &mut fmt::Formatter<'_>,
+) -> Result<(), fmt::Error> {
+    write!(f, "{}", head)?;
+
+    let mut iter = v.iter().peekable();
+    while let Some(next) = iter.next() {
+        write!(f, "{}", next)?;
+        if iter.peek().is_some() {
+            write!(f, " ")?;
+        }
+    }
+
+    write!(f, ")")
+}
+
+
+/*
 fn try_make_range(start: usize, end: usize) -> Result<Range<usize>, Condition> {
     if end < start {
         Err(Condition::error(format!(
@@ -73,6 +103,7 @@ impl Indexer for StringIndexer {
         val.try_into()
     }
 }
+
 struct VectorIndexer;
 impl Indexer for VectorIndexer {
     type Collection = Vec<Value>;
@@ -91,7 +122,9 @@ impl Indexer for VectorIndexer {
         val.try_into()
     }
 }
+*/
 
+/*
 #[bridge(name = "make-vector", lib = "(base)")]
 pub async fn make_vector(n: &Gc<Value>, with: &[Gc<Value>]) -> Result<Vec<Gc<Value>>, Condition> {
     let n = n.read();
@@ -304,3 +337,4 @@ pub async fn vector_fill(
 
     Ok(vec![])
 }
+*/

--- a/src/vectors.rs
+++ b/src/vectors.rs
@@ -7,13 +7,22 @@ use crate::{
     value::Value,
 };
 use malachite::Integer;
-use std::{clone::Clone, ops::{Deref, DerefMut, Range}, fmt};
+use std::{
+    clone::Clone,
+    fmt,
+    ops::{Deref, DerefMut, Range},
+};
 
 /// A vector aligned to 16 bytes.
 #[derive(Trace)]
 #[repr(align(16))]
 pub struct AlignedVector<T: Trace>(pub Vec<T>);
 
+impl<T: Trace> AlignedVector<T> {
+    pub fn new(v: Vec<T>) -> Self {
+        Self(v)
+    }
+}
 
 impl<T: Trace> Deref for AlignedVector<T> {
     type Target = Vec<T>;
@@ -23,8 +32,19 @@ impl<T: Trace> Deref for AlignedVector<T> {
     }
 }
 
+impl<T: Trace> DerefMut for AlignedVector<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
 
-fn display_vec<T: fmt::Display>(
+impl<T: Trace + PartialEq> PartialEq for AlignedVector<T> {
+    fn eq(&self, rhs: &Self) -> bool {
+        self.0 == rhs.0
+    }
+}
+
+pub fn display_vec<T: fmt::Display>(
     head: &str,
     v: &[T],
     f: &mut fmt::Formatter<'_>,
@@ -41,7 +61,6 @@ fn display_vec<T: fmt::Display>(
 
     write!(f, ")")
 }
-
 
 /*
 fn try_make_range(start: usize, end: usize) -> Result<Range<usize>, Condition> {

--- a/src/vectors.rs
+++ b/src/vectors.rs
@@ -1,6 +1,6 @@
 use crate::{
     exception::Condition,
-    gc::Gc,
+    gc::{Gc, Trace},
     lists::slice_to_list,
     num::{Number, NumberToUsizeError},
     registry::bridge,
@@ -8,6 +8,11 @@ use crate::{
 };
 use malachite::Integer;
 use std::{clone::Clone, ops::Range};
+
+/// A vector aligned to 16 bytes.
+#[derive(Trace)]
+#[repr(align(16))]
+pub struct AlignedVector<T: Trace>(pub Vec<T>);
 
 fn try_make_range(start: usize, end: usize) -> Result<Range<usize>, Condition> {
     if end < start {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -59,8 +59,8 @@ impl TestRuntime {
 }
 
 #[bridge(name = "assert-eq", lib = "(base)")]
-pub async fn test_assert(arg1: &Gc<Value>, arg2: &Gc<Value>) -> Result<Vec<Gc<Value>>, Condition> {
-    if !eqv(arg1, arg2) {
+pub async fn test_assert(arg1: &Value, arg2: &Value) -> Result<Vec<Value>, Condition> {
+    if arg1 != arg2 {
         let arg1 = format!("{arg1:?}");
         let arg2 = format!("{arg2:?}");
         Err(Condition::assert_eq_failed(&arg2, &arg1))
@@ -79,11 +79,7 @@ macro_rules! assert_file {
                 Some(concat!(stringify!($name), ".scm")),
             )
             .unwrap();
-            assert!(rt
-                .exec_syn(&sexprs)
-                .await
-                .inspect_err(|e| eprintln!("{}", e))
-                .is_ok());
+            rt.exec_syn(&sexprs).await.unwrap();
         }
     };
 }


### PR DESCRIPTION
This PR moves from a giant enum Value type into a tagged pointer/unpacked value representation.
There's a couple of reasons for this:
- It should be much more performant, ensuring that the value types are a single u64 in size means that less space is wasted and it is easier to move values.
   - Additionally, types that do not need to be Gc'd (i.e. they have no way of cyclically referencing data) are moved into Arcs to ensure much faster drops. 
- This representation is actually more correct; all values that need to be are not behind a box, meaning that a cell's value can be changed without the underlying value being modified. 
   - To this end, we will add a constants pool to the runtime to allow for the underlying values to be stored as raw u64s constants in the codegened functions, while having them be properly freed when the runtime drops. 