### PR TITLE
Implement basic form of escape analysis for arguments

### DIFF
--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -729,7 +729,7 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
         let env_type = ptr_type.array_type(env.len() as u32);
         let env_alloca = self.builder.build_alloca(env_type, "env_alloca")?;
 
-        for (i, var) in env.iter().enumerate() {
+        for (i, env_var) in env.iter().enumerate() {
             let ep = unsafe {
                 self.builder.build_gep(
                     ptr_type,
@@ -738,9 +738,13 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
                     "alloca_elem",
                 )?
             };
-            let Value::Var(var) = var else { unreachable!() };
+            let Value::Var(var) = env_var else {
+                unreachable!()
+            };
             let val = self.fetch_bind_or_undefined(var)?;
-            assert!(val.is_pointer_value());
+            if !val.is_pointer_value() {
+                panic!("{env_var:?} is not a pointer");
+            }
             self.builder.build_store(ep, val)?;
         }
 
@@ -797,7 +801,7 @@ impl<'ctx, 'b> CompilationUnit<'ctx, 'b> {
             if !val.is_pointer_value() {
                 panic!("{env_var:?} is not a pointer");
             }
-                // assert!(val.is_pointer_value());
+            // assert!(val.is_pointer_value());
             self.builder.build_store(ep, val)?;
         }
 

--- a/src/cps/mod.rs
+++ b/src/cps/mod.rs
@@ -150,6 +150,10 @@ impl ClosureArgs {
         }
     }
 
