### PR TITLE
Remove LLVM backend in favor of Cranelift

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ repository = "https://github.com/maplant/scheme-rs"
 ahash = "0.8"
 async-trait = "0.1"
 by_address = "1.2"
+derive_builder = "0.20"
 derive_more = { version = "1.0", features = ["debug", "from"]}
 dyn-clone = "1.0.13"
 either = "1"
 futures = "0.3"
 indexmap = "2"
 inventory = "0.3"
-inkwell = { version = "0.6", features = ["llvm18-1"] }
 nom = "7"
 nom_locate = "4"
 num = "0.4"
@@ -33,6 +33,25 @@ tokio = { version = "1.41", features = ["full"] }
 unicode_categories = "0.1"
 malachite = { version = "0.5.1", features = ["floats"] }
 rustyline = { version = "15.0.0", features = ["derive"] }
+
+# LLVM dependencies
+inkwell = { version = "0.6", features = ["llvm18-1"], optional = true }
+
+# Cranelift dependencies
+cranelift = { version = "0.122", optional = true }
+cranelift-jit = { version = "0.122", optional = true }
+cranelift-native = { version = "0.122", optional = true } 
+cranelift-module = { version = "0.122", optional = true }
+ 
+[features]
+default = ["cranelift"]
+cranelift = [
+  "dep:cranelift",
+  "dep:cranelift-jit",
+  "dep:cranelift-native",
+  "dep:cranelift-module"
+]
+llvm = ["dep:inkwell"]
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,7 @@ criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
 [[bench]]
 name = "fib"
 harness = false
+
+[[bench]]
+name = "cold_boot"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,24 +34,12 @@ unicode_categories = "0.1"
 malachite = { version = "0.5.1", features = ["floats"] }
 rustyline = { version = "15.0.0", features = ["derive"] }
 
-# LLVM dependencies
-inkwell = { version = "0.6", features = ["llvm18-1"], optional = true }
-
 # Cranelift dependencies
-cranelift = { version = "0.122", optional = true }
-cranelift-jit = { version = "0.122", optional = true }
-cranelift-native = { version = "0.122", optional = true } 
-cranelift-module = { version = "0.122", optional = true }
+cranelift = "0.122"
+cranelift-jit = "0.122"
+cranelift-native = "0.122"
+cranelift-module = "0.122"
  
-[features]
-default = ["cranelift"]
-cranelift = [
-  "dep:cranelift",
-  "dep:cranelift-jit",
-  "dep:cranelift-native",
-  "dep:cranelift-module"
-]
-llvm = ["dep:inkwell"]
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ homepage = "https://github.com/maplant/scheme-rs"
 repository = "https://github.com/maplant/scheme-rs"
 
 [dependencies]
+ahash = "0.8"
 async-trait = "0.1"
 by_address = "1.2"
 derive_more = { version = "1.0", features = ["debug", "from"]}

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ That is obviously a long way away.
 ## Implementation details:
 
 `scheme-rs` is JIT compiled, compiling the expanded Scheme code into a [CPS](https://en.wikipedia.org/wiki/Continuation-passing_style) 
-mid-level IR, and then converting that into LLVM IR. 
+mid-level IR, and then converting that into Cranelift IR.
 
 At present the code produced by `scheme-rs` is of pretty poor quality. Very few optimizations are performed, all variables 
 are boxed. Focus was spent on making this project as correct as possible, and to that end this is a JIT compiler for 

--- a/benches/cold_boot.rs
+++ b/benches/cold_boot.rs
@@ -23,12 +23,7 @@ fn cold_boot_benchmark(c: &mut Criterion) {
                 .await
                 .unwrap();
             let compiled = base.compile_top_level();
-            rt.compile_expr(compiled)
-                .await
-                .unwrap()
-                .call(&[])
-                .await
-                .unwrap();
+            rt.compile_expr(compiled).await.call(&[]).await.unwrap();
         })
     });
 }

