### PR TITLE
Fix exception handling interaction with dynamic-wind

### DIFF
--- a/proc-macros/Cargo.toml
+++ b/proc-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scheme-rs-macros"
 version = "0.1.0-alpha.1"
-edition = "2021"
+edition = "2024"
 authors = ["Matthew Plant <maplant@protonmail.com>"]
 description = "Embedded scheme for the async-rust ecosystem (macros)"
 license = "MPL-2.0"

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -64,10 +64,10 @@ pub fn bridge(args: TokenStream, item: TokenStream) -> TokenStream {
         let arg_indices: Vec<_> = (0..num_args).collect();
         parse_quote! {
             pub(crate) fn #wrapper_name<'a>(
+                _env: &'a [::scheme_rs::gc::Gc<::scheme_rs::value::Value>],
                 args: &'a [::scheme_rs::value::Value],
                 rest_args: &'a [::scheme_rs::value::Value],
                 cont: &'a ::scheme_rs::value::Value,
-                _env: &'a [::scheme_rs::gc::Gc<::scheme_rs::value::Value>],
                 exception_handler: &'a Option<::scheme_rs::gc::Gc<::scheme_rs::exception::ExceptionHandler>>,
                 dynamic_wind: &'a ::scheme_rs::proc::DynamicWind,
             ) -> futures::future::BoxFuture<'a, Result<scheme_rs::proc::Application, ::scheme_rs::value::Value>> {
@@ -93,10 +93,10 @@ pub fn bridge(args: TokenStream, item: TokenStream) -> TokenStream {
         let arg_indices: Vec<_> = (0..num_args).collect();
         parse_quote! {
             pub(crate) fn #wrapper_name<'a>(
+                _env: &'a [::scheme_rs::gc::Gc<::scheme_rs::value::Value>],
                 args: &'a [::scheme_rs::value::Value],
                 rest_args: &'a [::scheme_rs::value::Value],
                 cont: &'a ::scheme_rs::value::Value,
-                _env: &'a [::scheme_rs::gc::Gc<::scheme_rs::value::Value>],
                 exception_handler: &'a Option<::scheme_rs::gc::Gc<::scheme_rs::exception::ExceptionHandler>>,
                 dynamic_wind: &'a ::scheme_rs::proc::DynamicWind,
             ) -> futures::future::BoxFuture<'a, Result<scheme_rs::proc::Application, ::scheme_rs::value::Value>> {

--- a/scheme/rnrs.sls
+++ b/scheme/rnrs.sls
@@ -1,4 +1,5 @@
 (library (rnrs (6))
   (export (import (rnrs base))
-          (import (rnrs syntax-case))))
+          (import (rnrs syntax-case))
+          (import (rnrs records procedural))))
    

