### PR TITLE
Fancy error Display impl

### DIFF
--- a/src/err.rs
+++ b/src/err.rs
@@ -1,0 +1,9 @@
+use scheme_rs::{ast::ParseAstError, exception::Exception, lex::LexError, parse::ParseSyntaxError};
+
+#[derive(derive_more::From, Debug)]
+pub enum EvalError<'e> {
+    LexError(LexError<'e>),
+    ParseError(ParseSyntaxError<'e>),
+    ParseAstError(ParseAstError),
+    Exception(Exception),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod ast;
 pub mod character;
 pub mod cps;
 pub mod env;
+pub mod err;
 pub mod exception;
 pub mod expand;
 pub mod futures;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,10 @@ use rustyline::{
     validate::{ValidationContext, ValidationResult, Validator},
 };
 use scheme_rs::{
-    ast::{DefinitionBody, ImportSet, ParseAstError},
+    ast::{DefinitionBody, ImportSet},
     cps::Compile,
     env::Environment,
-    exception::Exception,
-    lex::LexError,
+    err::EvalError,
     parse::ParseSyntaxError,
     proc::{Application, DynamicWind},
     registry::Library,
@@ -96,14 +95,6 @@ async fn main() -> ExitCode {
     }
 
     ExitCode::SUCCESS
-}
-
-#[derive(derive_more::From, Debug)]
-pub enum EvalError<'e> {
-    LexError(LexError<'e>),
-    ParseError(ParseSyntaxError<'e>),
-    ParseAstError(ParseAstError),
-    Exception(Exception),
 }
 
 async fn compile_and_run_str<'e>(


### PR DESCRIPTION
What I have in mind:

```text
error[UndefinedVariable]: 
 -> /home/teo/programming/scheme-rs/bad.scm:3:3
 01 | (define (square n) (* n n))
 03 | (squar)
    |  ^^^^^ 'squar' is not defined
    |
    ~ note: did you mean 'square'?
  * UndefinedVariable: The variable 'test' is not bound in the current env
```

Something like this