--- a/benches/cold_boot.rs
+++ b/benches/cold_boot.rs
@@ -1,0 +1,37 @@
+use std::path::Path;
+
+use criterion::*;
+use scheme_rs::{
+    ast::DefinitionBody,
+    cps::Compile,
+    env::Environment,
+    registry::Library,
+    runtime::Runtime,
+    syntax::{Span, Syntax},
+};
+
+fn cold_boot_benchmark(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+
+    c.bench_function("cold boot", |b| {
+        b.to_async(&runtime).iter(|| async move {
+            let rt = Runtime::new();
+            let prog = Library::new_program(&rt, Path::new("in-line"));
+            let env = Environment::Top(prog);
+            let sexprs = Syntax::from_str("(import (rnrs base)) (abs -5)", None).unwrap();
+            let base = DefinitionBody::parse_lib_body(&rt, &sexprs, &env, &Span::default())
+                .await
+                .unwrap();
+            let compiled = base.compile_top_level();
+            rt.compile_expr(compiled)
+                .await
+                .unwrap()
+                .call(&[])
+                .await
+                .unwrap();
+        })
+    });
+}
+
+criterion_group!(benches, cold_boot_benchmark);
+criterion_main!(benches);

--- a/benches/fib.rs
+++ b/benches/fib.rs
@@ -22,7 +22,7 @@ async fn fib_fn() -> Closure {
         .await
         .unwrap();
     let compiled = base.compile_top_level();
-    rt.compile_expr(compiled).await.unwrap()
+    rt.compile_expr(compiled).await
 }
 
 fn fib_benchmark(c: &mut Criterion) {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -17,14 +17,12 @@ use crate::{
 };
 use either::Either;
 
+use ahash::{AHashMap, AHashSet};
 use derive_more::From;
 use futures::future::BoxFuture;
+#[cfg(feature = "llvm")]
 use inkwell::builder::BuilderError;
-use ahash::{AHashMap, AHashSet};
-use std::{
-    fmt,
-    sync::Arc,
-};
+use std::{fmt, sync::Arc};
 
 #[derive(Debug)]
 pub enum ParseAstError {
@@ -80,11 +78,13 @@ pub enum ParseAstError {
         second: Span,
     },
 
+    #[cfg(feature = "llvm")]
     BuilderError(BuilderError),
 
     RaisedValue(Value),
 }
 
+#[cfg(feature = "llvm")]
 impl From<BuilderError> for ParseAstError {
     fn from(be: BuilderError) -> Self {
         Self::BuilderError(be)
@@ -945,7 +945,7 @@ pub(super) async fn define_syntax(
     let cps_expr = expr.compile_top_level();
     let mac = runtime
         .compile_expr(cps_expr)
-        .await?
+        .await
         .call(&[])
         .await
         .map_err(|err| ParseAstError::RaisedValue(err.into()))?;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -20,8 +20,6 @@ use either::Either;
 use ahash::{AHashMap, AHashSet};
 use derive_more::From;
 use futures::future::BoxFuture;
-#[cfg(feature = "llvm")]
-use inkwell::builder::BuilderError;
 use std::{fmt, sync::Arc};
 
 #[derive(Debug)]
@@ -78,17 +76,7 @@ pub enum ParseAstError {
         second: Span,
     },
 
-    #[cfg(feature = "llvm")]
-    BuilderError(BuilderError),
-
     RaisedValue(Value),
-}
-
-#[cfg(feature = "llvm")]
-impl From<BuilderError> for ParseAstError {
-    fn from(be: BuilderError) -> Self {
-        Self::BuilderError(be)
-    }
 }
 
 impl From<Value> for ParseAstError {

--- a/src/cps/analysis.rs
+++ b/src/cps/analysis.rs
@@ -255,11 +255,21 @@ fn values_to_globals(vals: &[Value]) -> AHashSet<Global> {
     vals.iter().flat_map(|val| val.to_global()).collect()
 }
 
-fn merge_uses(mut l: AHashMap<Local, usize>, r: AHashMap<Local, usize>) -> AHashMap<Local, usize> {
-    for (local, uses) in r.into_iter() {
-        *l.entry(local).or_default() += uses;
+fn merge_uses(
+    mut l: AHashMap<Local, usize>,
+    mut r: AHashMap<Local, usize>,
+) -> AHashMap<Local, usize> {
+    if r.len() > l.len() {
+        for (local, uses) in l.into_iter() {
+            *r.entry(local).or_default() += uses;
+        }
+        r
+    } else {
+        for (local, uses) in r.into_iter() {
+            *l.entry(local).or_default() += uses;
+        }
+        l
     }
-    l
 }
 fn add_value_use(mut uses: AHashMap<Local, usize>, value: &Value) -> AHashMap<Local, usize> {
     if let Some(local) = value.to_local() {

--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -1106,7 +1106,7 @@ impl<'ctx> ClosureBundle<'ctx> {
         // TODO: These calls need to be cached and also calculated at the same time.
         let env = body
             .free_variables()
-            .difference(&args.iter().cloned().collect::<HashSet<_>>())
+            .difference(&args.iter().cloned().collect::<AHashSet<_>>())
             .cloned()
             .collect::<Vec<_>>();
         let globals = body.globals().into_iter().collect::<Vec<_>>();

--- a/src/cps/compile.rs
+++ b/src/cps/compile.rs
@@ -27,7 +27,7 @@ pub trait Compile: std::fmt::Debug {
             span: None,
         }
         .reduce()
-        .args_to_cells(&mut HashMap::default())
+        .args_to_cells(&mut AHashMap::default())
     }
 }
 
@@ -754,7 +754,7 @@ impl Compile for SyntaxQuote {
         let expanded = Local::gensym();
 
         let mut expansions_seen = IndexSet::new();
-        let mut uses = HashMap::new();
+        let mut uses = AHashMap::new();
 
         for (ident, expansion) in self.expansions.iter() {
             let (idx, _) = expansions_seen.insert_full(expansion);
@@ -929,7 +929,7 @@ impl Compile for Vec<u8> {
 
 impl Cps {
     /// Convert arguments for closures into cells if they are written to or escape.
-    fn args_to_cells(self, needs_cell_cache: &mut HashMap<Local, HashSet<Local>>) -> Self {
+    fn args_to_cells(self, needs_cell_cache: &mut AHashMap<Local, AHashSet<Local>>) -> Self {
         match self {
             Self::PrimOp(PrimOp::AllocCell, vals, local, cexpr) => Self::PrimOp(
                 PrimOp::AllocCell,
@@ -960,7 +960,7 @@ impl Cps {
                 cexp,
                 span: loc,
             } => {
-                let local_args: HashSet<_> = args.iter().copied().collect();
+                let local_args: AHashSet<_> = args.iter().copied().collect();
                 let escaping_args = body.need_cells(&local_args, needs_cell_cache);
 
                 let mut body = Box::new(body.args_to_cells(needs_cell_cache));

--- a/src/cps/mod.rs
+++ b/src/cps/mod.rs
@@ -19,15 +19,26 @@ use crate::{
     syntax::Span,
     value::Value as RuntimeValue,
 };
-use std::fmt;
 use ahash::{AHashMap, AHashSet};
+use std::fmt;
 
 mod analysis;
-mod codegen;
 mod compile;
 mod reduce;
 
 pub use compile::Compile;
+
+#[cfg(all(feature = "cranelift", feature = "llvm"))]
+compile_error!("Cannot enable LLVM and Cranelift at the same time");
+
+#[cfg(all(not(feature = "cranelift"), not(feature = "llvm")))]
+compile_error!("Must enable one of LLVM or Cranelift features");
+
+#[cfg(feature = "cranelift")]
+pub mod cranelift_codegen;
+
+#[cfg(feature = "llvm")]
+mod llvm_codegen;
 
 #[derive(Clone, PartialEq)]
 pub enum Value {

--- a/src/cps/mod.rs
+++ b/src/cps/mod.rs
@@ -19,10 +19,8 @@ use crate::{
     syntax::Span,
     value::Value as RuntimeValue,
 };
-use std::{
-    collections::{HashMap, HashSet},
-    fmt,
-};
+use std::fmt;
+use ahash::{AHashMap, AHashSet};
 
 mod analysis;
 mod codegen;
@@ -200,7 +198,7 @@ pub enum Cps {
 
 impl Cps {
     /// Perform substitutions on local variables.
-    fn substitute(&mut self, substitutions: &HashMap<Local, Value>) {
+    fn substitute(&mut self, substitutions: &AHashMap<Local, Value>) {
         match self {
             Self::PrimOp(_, args, _, cexp) => {
                 substitute_values(args, substitutions);
@@ -230,7 +228,7 @@ impl Cps {
     }
 }
 
-fn substitute_value(value: &mut Value, substitutions: &HashMap<Local, Value>) {
+fn substitute_value(value: &mut Value, substitutions: &AHashMap<Local, Value>) {
     if let Some(local) = value.to_local()
         && let Some(substitution) = substitutions.get(&local)
     {
@@ -238,7 +236,7 @@ fn substitute_value(value: &mut Value, substitutions: &HashMap<Local, Value>) {
     }
 }
 
-fn substitute_values(values: &mut [Value], substitutions: &HashMap<Local, Value>) {
+fn substitute_values(values: &mut [Value], substitutions: &AHashMap<Local, Value>) {
     values
         .iter_mut()
         .for_each(|value| substitute_value(value, substitutions))

--- a/src/cps/mod.rs
+++ b/src/cps/mod.rs
@@ -23,22 +23,11 @@ use ahash::{AHashMap, AHashSet};
 use std::fmt;
 
 mod analysis;
+pub(crate) mod codegen;
 mod compile;
 mod reduce;
 
 pub use compile::Compile;
-
-#[cfg(all(feature = "cranelift", feature = "llvm"))]
-compile_error!("Cannot enable LLVM and Cranelift at the same time");
-
-#[cfg(all(not(feature = "cranelift"), not(feature = "llvm")))]
-compile_error!("Must enable one of LLVM or Cranelift features");
-
-#[cfg(feature = "cranelift")]
-pub mod cranelift_codegen;
-
-#[cfg(feature = "llvm")]
-mod llvm_codegen;
 
 #[derive(Clone, PartialEq)]
 pub enum Value {

--- a/src/cps/reduce.rs
+++ b/src/cps/reduce.rs
@@ -84,13 +84,13 @@ impl Cps {
             }
             Cps::If(_, succ, fail) => {
                 return succ.reduce_function(func, args, func_body, uses_cache)
-                    | fail.reduce_function(func, args, func_body, uses_cache);
+                    || fail.reduce_function(func, args, func_body, uses_cache);
             }
             Cps::Lambda {
                 val, body, cexp, ..
             } => {
                 let reduced = body.reduce_function(func, args, func_body, uses_cache)
-                    | cexp.reduce_function(func, args, func_body, uses_cache);
+                    || cexp.reduce_function(func, args, func_body, uses_cache);
                 if reduced {
                     uses_cache.remove(val);
                 }

--- a/src/cps/reduce.rs
+++ b/src/cps/reduce.rs
@@ -84,13 +84,13 @@ impl Cps {
             }
             Cps::If(_, succ, fail) => {
                 return succ.reduce_function(func, args, func_body, uses_cache)
-                    || fail.reduce_function(func, args, func_body, uses_cache);
+                    | fail.reduce_function(func, args, func_body, uses_cache);
             }
             Cps::Lambda {
                 val, body, cexp, ..
             } => {
                 let reduced = body.reduce_function(func, args, func_body, uses_cache)
-                    || cexp.reduce_function(func, args, func_body, uses_cache);
+                    | cexp.reduce_function(func, args, func_body, uses_cache);
                 if reduced {
                     uses_cache.remove(val);
                 }

--- a/src/cps/reduce.rs
+++ b/src/cps/reduce.rs
@@ -111,7 +111,10 @@ impl Cps {
 
     /// Removes any closures and allocated cells that are left unused.
     #[allow(dead_code)]
-    fn dead_code_elimination(self, uses_cache: &mut AHashMap<Local, AHashMap<Local, usize>>) -> Self {
+    fn dead_code_elimination(
+        self,
+        uses_cache: &mut AHashMap<Local, AHashMap<Local, usize>>,
+    ) -> Self {
         match self {
             Cps::Lambda { val, cexp, .. } if !cexp.uses(uses_cache).contains_key(&val) => {
                 // Unused closure can be eliminated

--- a/src/cps/reduce.rs
+++ b/src/cps/reduce.rs
@@ -6,10 +6,10 @@ use super::*;
 impl Cps {
     pub(super) fn reduce(self) -> Self {
         // Perform beta reduction twice. This seems like the sweet spot for now
-        let mut uses_cache = HashMap::default();
+        let mut uses_cache = AHashMap::default();
         self.beta_reduction(&mut uses_cache)
             .beta_reduction(&mut uses_cache)
-            .dead_code_elimination(&mut HashMap::default())
+            .dead_code_elimination(&mut uses_cache)
     }
 
     /// Beta-reduction optimization step. This function replaces applications to
@@ -21,7 +21,7 @@ impl Cps {
     ///
     /// The uses analysis cache is absolutely demolished and dangerous to use by
     /// the end of this function.
-    fn beta_reduction(self, uses_cache: &mut HashMap<Local, HashMap<Local, usize>>) -> Self {
+    fn beta_reduction(self, uses_cache: &mut AHashMap<Local, AHashMap<Local, usize>>) -> Self {
         match self {
             Cps::PrimOp(prim_op, values, result, cexp) => Cps::PrimOp(
                 prim_op,
@@ -76,7 +76,7 @@ impl Cps {
         func: Local,
         args: &ClosureArgs,
         func_body: &Cps,
-        uses_cache: &mut HashMap<Local, HashMap<Local, usize>>,
+        uses_cache: &mut AHashMap<Local, AHashMap<Local, usize>>,
     ) -> bool {
         let new = match self {
             Cps::PrimOp(_, _, _, cexp) => {
@@ -97,7 +97,7 @@ impl Cps {
                 return reduced;
             }
             Cps::App(Value::Var(Var::Local(operator)), applied, _) if *operator == func => {
-                let substitutions: HashMap<_, _> =
+                let substitutions: AHashMap<_, _> =
                     args.iter().copied().zip(applied.iter().cloned()).collect();
                 let mut body = func_body.clone();
                 body.substitute(&substitutions);
@@ -111,7 +111,7 @@ impl Cps {
 
     /// Removes any closures and allocated cells that are left unused.
     #[allow(dead_code)]
-    fn dead_code_elimination(self, uses_cache: &mut HashMap<Local, HashMap<Local, usize>>) -> Self {
+    fn dead_code_elimination(self, uses_cache: &mut AHashMap<Local, AHashMap<Local, usize>>) -> Self {
         match self {
             Cps::Lambda { val, cexp, .. } if !cexp.uses(uses_cache).contains_key(&val) => {
                 // Unused closure can be eliminated

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet, hash_map::Entry},
+    collections::hash_map::Entry,
     fmt,
     hash::{Hash, Hasher},
     sync::atomic::{AtomicUsize, Ordering},
@@ -7,6 +7,7 @@ use std::{
 
 use either::Either;
 use futures::future::BoxFuture;
+use ahash::{AHashMap, AHashSet};
 
 use crate::{
     ast::{ImportSet, SpecialKeyword},
@@ -26,9 +27,9 @@ use crate::{
 #[derive(Trace)]
 pub struct LexicalContour {
     up: Environment,
-    vars: HashMap<Identifier, Local>,
-    keywords: HashMap<Identifier, Closure>,
-    imports: HashMap<Identifier, Import>,
+    vars: AHashMap<Identifier, Local>,
+    keywords: AHashMap<Identifier, Closure>,
+    imports: AHashMap<Identifier, Import>,
 }
 
 impl LexicalContour {
@@ -141,7 +142,7 @@ impl Gc<LexicalContour> {
 #[derive(Trace)]
 pub struct LetSyntaxContour {
     up: Environment,
-    keywords: HashMap<Identifier, Closure>,
+    keywords: AHashMap<Identifier, Closure>,
     recursive: bool,
 }
 
@@ -376,11 +377,11 @@ pub struct SyntaxCaseExpr {
     #[debug(skip)]
     up: Environment,
     expansions_store: Local,
-    pattern_vars: HashSet<Identifier>,
+    pattern_vars: AHashSet<Identifier>,
 }
 
 impl SyntaxCaseExpr {
-    fn new(env: &Environment, expansions_store: Local, pattern_vars: HashSet<Identifier>) -> Self {
+    fn new(env: &Environment, expansions_store: Local, pattern_vars: AHashSet<Identifier>) -> Self {
         Self {
             up: env.clone(),
             expansions_store,
@@ -624,7 +625,7 @@ impl Environment {
     pub fn new_syntax_case_expr(
         &self,
         expansions_store: Local,
-        pattern_vars: HashSet<Identifier>,
+        pattern_vars: AHashSet<Identifier>,
     ) -> Self {
         let syntax_case_expr = SyntaxCaseExpr::new(self, expansions_store, pattern_vars);
         Self::SyntaxCaseExpr(Gc::new(syntax_case_expr))

--- a/src/env.rs
+++ b/src/env.rs
@@ -5,9 +5,9 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
+use ahash::{AHashMap, AHashSet};
 use either::Either;
 use futures::future::BoxFuture;
-use ahash::{AHashMap, AHashSet};
 
 use crate::{
     ast::{ImportSet, SpecialKeyword},

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -9,12 +9,9 @@ use crate::{
     syntax::{Identifier, Span, Syntax},
     value::Value,
 };
-use scheme_rs_macros::{bridge, runtime_fn};
-use std::{
-    any::Any,
-    collections::BTreeSet,
-};
 use ahash::{AHashMap, AHashSet};
+use scheme_rs_macros::{bridge, runtime_fn};
+use std::{any::Any, collections::BTreeSet};
 
 // TODO: This code needs _a lot_ more error checking: error checking for missing
 // ellipsis, error checking for too many ellipsis. It makes debugging extremely

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -577,9 +577,10 @@ where
     }
 }
 
-unsafe impl<K> Trace for HashSet<K>
+unsafe impl<K, S> Trace for HashSet<K, S>
 where
     K: GcOrTrace,
+    S: Default + 'static 
 {
     unsafe fn visit_children(&self, visitor: unsafe fn(OpaqueGcPtr)) {
         unsafe {
@@ -598,10 +599,11 @@ where
     }
 }
 
-unsafe impl<K, V> Trace for HashMap<K, V>
+unsafe impl<K, V, S> Trace for HashMap<K, V, S>
 where
     K: GcOrTrace,
     V: GcOrTrace,
+    S: Default + 'static, 
 {
     unsafe fn visit_children(&self, visitor: unsafe fn(OpaqueGcPtr)) {
         unsafe {

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -580,7 +580,7 @@ where
 unsafe impl<K, S> Trace for HashSet<K, S>
 where
     K: GcOrTrace,
-    S: Default + 'static 
+    S: Default + 'static,
 {
     unsafe fn visit_children(&self, visitor: unsafe fn(OpaqueGcPtr)) {
         unsafe {
@@ -603,7 +603,7 @@ unsafe impl<K, V, S> Trace for HashMap<K, V, S>
 where
     K: GcOrTrace,
     V: GcOrTrace,
-    S: Default + 'static, 
+    S: Default + 'static,
 {
     unsafe fn visit_children(&self, visitor: unsafe fn(OpaqueGcPtr)) {
         unsafe {

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,7 +119,7 @@ async fn compile_and_run_str<'e>(
         let span = sexpr.span().clone();
         let expr = DefinitionBody::parse(runtime, &[sexpr], &env, &span).await?;
         let compiled = expr.compile_top_level();
-        let closure = runtime.compile_expr(compiled).await.unwrap();
+        let closure = runtime.compile_expr(compiled).await;
         let result = Application::new(closure, Vec::new(), None, DynamicWind::default(), None)
             .eval()
             .await?;

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -188,11 +188,7 @@ impl ClosureInner {
 
             let env = cells_to_vec_of_ptrs(&self.env);
             let globals = cells_to_vec_of_ptrs(&self.globals);
-
-            // let args_cells = values_to_vec_of_cells(&args);
-            // let args = cells_to_vec_of_ptrs(&args_cells);
-
-            let cont = cont.map(|v| Gc::new(v));
+            let cont = cont.map(Gc::new);
 
             // Finally: call the function pointer
             let app = match self.func {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -697,7 +697,7 @@ impl Library {
         };
         let compiled = defn_body.compile_top_level();
         let rt = { self.0.read().rt.clone() };
-        let closure = rt.compile_expr(compiled).await.unwrap();
+        let closure = rt.compile_expr(compiled).await;
         let _ = Application::new(closure, Vec::new(), None, DynamicWind::default(), None)
             .eval()
             .await?;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -200,7 +200,7 @@ fn compilation_task(mut compilation_queue_rx: mpsc::Receiver<CompilationTask>) {
         let module = context.create_module("scheme_rs");
         ExecutionEngine::link_in_mc_jit();
         let execution_engine = module
-            .create_jit_execution_engine(OptimizationLevel::default())
+            .create_jit_execution_engine(OptimizationLevel::None)
             .unwrap();
         let builder = context.create_builder();
 


### PR DESCRIPTION
This PR removes the LLVM backend in favor of Cranelift.

We don't do anything special with LLVM, and Cranelift's JIT is much, much faster. We don't see any loss in performance in benchmarks, and the cold boot benchmark (added with this PR) is about 60% faster.

Additionally, this allows for the project to be entirely built in Rust. No external libraries required.