--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -13,15 +13,15 @@ use crate::{
     cps::{Value as CpsValue, analysis::MaxDrops},
     proc::{ClosureInner, ContinuationPtr, FuncDebugInfo, FuncPtr},
     runtime::{DebugInfo, Runtime},
-    value::{ReflexiveValue, Value as SchemeValue},
+    value::{self, ReflexiveValue, Value as SchemeValue},
 };
 
 use super::*;
 
 #[derive(Copy, Clone, Debug)]
 enum IrValue {
-    Ptr(Value),
-    Int(Value),
+    Cell(Value),
+    Value(Value),
 }
 
 struct Rebinds {
@@ -65,6 +65,7 @@ pub(crate) struct RuntimeFunctions {
     error_no_patterns_match: FuncId,
     dropv: FuncId,
     dropc: FuncId,
+    raise_rt: FuncId,
 
     // Math primops:
     add: FuncId,
@@ -145,7 +146,7 @@ impl Cps {
                 builder
                     .ins()
                     .load(types::I64, MemFlags::new(), globals_param, (i * 8) as i32);
-            rebinds.rebind(Var::Global(global.clone()), IrValue::Ptr(var));
+            rebinds.rebind(Var::Global(global.clone()), IrValue::Cell(var));
         }
 
         let mut deferred = Vec::new();
@@ -315,8 +316,8 @@ impl<'m, 'f, 'd> CompilationUnit<'m, 'f, 'd> {
         match value {
             CpsValue::Var(var) => {
                 let cell = match *self.rebinds.fetch_bind(var) {
-                    IrValue::Ptr(cell) => cell,
-                    IrValue::Int(int) => return int,
+                    IrValue::Cell(cell) => cell,
+                    IrValue::Value(int) => return int,
                 };
 
                 let read_cell = self
@@ -354,7 +355,7 @@ impl<'m, 'f, 'd> CompilationUnit<'m, 'f, 'd> {
                 );
                 let call = self.builder.ins().call(error_unbound_variable, &[symbol]);
                 let unbound_variable_error = self.builder.inst_results(call)[0];
-                self.builder.ins().return_(&[unbound_variable_error]);
+                self.raise_codegen(unbound_variable_error);
 
                 self.builder.switch_to_block(defined_block);
                 self.builder.seal_block(defined_block);
@@ -393,7 +394,7 @@ impl<'m, 'f, 'd> CompilationUnit<'m, 'f, 'd> {
 
         let winders = self.builder.inst_results(call)[0];
         self.rebinds
-            .rebind(Var::Local(extract_to), IrValue::Int(winders));
+            .rebind(Var::Local(extract_to), IrValue::Value(winders));
         self.push_val_alloc(winders);
         self.cps_codegen(cexpr, deferred);
     }
@@ -414,7 +415,7 @@ impl<'m, 'f, 'd> CompilationUnit<'m, 'f, 'd> {
         let call = self.builder.ins().call(matches, &[pattern, expr]);
         let match_result = self.builder.inst_results(call)[0];
         self.rebinds
-            .rebind(Var::Local(binds), IrValue::Int(match_result));
+            .rebind(Var::Local(binds), IrValue::Value(match_result));
         self.push_val_alloc(match_result);
         self.cps_codegen(cexpr, deferred);
     }
@@ -461,7 +462,7 @@ impl<'m, 'f, 'd> CompilationUnit<'m, 'f, 'd> {
         );
         let expanded = self.builder.inst_results(call)[0];
         self.rebinds
-            .rebind(Var::Local(dest), IrValue::Int(expanded));
+            .rebind(Var::Local(dest), IrValue::Value(expanded));
         self.push_val_alloc(expanded);
         self.cps_codegen(cexpr, deferred);
     }
@@ -486,7 +487,7 @@ impl<'m, 'f, 'd> CompilationUnit<'m, 'f, 'd> {
             .call(prepare_continuation, &[cont, winders, dynamic_wind]);
         let prepared = self.builder.inst_results(call)[0];
         self.rebinds
-            .rebind(Var::Local(dest), IrValue::Int(prepared));
+            .rebind(Var::Local(dest), IrValue::Value(prepared));
         self.push_val_alloc(prepared);
         self.cps_codegen(cexpr, deferred);
     }
@@ -530,7 +531,6 @@ impl<'m, 'f, 'd> CompilationUnit<'m, 'f, 'd> {
 
         let error_slot = self.alloc_array(1);
         let error_addr = self.builder.ins().stack_addr(types::I64, error_slot, 0);
-
         let primop_call = self
             .builder
             .ins()
@@ -551,14 +551,15 @@ impl<'m, 'f, 'd> CompilationUnit<'m, 'f, 'd> {
         self.builder.switch_to_block(failure_block);
         self.builder.seal_block(failure_block);
 
-        let error_val = self.array_load(error_slot, 0);
+        let error_val = self.array_load(error_slot, 0);        
         self.drops_codegen();
-        self.builder.ins().return_(&[error_val]);
+        self.raise_codegen(error_val);
 
         // Otherwise continue with the correct value
         self.builder.switch_to_block(success_block);
         self.builder.seal_block(success_block);
-        self.rebinds.rebind(Var::Local(dest), IrValue::Int(result));
+        self.rebinds
+            .rebind(Var::Local(dest), IrValue::Value(result));
         self.push_val_alloc(result);
         self.cps_codegen(cexpr, deferred);
     }
@@ -571,7 +572,7 @@ impl<'m, 'f, 'd> CompilationUnit<'m, 'f, 'd> {
         );
         let call = self.builder.ins().call(error_no_patterns_match, &[]);
         let error = self.builder.inst_results(call)[0];
-        self.builder.ins().return_(&[error]);
+        self.raise_codegen(error);
     }
 
     fn alloc_cell_codegen(&mut self, var: Local, cexpr: Cps, deferred: &mut Vec<ClosureBundle>) {
@@ -580,7 +581,7 @@ impl<'m, 'f, 'd> CompilationUnit<'m, 'f, 'd> {
             .declare_func_in_func(self.runtime_funcs.alloc_cell, self.builder.func);
         let call = self.builder.ins().call(alloc_cell, &[]);
         let cell = self.builder.inst_results(call)[0];
-        self.rebinds.rebind(Var::Local(var), IrValue::Ptr(cell));
+        self.rebinds.rebind(Var::Local(var), IrValue::Cell(cell));
         self.push_cell_alloc(cell);
         self.cps_codegen(cexpr, deferred);
     }
@@ -613,6 +614,7 @@ impl<'m, 'f, 'd> CompilationUnit<'m, 'f, 'd> {
     }
 
     fn app_codegen(&mut self, operator: &CpsValue, args: &[CpsValue], loc: Option<Span>) {
+        let runtime = self.get_runtime();
         let operator = self.value_codegen(operator);
 
         // Allocate space for the args to be passed to make_application
@@ -640,6 +642,7 @@ impl<'m, 'f, 'd> CompilationUnit<'m, 'f, 'd> {
         let call = self.builder.ins().call(
             apply,
             &[
+                runtime,
                 operator,
                 args_addr,
                 args_len,
@@ -654,6 +657,7 @@ impl<'m, 'f, 'd> CompilationUnit<'m, 'f, 'd> {
     }
 
     fn forward_codegen(&mut self, operator: &CpsValue, arg: &CpsValue) {
+        let runtime = self.get_runtime();
         let operator = self.value_codegen(operator);
         let arg = self.value_codegen(arg);
         let exception_handler = self.get_exception_handler();
@@ -662,10 +666,10 @@ impl<'m, 'f, 'd> CompilationUnit<'m, 'f, 'd> {
         let forward = self
             .module
             .declare_func_in_func(self.runtime_funcs.forward, self.builder.func);
-        let call = self
-            .builder
-            .ins()
-            .call(forward, &[operator, arg, exception_handler, dynamic_wind]);
+        let call = self.builder.ins().call(
+            forward,
+            &[runtime, operator, arg, exception_handler, dynamic_wind],
+        );
         let result = self.builder.inst_results(call)[0];
         self.drops_codegen();
         self.builder.ins().return_(&[result]);
@@ -721,6 +725,21 @@ impl<'m, 'f, 'd> CompilationUnit<'m, 'f, 'd> {
         self.cps_codegen(failure, deferred);
     }
 
+    fn raise_codegen(&mut self, val: Value) {
+        let runtime = self.get_runtime();
+        let exception_handler = self.get_exception_handler();
+        let dynamic_wind = self.get_dynamic_wind();
+        let raise = self
+            .module
+            .declare_func_in_func(self.runtime_funcs.raise_rt, self.builder.func);
+        let call = self
+            .builder
+            .ins()
+            .call(raise, &[runtime, val, exception_handler, dynamic_wind]);
+        let result = self.builder.inst_results(call)[0];
+        self.builder.ins().return_(&[result]);
+    }
+
     fn store_codegen(
         &mut self,
         from: &CpsValue,
@@ -732,7 +751,7 @@ impl<'m, 'f, 'd> CompilationUnit<'m, 'f, 'd> {
         let CpsValue::Var(to) = to else {
             unreachable!()
         };
-        let IrValue::Ptr(to) = self.rebinds.fetch_bind(to) else {
+        let IrValue::Cell(to) = self.rebinds.fetch_bind(to) else {
             panic!("{to:?} is not a pointer");
         };
         let store = self
@@ -770,8 +789,8 @@ impl<'m, 'f, 'd> CompilationUnit<'m, 'f, 'd> {
         let env = self.alloc_array(bundle.env.len());
         for (i, env_var) in bundle.env.iter().enumerate() {
             let val = match *self.rebinds.fetch_bind(&Var::Local(*env_var)) {
-                IrValue::Ptr(ptr) => ptr,
-                IrValue::Int(val) => panic!("{val:?} is not a pointer"),
+                IrValue::Cell(ptr) => ptr,
+                IrValue::Value(val) => panic!("{val:?} is not a pointer"),
             };
             self.array_store(env, i, val);
         }
@@ -780,8 +799,8 @@ impl<'m, 'f, 'd> CompilationUnit<'m, 'f, 'd> {
         let globals = self.alloc_array(bundle.globals.len());
         for (i, global_var) in bundle.globals.iter().enumerate() {
             let val = match *self.rebinds.fetch_bind(&Var::Global(global_var.clone())) {
-                IrValue::Ptr(ptr) => ptr,
-                IrValue::Int(val) => panic!("{val:?} is not a pointer"),
+                IrValue::Cell(ptr) => ptr,
+                IrValue::Value(val) => panic!("{val:?} is not a pointer"),
             };
             self.array_store(globals, i, val);
         }
@@ -846,7 +865,7 @@ impl<'m, 'f, 'd> CompilationUnit<'m, 'f, 'd> {
         let call = self.builder.ins().call(make_closure, &args);
         let closure = self.builder.inst_results(call)[0];
         self.rebinds
-            .rebind(Var::Local(bundle.val), IrValue::Ptr(closure));
+            .rebind(Var::Local(bundle.val), IrValue::Cell(closure));
         self.push_cell_alloc(closure);
         self.cps_codegen(cexp, deferred);
     }
@@ -971,7 +990,7 @@ impl ClosureBundle {
             let var = builder
                 .ins()
                 .load(types::I64, MemFlags::new(), env_param, (i * 8) as i32);
-            rebinds.rebind(Var::Local(env_var), IrValue::Ptr(var));
+            rebinds.rebind(Var::Local(env_var), IrValue::Cell(var));
         }
 
         // Load globals:
@@ -981,7 +1000,7 @@ impl ClosureBundle {
                 builder
                     .ins()
                     .load(types::I64, MemFlags::new(), globals_param, (i * 8) as i32);
-            rebinds.rebind(Var::Global(global), IrValue::Ptr(var));
+            rebinds.rebind(Var::Global(global), IrValue::Cell(var));
         }
 
         // Load args:
@@ -990,13 +1009,13 @@ impl ClosureBundle {
             let var = builder
                 .ins()
                 .load(types::I64, MemFlags::new(), args_param, (i * 8) as i32);
-            rebinds.rebind(Var::Local(*arg), IrValue::Int(var));
+            rebinds.rebind(Var::Local(*arg), IrValue::Value(var));
         }
 
         // Load continuation:
         if let Some(cont) = self.args.continuation {
             let cont_param = builder.block_params(entry_block)[CONTINUATION_PARAM];
-            rebinds.rebind(Var::Local(cont), IrValue::Ptr(cont_param));
+            rebinds.rebind(Var::Local(cont), IrValue::Cell(cont_param));
         }
 
         {

--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -13,7 +13,7 @@ use crate::{
     cps::{Value as CpsValue, analysis::MaxDrops},
     proc::{ClosureInner, ContinuationPtr, FuncDebugInfo, FuncPtr},
     runtime::{DebugInfo, Runtime},
-    value::{self, ReflexiveValue, Value as SchemeValue},
+    value::{ReflexiveValue, Value as SchemeValue},
 };
 
 use super::*;

--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -551,7 +551,7 @@ impl<'m, 'f, 'd> CompilationUnit<'m, 'f, 'd> {
         self.builder.switch_to_block(failure_block);
         self.builder.seal_block(failure_block);
 
-        let error_val = self.array_load(error_slot, 0);        
+        let error_val = self.array_load(error_slot, 0);
         self.drops_codegen();
         self.raise_codegen(error_val);
 

--- a/src/cps/compile.rs
+++ b/src/cps/compile.rs
@@ -69,11 +69,11 @@ fn compile_lambda(
             }))),
             val: k4,
             cexp: Box::new(Cps::App(Value::from(k2), vec![Value::from(k4)], None)),
-            span: Some(span),
+            span: Some(span.clone()),
         }),
         val: k1,
         cexp: Box::new(meta_cont(Value::from(k1))),
-        span: None,
+        span: Some(span),
     }
 }
 

--- a/src/cps/mod.rs
+++ b/src/cps/mod.rs
@@ -115,7 +115,7 @@ pub enum PrimOp {
     Matches,
     /// Expands a syntax template with the current set of bindings.
     ExpandTemplate,
-    /// Return an error indicating a failure to match the pattern.
+    /// Raise an error indicating a failure to match the pattern.
     ErrorNoPatternsMatch,
 
     // Continuation primitive operators:

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -1,6 +1,5 @@
 //! Exceptional situations and conditions
 
-use futures::future::BoxFuture;
 use scheme_rs_macros::{cps_bridge, runtime_fn};
 
 use crate::{
@@ -8,7 +7,6 @@ use crate::{
     gc::{Gc, GcInner, Trace},
     lists,
     proc::{Application, Closure, DynamicWind, FuncPtr},
-    registry::{BridgeFn, BridgeFnDebugInfo},
     runtime::{Runtime, RuntimeInner},
     symbols::Symbol,
     syntax::{Identifier, Span, Syntax},
@@ -256,7 +254,7 @@ pub async fn with_exception_handler(
 }
 
 #[cps_bridge(name = "raise", lib = "(rnrs base builtins (6))", args = "obj")]
-async fn raise_builtin(
+pub async fn raise_builtin(
     runtime: &Runtime,
     _env: &[Gc<Value>],
     args: &[Value],

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -3,7 +3,7 @@ use crate::{
     env::{Environment, Local},
     exception::Condition,
     gc::{Gc, Trace},
-    proc::{Application, Closure},
+    proc::Closure,
     runtime::Runtime,
     symbols::Symbol,
     syntax::{Identifier, Span, Syntax},

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -619,9 +619,9 @@ impl<'a> Binds<'a> {
 }
 
 #[runtime_fn]
-unsafe extern "C" fn error_no_patterns_match() -> *mut Result<Application, Condition> {
+unsafe extern "C" fn error_no_patterns_match() -> i64 {
     let condition = Condition::error("No patterns match!".to_string());
-    Box::into_raw(Box::new(Err(condition)))
+    Value::into_raw(Value::from(condition)) as i64
 }
 
 #[bridge(name = "make-variable-transformer", lib = "(rnrs base builtins (6))")]

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -491,7 +491,6 @@ where
     unsafe fn visit_children(&self, _visitor: unsafe fn(OpaqueGcPtr)) {}
 }
 
-
 /// # Safety
 ///
 /// This function is _not_ safe to implement!

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -384,31 +384,11 @@ impl<T: ?Sized> AsRef<T> for GcReadGuard<'_, T> {
     }
 }
 
-// unsafe impl<T: ?Sized + Send> Send for GcReadGuard<'_, T> {}
-// unsafe impl<T: ?Sized + Sync> Sync for GcReadGuard<'_, T> {}
-
 pub struct GcWriteGuard<'a, T: ?Sized> {
     _permit: RwLockWriteGuard<'a, ()>,
     data: *mut T,
     marker: PhantomData<&'a mut T>,
 }
-
-/*
-impl<'a, T: ?Sized> GcWriteGuard<'a, T> {
-    pub fn try_map<U, E, F>(mut orig: Self, f: F) -> Result<GcWriteGuard<'a, U>, E>
-    where
-        F: FnOnce(&mut T) -> Result<&mut U, E>,
-        U: ?Sized,
-    {
-        let data = NonNull::from(f(orig.as_mut())?).as_ptr();
-        Ok(GcWriteGuard {
-            _permit: orig._permit,
-            data,
-            marker: PhantomData,
-        })
-    }
-}
-*/
 
 impl<T: ?Sized> Deref for GcWriteGuard<'_, T> {
     type Target = T;
@@ -435,9 +415,6 @@ impl<T: ?Sized> AsMut<T> for GcWriteGuard<'_, T> {
         self
     }
 }
-
-// impl<T: ?Sized> !Send for GcWriteGuard<'_, T> {}
-// unsafe impl<T: ?Sized + Sync> Sync for GcWriteGuard<'_, T> {}
 
 /// A type that can be traced for garbage collection.
 ///
@@ -504,6 +481,16 @@ impl_empty_trace! {
     String,
     PathBuf
 }
+
+// Function pointer impls:
+unsafe impl<A, B> Trace for fn(A) -> B
+where
+    A: ?Sized + 'static,
+    B: ?Sized + 'static,
+{
+    unsafe fn visit_children(&self, _visitor: unsafe fn(OpaqueGcPtr)) {}
+}
+
 
 /// # Safety
 ///

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -162,6 +162,7 @@ fn whitespace(i: InputSpan) -> IResult<InputSpan, ()> {
             satisfy(UnicodeCategories::is_separator),
             match_char('\t'),
             match_char('\n'),
+            match_char('\r'),
         )),
         |_| (),
     )(i)

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -6,7 +6,7 @@ use crate::{
     exception::{Condition, Exception, ExceptionHandler, Frame, raise},
     gc::{Gc, GcInner, Trace},
     lists::{list_to_vec, slice_to_list},
-    registry::{BridgeFn, BridgeFnDebugInfo},
+    registry::BridgeFnDebugInfo,
     runtime::{Runtime, RuntimeInner},
     symbols::Symbol,
     syntax::Span,
@@ -204,7 +204,7 @@ impl ClosureInner {
             )
             .await)
         } else if let FuncPtr::HaltError = self.func {
-            return Err(args[0].clone());
+            Err(args[0].clone())
         } else {
             // For LLVM functions, we need to convert our args into raw pointers
             // and make sure any freshly allocated rest_args are disposed of properly.
@@ -497,7 +497,7 @@ impl FuncDebugInfo {
 }
 
 #[cps_bridge(name = "apply", lib = "(rnrs base builtins (6))", args = "arg1 . args")]
-async fn apply(
+pub async fn apply(
     _runtime: &Runtime,
     _env: &[Gc<Value>],
     args: &[Value],
@@ -507,7 +507,7 @@ async fn apply(
     dynamic_wind: &DynamicWind,
 ) -> Result<Application, Condition> {
     if rest_args.is_empty() {
-        return Err(Condition::wrong_num_of_args(2, args.len()).into());
+        return Err(Condition::wrong_num_of_args(2, args.len()));
     }
     let op: Closure = args[0].clone().try_into()?;
     let (last, args) = rest_args.split_last().unwrap();
@@ -638,7 +638,7 @@ unsafe extern "C" fn call_consumer_with_values(
     lib = "(rnrs base builtins (6))",
     args = "producer consumer"
 )]
-async fn call_with_values(
+pub async fn call_with_values(
     runtime: &Runtime,
     _env: &[Gc<Value>],
     args: &[Value],
@@ -689,7 +689,7 @@ pub struct DynamicWind {
     lib = "(rnrs base builtins (6))",
     args = "in body out"
 )]
-async fn dynamic_wind(
+pub async fn dynamic_wind(
     runtime: &Runtime,
     _env: &[Gc<Value>],
     args: &[Value],

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -59,6 +59,8 @@ pub(crate) enum FuncPtr {
     Continuation(ContinuationPtr),
     User(UserPtr),
     Bridge(BridgePtr),
+    /// Special type to indicate that we should return the argument as an Err.
+    HaltError,
 }
 
 unsafe impl Trace for FuncPtr {
@@ -200,6 +202,8 @@ impl ClosureInner {
                 dynamic_wind,
             )
             .await
+        } else if let FuncPtr::HaltError = self.func {
+            return Err(args[0].clone());
         } else {
             // For LLVM functions, we need to convert our args into raw pointers
             // and make sure any freshly allocated rest_args are disposed of properly.

--- a/src/records.rs
+++ b/src/records.rs
@@ -10,6 +10,7 @@ use by_address::ByAddress;
 use futures::future::BoxFuture;
 
 use crate::{
+    raise_on_err,
     exception::{raise, Condition, ExceptionHandler},
     gc::{Gc, GcInner, Trace},
     num::Number,
@@ -164,6 +165,12 @@ pub fn make_record_constructor_descriptor<'a>(
     dynamic_wind: &'a DynamicWind,
 ) -> BoxFuture<'a, Result<Application, Value>> {
     Box::pin(async move {
+        raise_on_err! {
+            runtime,
+            exception_handler,
+            dynamic_wind,
+            {
+            
         let cont: Closure = cont.clone().try_into()?;
         let [rtd, parent_rcd, protocol] = args else {
             unreachable!();
@@ -224,6 +231,8 @@ pub fn make_record_constructor_descriptor<'a>(
             dynamic_wind.clone(),
             None,
         ))
+            }
+        }
     })
 }
 
@@ -607,7 +616,7 @@ pub fn is_subtype_of(val: &Value, rt: &Value) -> Result<bool, Condition> {
 }
 
 fn record_predicate_fn<'a>(
-    runtime: &'a Runtime,
+    _runtime: &'a Runtime,
     env: &'a [Gc<Value>],
     args: &'a [Value],
     _rest_args: &'a [Value],

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -23,7 +23,7 @@ use std::{
 };
 
 use futures::future::BoxFuture;
-pub use scheme_rs_macros::bridge;
+pub use scheme_rs_macros::{bridge, cps_bridge};
 
 pub struct BridgeFn {
     name: &'static str,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,13 +1,14 @@
 use crate::{
     ast::DefinitionBody,
-    cps::{codegen::RuntimeFunctionsBuilder, Compile, Cps},
+    cps::{Compile, Cps, codegen::RuntimeFunctionsBuilder},
     env::Environment,
-    exception::{raise, Condition, Exception, ExceptionHandler},
-    gc::{init_gc, Gc, GcInner, Trace},
+    exception::{Condition, Exception, ExceptionHandler, raise},
+    gc::{Gc, GcInner, Trace, init_gc},
     lists::{self, list_to_vec},
     num,
     proc::{
-        clone_continuation_env, Application, Closure, ContinuationPtr, DynamicWind, FuncDebugInfo, FuncPtr, UserPtr
+        Application, Closure, ContinuationPtr, DynamicWind, FuncDebugInfo, FuncPtr, UserPtr,
+        clone_continuation_env,
     },
     registry::{ImportError, Library, Registry},
     symbols::Symbol,
@@ -306,9 +307,7 @@ unsafe extern "C" fn apply(
             x => {
                 let raised = raise(
                     Runtime::from_raw_inc_rc(runtime),
-                    Condition::invalid_operator_type(
-                        x.type_name(),
-                    ).into(),
+                    Condition::invalid_operator_type(x.type_name()).into(),
                     ExceptionHandler::from_ptr(exception_handler),
                     dynamic_wind.as_ref().unwrap(),
                 );
@@ -343,9 +342,7 @@ unsafe extern "C" fn forward(
             x => {
                 let raised = raise(
                     Runtime::from_raw_inc_rc(runtime),
-                    Condition::invalid_operator_type(
-                        x.type_name(),
-                    ).into(),
+                    Condition::invalid_operator_type(x.type_name()).into(),
                     ExceptionHandler::from_ptr(exception_handler),
                     dynamic_wind.as_ref().unwrap(),
                 );
@@ -744,11 +741,7 @@ unsafe extern "C" fn call_thunks_pass_args(
 }
 
 #[runtime_fn]
-unsafe extern "C" fn add(
-    vals: *const i64,
-    num_vals: u32,
-    error: *mut Value,
-) -> i64 {
+unsafe extern "C" fn add(vals: *const i64, num_vals: u32, error: *mut Value) -> i64 {
     unsafe {
         let vals: Vec<_> = (0..num_vals)
             // Can't easily wrap these in a ManuallyDrop, so we dec the rc.
@@ -765,11 +758,7 @@ unsafe extern "C" fn add(
 }
 
 #[runtime_fn]
-unsafe extern "C" fn sub(
-    vals: *const i64,
-    num_vals: u32,
-    error: *mut Value,
-) -> i64 {
+unsafe extern "C" fn sub(vals: *const i64, num_vals: u32, error: *mut Value) -> i64 {
     unsafe {
         let vals: Vec<_> = (0..num_vals)
             .map(|i| Value::from_raw_inc_rc(vals.add(i as usize).read() as u64))
@@ -785,11 +774,7 @@ unsafe extern "C" fn sub(
 }
 
 #[runtime_fn]
-unsafe extern "C" fn mul(
-    vals: *const i64,
-    num_vals: u32,
-    error: *mut Value,
-) -> i64 {
+unsafe extern "C" fn mul(vals: *const i64, num_vals: u32, error: *mut Value) -> i64 {
     unsafe {
         let vals: Vec<_> = (0..num_vals)
             .map(|i| Value::from_raw_inc_rc(vals.add(i as usize).read() as u64))
@@ -805,11 +790,7 @@ unsafe extern "C" fn mul(
 }
 
 #[runtime_fn]
-unsafe extern "C" fn div(
-    vals: *const i64,
-    num_vals: u32,
-    error: *mut Value,
-) -> i64 {
+unsafe extern "C" fn div(vals: *const i64, num_vals: u32, error: *mut Value) -> i64 {
     unsafe {
         let vals: Vec<_> = (0..num_vals)
             .map(|i| Value::from_raw_inc_rc(vals.add(i as usize).read() as u64))
@@ -827,11 +808,7 @@ unsafe extern "C" fn div(
 macro_rules! define_comparison_fn {
     ( $name:ident ) => {
         #[runtime_fn]
-        unsafe extern "C" fn $name(
-            vals: *const i64,
-            num_vals: u32,
-            error: *mut Value,
-        ) -> i64 {
+        unsafe extern "C" fn $name(vals: *const i64, num_vals: u32, error: *mut Value) -> i64 {
             unsafe {
                 let vals: Vec<_> = (0..num_vals)
                     .map(|i| Value::from_raw_inc_rc(vals.add(i as usize).read() as u64))

--- a/src/value.rs
+++ b/src/value.rs
@@ -25,6 +25,8 @@ const TAG: u64 = 0b1111;
 #[repr(transparent)]
 pub struct Value(u64);
 
+pub(crate) const FALSE_VALUE: u64 = ValueType::Boolean as u64;
+
 impl Value {
     pub fn new(v: UnpackedValue) -> Self {
         v.into_value()
@@ -32,7 +34,7 @@ impl Value {
 
     /// #f is false, everything else is true
     pub fn is_true(&self) -> bool {
-        self.0 != ValueType::Boolean as u64
+        self.0 != FALSE_VALUE
     }
 
     /// Creates a new Value from a raw u64.
@@ -771,7 +773,7 @@ pub async fn eqv(a: &Value, b: &Value) -> Result<Vec<Value>, Condition> {
 
 #[bridge(name = "eq?", lib = "(rnrs base builtins (6))")]
 pub async fn eq(a: &Value, b: &Value) -> Result<Vec<Value>, Condition> {
-    Ok(vec![Value::from(a == b)])
+    Ok(vec![Value::from(a.0 == b.0)])
 }
 
 #[bridge(name = "boolean?", lib = "(rnrs base builtins (6))")]


### PR DESCRIPTION
This PR fixes exception handling interaction with dynamic wind. Now, exit winders will properly be called when `raise` is called within a `dynamic-wind`.

Interestingly, no changes needed to be made for `raise-continuable`. That already worked perfectly.

In addition to fixing this, all exceptions that were thrown from JIT compiled functions now hit winders and exception handlers when they are raised. I've made all of them non-continuable, but I think that's fine. 

This required a substantial refactoring of the whole system, and the result is largely for the better. Here are some changes:

- No FuncPtr variant returns a Result. There is now a HaltError variant that does that. This ensures that bridge and JIT compiled functions must be extremely explicit in bubbling errors up instantly, as this will skip winders and exception handlers. 
- There is a `cps_bridge` attribute proc macro that works similarly to the `bridge`  one. It's used for functions that return applications. 