+    fn iter_mut(&mut self) -> impl Iterator<Item = &mut Local> {
+        self.args.iter_mut().chain(self.continuation.as_mut())
+    }
+
     fn to_vec(&self) -> Vec<Local> {
         self.args
             .clone()
@@ -172,7 +176,7 @@ pub enum Cps {
     App(Value, Vec<Value>, Option<CallSiteId>),
 
     /// Forward a list of values into an application.
-    // TODO: I'm not sure I like this name
+    // TODO: I think we can get rid of this with better primitive operators, maybe.
     Forward(Value, Value),
 
     /// Branching.

--- a/src/cps/reduce.rs
+++ b/src/cps/reduce.rs
@@ -110,16 +110,15 @@ impl Cps {
 
     /// Removes any closures and allocated cells that are left unused.
     #[allow(dead_code)]
-    fn dead_code_elimination(
-        self,
-        uses_cache: &mut HashMap<Local, HashMap<Local, usize>>,
-    ) -> Self {
+    fn dead_code_elimination(self, uses_cache: &mut HashMap<Local, HashMap<Local, usize>>) -> Self {
         match self {
             Cps::Closure { val, cexp, .. } if !cexp.uses(uses_cache).contains_key(&val) => {
                 // Unused closure can be eliminated
                 cexp.dead_code_elimination(uses_cache)
             }
-            Cps::PrimOp(PrimOp::AllocCell, _, result, cexp) if !cexp.uses(uses_cache).contains_key(&result) => {
+            Cps::PrimOp(PrimOp::AllocCell, _, result, cexp)
+                if !cexp.uses(uses_cache).contains_key(&result) =>
+            {
                 cexp.dead_code_elimination(uses_cache)
             }
             Cps::PrimOp(prim_op, values, result, cexp) => Cps::PrimOp(
@@ -138,7 +137,7 @@ impl Cps {
                 body,
                 val,
                 cexp,
-                debug
+                debug,
             } => Cps::Closure {
                 args,
                 body: Box::new(body.dead_code_elimination(uses_cache)),

--- a/src/cps/reduce.rs
+++ b/src/cps/reduce.rs
@@ -8,6 +8,7 @@ impl Cps {
         // Perform beta reduction twice. This seems like the sweet spot for now
         self.beta_reduction(&mut HashMap::default())
             .beta_reduction(&mut HashMap::default())
+            .dead_code_elimination(&mut HashMap::default())
     }
 
     /// Beta-reduction optimization step. This function replaces applications to
@@ -107,7 +108,6 @@ impl Cps {
         true
     }
 
-    /*
     /// Removes any closures and allocated cells that are left unused.
     #[allow(dead_code)]
     fn dead_code_elimination(
@@ -117,6 +117,9 @@ impl Cps {
         match self {
             Cps::Closure { val, cexp, .. } if !cexp.uses(uses_cache).contains_key(&val) => {
                 // Unused closure can be eliminated
+                cexp.dead_code_elimination(uses_cache)
+            }
+            Cps::PrimOp(PrimOp::AllocCell, _, result, cexp) if !cexp.uses(uses_cache).contains_key(&result) => {
                 cexp.dead_code_elimination(uses_cache)
             }
             Cps::PrimOp(prim_op, values, result, cexp) => Cps::PrimOp(
@@ -146,5 +149,4 @@ impl Cps {
             cexp => cexp,
         }
     }
-    */
 }

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -88,6 +88,7 @@ impl Condition {
     }
 
     pub fn invalid_type(expected: &str, provided: &str) -> Self {
+        // panic!();
         Self::error(format!(
             "Expected value of type {expected}, provided {provided}"
         ))
@@ -313,7 +314,7 @@ unsafe extern "C" fn reraise_exception(
     runtime: *mut GcInner<Runtime>,
     env: *const *mut GcInner<Value>,
     _globals: *const *mut GcInner<Value>,
-    _args: *const *mut GcInner<Value>,
+    _args: *const Value,
     exception_handler: *mut GcInner<ExceptionHandler>,
     dynamic_wind: *const DynamicWind,
 ) -> *mut Result<Application, Condition> {

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -446,7 +446,7 @@ pub fn call_transformer<'a>(
             panic!("wrong args");
         };
 
-        let cont: Gc<Closure> = cont.clone().try_into()?;
+        let cont: Gc<Closure> = cont.clone().try_into().expect("huh");
 
         // Fetch a runtime from the continuation. It doesn't really matter
         // _which_ runtime we use, in fact we could create a new one, but it

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -192,6 +192,7 @@ impl Registry {
     pub async fn new(runtime: &Gc<Runtime>) -> Self {
         let mut libs = HashMap::<LibraryName, Gc<Top>>::default();
 
+        
         for bridge_fn in inventory::iter::<BridgeFn>() {
             let debug_info_id = runtime.write().debug_info.new_function_debug_info(
                 crate::proc::FunctionDebugInfo::from_bridge_fn(

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -192,7 +192,6 @@ impl Registry {
     pub async fn new(runtime: &Gc<Runtime>) -> Self {
         let mut libs = HashMap::<LibraryName, Gc<Top>>::default();
 
-        
         for bridge_fn in inventory::iter::<BridgeFn>() {
             let debug_info_id = runtime.write().debug_info.new_function_debug_info(
                 crate::proc::FunctionDebugInfo::from_bridge_fn(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -711,7 +711,7 @@ unsafe extern "C" fn call_thunks(
     runtime: *mut GcInner<Runtime>,
     env: *const *mut GcInner<Value>,
     _globals: *const *mut GcInner<Value>,
-    args: *const *mut GcInner<Value>,
+    args: *const Value,
     exception_handler: *mut GcInner<ExceptionHandler>,
     dynamic_wind: *const DynamicWind,
 ) -> *mut Result<Application, Condition> {
@@ -730,18 +730,14 @@ unsafe extern "C" fn call_thunks(
         let num_args = k_read.num_required_args;
 
         let mut collected_args = if k_read.variadic {
-            let var_arg = Gc::from_raw_inc_rc(args.add(num_args).read());
-            let var_read = var_arg.read();
-            var_read.clone()
-            // Value::from_raw_inc_rc( as u64)
+            args.add(num_args).as_ref().unwrap().clone()
         } else {
             Value::null()
         };
 
         for i in (0..num_args).rev() {
-            let arg = Gc::from_raw_inc_rc(args.add(i).read());
-            let arg_read = arg.read();
-            collected_args = Value::from((arg_read.clone(), collected_args));
+            let arg = args.add(i).as_ref().unwrap().clone();
+            collected_args = Value::from((arg, collected_args));
         }
 
         collected_args
@@ -772,7 +768,7 @@ unsafe extern "C" fn call_thunks_pass_args(
     runtime: *mut GcInner<Runtime>,
     env: *const *mut GcInner<Value>,
     _globals: *const *mut GcInner<Value>,
-    _args: *const *mut GcInner<Value>,
+    _args: *const Value,
     exception_handler: *mut GcInner<ExceptionHandler>,
     dynamic_wind: *const DynamicWind,
 ) -> *mut Result<Application, Condition> {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -211,15 +211,15 @@ fn install_runtime<'ctx>(ctx: &'ctx Context, module: &Module<'ctx>, ee: &Executi
     let f = module.add_function("read_cell", sig, None);
     ee.add_global_mapping(&f, read_cell as usize);
 
-    // drop_cells:
-    let sig = void_type.fn_type(&[ptr_type.into(), i32_type.into()], false);
-    let f = module.add_function("drop_cells", sig, None);
-    ee.add_global_mapping(&f, drop_cells as usize);
+    // dropc:
+    let sig = void_type.fn_type(&[ptr_type.into()], false);
+    let f = module.add_function("dropc", sig, None);
+    ee.add_global_mapping(&f, dropc as usize);
 
-    // drop_values:
-    let sig = void_type.fn_type(&[ptr_type.into(), i32_type.into()], false);
-    let f = module.add_function("drop_values", sig, None);
-    ee.add_global_mapping(&f, drop_values as usize);
+    // dropv:
+    let sig = void_type.fn_type(&[i64_type.into()], false);
+    let f = module.add_function("dropv", sig, None);
+    ee.add_global_mapping(&f, dropv as usize);
 
     // apply:
     let sig = ptr_type.fn_type(
@@ -376,18 +376,14 @@ unsafe extern "C" fn read_cell(cell: *mut GcInner<Value>) -> i64 {
     raw as i64
 }
 
-/// Decrement the reference count of all of the cells
-unsafe extern "C" fn drop_cells(cells: *const *mut GcInner<Value>, num_cells: u32) {
-    for i in 0..num_cells {
-        Gc::decrement_reference_count(cells.add(i as usize).read())
-    }
+/// Decrement the reference count of a cell
+unsafe extern "C" fn dropc(cell: *mut GcInner<Value>) {
+    Gc::decrement_reference_count(cell)
 }
 
-/// Decrement the reference count of all of the values
-unsafe extern "C" fn drop_values(vals: *const i64, num_vals: u32) {
-    for i in 0..num_vals {
-        drop(Value::from_raw(vals.add(i as usize).read() as u64));
-    }
+/// Decrement the reference count of a value
+unsafe extern "C" fn dropv(val: i64) {
+    drop(Value::from_raw(val as u64))
 }
 
 /// Create a boxed application

--- a/src/stdlib.scm
+++ b/src/stdlib.scm
@@ -295,6 +295,8 @@
     ((_ args n (r b1 b2 ...) more ...)
      (apply (lambda r b1 b2 ...) args))))
 
+;; This fails:
+
 (define (for-each func lst . remaining)
   (let loop ((rest lst))
     (unless (null? rest)

--- a/src/value.rs
+++ b/src/value.rs
@@ -25,6 +25,7 @@ const TAG_BITS: u64 = ALIGNMENT.ilog2() as u64;
 const TAG: u64 = 0b1111;
 
 /// A Scheme value. Represented as a tagged pointer.
+#[repr(transparent)]
 pub struct Value(u64);
 
 impl Value {

--- a/tests/r6rs.scm
+++ b/tests/r6rs.scm
@@ -385,7 +385,8 @@
                (list (f 1) (g 1))))
            '(1 1))
 
-;; Extra stuff
+;; Extra stuff:
+
 (assert-eq (let ([x 1])
              (syntax-case #'() ()
                ([] x)))
@@ -410,3 +411,6 @@
 
 (assert-eq (newfoo) 42)
 (assert-eq (newbar) 70)
+
+;; Realized this was an issue when doing escape analysis:
+(define (test a) (set! a '()))


### PR DESCRIPTION
This PR defers Cell allocation for arguments until function entry, allowing us to avoid the allocation if the cell is not part of the environment for another function. We can determine that with an extremely basic escape analysis. Basic or not, that escape analysis is extremely effective (at least for the fib benchmark):

```console
     Running benches/fib.rs (target/release/deps/fib-d4c224a781aa0fea)
fib 10000               time:   [4.9588 ms 5.0157 ms 5.0742 ms]
                        change: [-59.781% -58.675% -57.508%] (p = 0.00 < 0.05)
                        Performance has improved.
```