### PR TITLE
Implement `equal?` and properly display circular data structures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ nom_locate = "4"
 num = "0.4"
 ordered-float = "5"
 scheme-rs-macros = { version = "0.1.0-alpha.1", path = "proc-macros" }
-rand = "0.8"
+rand = { version = "0.9", features = ["thread_rng"] }
 rust-embed = { version = "8", features = ["debug-embed"] }
 thiserror = "1"
 tokio = { version = "1.41", features = ["full"] }

--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -80,7 +80,6 @@ pub(crate) struct RuntimeFunctions {
 }
 
 impl Cps {
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn into_closure(
         self,
         runtime: Runtime,

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -1,10 +1,12 @@
+use indexmap::IndexMap;
+
 use crate::{
     exception::Condition,
     gc::{Gc, Trace},
     num::Number,
     registry::bridge,
     syntax::Syntax,
-    value::{UnpackedValue, Value},
+    value::{EqvValue, UnpackedValue, Value, ValueType, write_value},
 };
 use std::fmt;
 
@@ -25,21 +27,40 @@ impl PartialEq for Pair {
     }
 }
 
-pub fn display_list(car: &Value, cdr: &Value, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    // TODO(map): If the list is circular, DO NOT print infinitely!
-    match &*cdr.unpacked_ref() {
-        UnpackedValue::Pair(_) | UnpackedValue::Null => (),
-        cdr => {
+pub(crate) fn write_list(
+    car: &Value,
+    cdr: &Value,
+    fmt: fn(&Value, &mut IndexMap<EqvValue, bool>, &mut fmt::Formatter<'_>) -> fmt::Result,
+    circular_values: &mut IndexMap<EqvValue, bool>,
+    f: &mut fmt::Formatter<'_>,
+) -> fmt::Result {
+    match cdr.type_of() {
+        ValueType::Pair | ValueType::Null => (),
+        _ => {
             // This is not a proper list
-            return write!(f, "({car} . {cdr})");
+            write!(f, "(")?;
+            write_value(car, fmt, circular_values, f)?;
+            write!(f, " . ")?;
+            write_value(cdr, fmt, circular_values, f)?;
+            write!(f, ")")?;
+            return Ok(());
         }
     }
 
-    write!(f, "({car}")?;
-
+    write!(f, "(")?;
+    write_value(car, fmt, circular_values, f)?;
     let mut stack = vec![cdr.clone()];
 
     while let Some(head) = stack.pop() {
+        if let Some((idx, _, seen)) = circular_values.get_full_mut(&EqvValue(head.clone())) {
+            if *seen {
+                write!(f, " . #{idx}#")?;
+                continue;
+            } else {
+                write!(f, " #{idx}=")?;
+                *seen = true;
+            }
+        }
         match &*head.unpacked_ref() {
             UnpackedValue::Null => {
                 if !stack.is_empty() {
@@ -49,47 +70,15 @@ pub fn display_list(car: &Value, cdr: &Value, f: &mut fmt::Formatter<'_>) -> fmt
             UnpackedValue::Pair(pair) => {
                 let pair_read = pair.read();
                 let Pair(car, cdr) = pair_read.as_ref();
-                write!(f, " {car}")?;
+                write!(f, " ")?;
+                write_value(car, fmt, circular_values, f)?;
+                // write!(f, " {car}")?;
                 stack.push(cdr.clone());
             }
             x => {
-                write!(f, " {x}")?;
-            }
-        }
-    }
-
-    write!(f, ")")
-}
-
-pub fn debug_list(car: &Value, cdr: &Value, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    // TODO(map): If the list is circular, DO NOT print infinitely!
-    match &*cdr.unpacked_ref() {
-        UnpackedValue::Pair(_) | UnpackedValue::Null => (),
-        cdr => {
-            // This is not a proper list
-            return write!(f, "({car:?} . {cdr:?})");
-        }
-    }
-
-    write!(f, "({car:?}")?;
-
-    let mut stack = vec![cdr.clone()];
-
-    while let Some(head) = stack.pop() {
-        match &*head.unpacked_ref() {
-            UnpackedValue::Null => {
-                if !stack.is_empty() {
-                    write!(f, " ()")?;
-                }
-            }
-            UnpackedValue::Pair(pair) => {
-                let pair_read = pair.read();
-                let Pair(car, cdr) = pair_read.as_ref();
-                write!(f, " {car:?}")?;
-                stack.push(cdr.clone());
-            }
-            x => {
-                write!(f, " {x:?}")?;
+                let val = x.clone().into_value();
+                write!(f, " ")?;
+                write_value(&val, fmt, circular_values, f)?;
             }
         }
     }

--- a/src/num.rs
+++ b/src/num.rs
@@ -37,7 +37,10 @@ pub enum Number {
 
 impl Number {
     pub fn is_exact(&self) -> bool {
-        matches!(self, Self::FixedInteger(_) | Self::BigInteger(_) | Self::Rational(_))
+        matches!(
+            self,
+            Self::FixedInteger(_) | Self::BigInteger(_) | Self::Rational(_)
+        )
     }
 
     pub fn is_zero(&self) -> bool {
@@ -108,7 +111,6 @@ impl From<usize> for Number {
         }
     }
 }
-
 
 impl From<i32> for Number {
     fn from(i: i32) -> Self {

--- a/src/num.rs
+++ b/src/num.rs
@@ -36,8 +36,11 @@ pub enum Number {
 }
 
 impl Number {
-    #[allow(dead_code)]
-    fn is_zero(&self) -> bool {
+    pub fn is_exact(&self) -> bool {
+        matches!(self, Self::FixedInteger(_) | Self::BigInteger(_) | Self::Rational(_))
+    }
+
+    pub fn is_zero(&self) -> bool {
         match self {
             Self::FixedInteger(i) => i.is_zero(),
             Self::BigInteger(i) => i.eq(&0),
@@ -47,8 +50,7 @@ impl Number {
         }
     }
 
-    #[allow(dead_code)]
-    fn is_even(&self) -> bool {
+    pub fn is_even(&self) -> bool {
         match self {
             Self::FixedInteger(i) => i.even(),
             Self::BigInteger(i) => i.even(),
@@ -58,8 +60,7 @@ impl Number {
         }
     }
 
-    #[allow(dead_code)]
-    fn is_odd(&self) -> bool {
+    pub fn is_odd(&self) -> bool {
         match self {
             Self::FixedInteger(i) => i.odd(),
             Self::BigInteger(i) => i.odd(),
@@ -69,8 +70,7 @@ impl Number {
         }
     }
 
-    #[allow(dead_code)]
-    fn is_complex(&self) -> bool {
+    pub fn is_complex(&self) -> bool {
         matches!(self, Self::Complex(_))
     }
 }
@@ -106,6 +106,13 @@ impl From<usize> for Number {
             Ok(i) => Number::FixedInteger(i),
             Err(_) => Number::BigInteger(Integer::from(u)),
         }
+    }
+}
+
+
+impl From<i32> for Number {
+    fn from(i: i32) -> Self {
+        Self::FixedInteger(i as i64)
     }
 }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -14,7 +14,10 @@ use futures::future::BoxFuture;
 use std::{
     collections::{BTreeSet, HashSet},
     fmt,
-    sync::{atomic::{AtomicUsize, Ordering}, Arc},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
 };
 
 /// Source location for an s-expression.
@@ -170,7 +173,7 @@ impl Syntax {
                 literal: Literal::Number(num.as_ref().clone()),
                 span: Span::default(),
             },
-            x => unimplemented!("{x:?}"),
+            x => unimplemented!("{:?}", x.into_value()),
         }
     }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -14,7 +14,7 @@ use futures::future::BoxFuture;
 use std::{
     collections::{BTreeSet, HashSet},
     fmt,
-    sync::Arc,
+    sync::{atomic::{AtomicUsize, Ordering}, Arc},
 };
 
 /// Source location for an s-expression.
@@ -422,7 +422,8 @@ pub struct Mark(usize);
 
 impl Mark {
     pub fn new() -> Self {
-        Self(rand::random())
+        static NEXT_MARK: AtomicUsize = AtomicUsize::new(0);
+        Self(NEXT_MARK.fetch_add(1, Ordering::Relaxed))
     }
 }
 
@@ -441,16 +442,6 @@ pub struct Identifier {
 impl fmt::Debug for Identifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.sym)
-        /*
-            f,
-            "{} ({})",
-            self.sym,
-            self.marks
-                .iter()
-                .map(|m| m.0.to_string() + " ")
-                .collect::<String>()
-        )
-         */
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -235,6 +235,12 @@ impl Value {
         }
     }
 
+    pub fn eq(&self, rhs: &Self) -> bool {
+        let obj1 = self.unpacked_ref();
+        let obj2 = rhs.unpacked_ref();
+        obj1.eq(&*obj2)
+    }
+
     /// The eqv? predicate as defined by the R6RS specification.
     pub fn eqv(&self, rhs: &Self) -> bool {
         let obj1 = self.unpacked_ref();
@@ -432,6 +438,25 @@ impl UnpackedValue {
                 let untagged = Gc::into_raw(any);
                 Value::from_mut_ptr_and_tag(untagged, ValueType::Any)
             }
+        }
+    }
+
+    pub fn eq(&self, rhs: &Self) -> bool {
+        match (self, rhs) {
+            (Self::Boolean(a), Self::Boolean(b)) => a == b,
+            (Self::Symbol(a), Self::Symbol(b)) => a == b,
+            (Self::Number(a), Self::Number(b)) => Arc::ptr_eq(&a, &b),
+            (Self::Character(a), Self::Character(b)) => a == b,
+            (Self::Null, Self::Null) => true,
+            (Self::String(a), Self::String(b)) => Arc::ptr_eq(&a, &b),
+            (Self::Pair(a), Self::Pair(b)) => Gc::ptr_eq(&a, &b),
+            (Self::Vector(a), Self::Vector(b)) => Gc::ptr_eq(&a, &b),
+            (Self::ByteVector(a), Self::ByteVector(b)) => Arc::ptr_eq(&a, &b),
+            (Self::Closure(a), Self::Closure(b)) => Gc::ptr_eq(&a.0, &b.0),
+            (Self::Syntax(a), Self::Syntax(b)) => Arc::ptr_eq(a, b),
+            (Self::Record(a), Self::Record(b)) => Gc::ptr_eq(a, b),
+            (Self::RecordTypeDescriptor(a), Self::RecordTypeDescriptor(b)) => Arc::ptr_eq(a, b),
+            _ => false,
         }
     }
 

--- a/src/vectors.rs
+++ b/src/vectors.rs
@@ -5,8 +5,9 @@ use crate::{
     num::{Number, NumberToUsizeError},
     registry::bridge,
     strings,
-    value::Value,
+    value::{EqvValue, Value, write_value},
 };
+use indexmap::IndexMap;
 use malachite::Integer;
 use std::{
     clone::Clone,
@@ -46,12 +47,31 @@ impl<T: Trace + PartialEq> PartialEq for AlignedVector<T> {
     }
 }
 
-pub fn display_vec<T: fmt::Display>(
-    head: &str,
-    v: &[T],
+pub(crate) fn write_vec(
+    v: &Gc<AlignedVector<Value>>,
+    fmt: fn(&Value, &mut IndexMap<EqvValue, bool>, &mut fmt::Formatter<'_>) -> fmt::Result,
+    circular_values: &mut IndexMap<EqvValue, bool>,
     f: &mut fmt::Formatter<'_>,
 ) -> Result<(), fmt::Error> {
-    write!(f, "{head}")?;
+    write!(f, "#(")?;
+
+    let v = v.read();
+    let mut iter = v.iter().peekable();
+    while let Some(next) = iter.next() {
+        write_value(next, fmt, circular_values, f)?;
+        if iter.peek().is_some() {
+            write!(f, " ")?;
+        }
+    }
+
+    write!(f, ")")
+}
+
+pub(crate) fn write_bytevec(
+    v: &AlignedVector<u8>,
+    f: &mut fmt::Formatter<'_>,
+) -> Result<(), fmt::Error> {
+    write!(f, "#u8(")?;
 
     let mut iter = v.iter().peekable();
     while let Some(next) = iter.next() {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,7 +2,7 @@
 
 use scheme_rs::{exception::Condition, registry::bridge, value::Value};
 
-#[bridge(name = "assert-eqv?", lib = "(test)")]
+#[bridge(name = "assert-equal?", lib = "(test)")]
 async fn test_assert(arg1: &Value, arg2: &Value) -> Result<Vec<Value>, Condition> {
     if arg1 != arg2 {
         let arg1 = format!("{arg1:?}");

--- a/tests/r6rs.scm
+++ b/tests/r6rs.scm
@@ -10,15 +10,15 @@
 ;; 1.2. Expressions
 
 ;; The following are omitted because they don't really show anything:
-;; (assert-eqv? #t #t)
-;; (assert-eqv? 23 23)
+;; (assert-equal? #t #t)
+;; (assert-equal? 23 23)
 
-(assert-eqv? (+ 23 42) 65)
-(assert-eqv? (+ 14 (* 23 42)) 980)
+(assert-equal? (+ 23 42) 65)
+(assert-equal? (+ 14 (* 23 42)) 980)
 
 ;; 1.3. Variables and binding
 
-(assert-eqv?
+(assert-equal?
  (let ((x 23)
        (y 42))
    (+ x y))
@@ -28,16 +28,16 @@
 
 (define x 23)
 (define y 42)
-(assert-eqv? (+ x y) 65)
+(assert-equal? (+ x y) 65)
 
 (define x 23)
 (define y 42)
 
-(assert-eqv? (let ((y 43))
+(assert-equal? (let ((y 43))
                (+ x y))
              66)
 
-(assert-eqv? (let ((y 43))
+(assert-equal? (let ((y 43))
                (let ((y 44))
                  (+ x y)))
              67)
@@ -47,7 +47,7 @@
 (define (f x)
   (+ x 42))
 
-(assert-eqv? (f 23) 65)
+(assert-equal? (f 23) 65)
 
 (define (f x)
   (+ x 42))
@@ -55,66 +55,66 @@
 (define (g p x)
   (p x))
 
-(assert-eqv? (g f 23) 65)
+(assert-equal? (g f 23) 65)
 
 (define (h op x y)
   (op x y))
 
-(assert-eqv? (h + 23 42) 65)
-(assert-eqv? (h * 23 42) 966)
+(assert-equal? (h + 23 42) 65)
+(assert-equal? (h * 23 42) 966)
 
 ;; mark
 
-(assert-eqv? ((lambda (x) (+ x 42)) 23) 65)
+(assert-equal? ((lambda (x) (+ x 42)) 23) 65)
 
 ;; 1.8 Assignments
 
-(assert-eqv? (let ((x 23))
+(assert-equal? (let ((x 23))
                (set! x 42)
                x)
              42)
 
 ;; 1.11 Continuations
-(assert-eqv? (+ 1 (call-with-current-continuation
+(assert-equal? (+ 1 (call-with-current-continuation
                    (lambda (escape)
                      (+ 2 (escape 3)))))
              4)
 
 ;; ?? boolean=?
 
-(assert-eqv? (boolean=? #t #t #t) #t)
-(assert-eqv? (boolean=? #f #f #f) #t)
-(assert-eqv? (boolean=? #t #f #f) #f)
-(assert-eqv? (boolean=? #f #t #t) #f)
-(assert-eqv? (boolean=? 1 2) #f)
-(assert-eqv? (boolean=? #t 2) #f)
-(assert-eqv? (boolean=? #t) #t)
-(assert-eqv? (boolean=? #f) #t)
+(assert-equal? (boolean=? #t #t #t) #t)
+(assert-equal? (boolean=? #f #f #f) #t)
+(assert-equal? (boolean=? #t #f #f) #f)
+(assert-equal? (boolean=? #f #t #t) #f)
+(assert-equal? (boolean=? 1 2) #f)
+(assert-equal? (boolean=? #t 2) #f)
+(assert-equal? (boolean=? #t) #t)
+(assert-equal? (boolean=? #f) #t)
 
 ;;  6.4. list procedures
 
-(assert-eqv? (make-list 2) '(#f #f))
-(assert-eqv? (make-list 5) '(#f #f #f #f #f))
+(assert-equal? (make-list 2) '(#f #f))
+(assert-equal? (make-list 5) '(#f #f #f #f #f))
 
 (define xs '(1 2 3 4 5))
 
-(assert-eqv? (eq? (list-copy xs) xs) #f)
-(assert-eqv? (eq? xs xs) #t)
+(assert-equal? (eq? (list-copy xs) xs) #f)
+(assert-equal? (eq? xs xs) #t)
 
-(assert-eqv? (list-ref xs 2) 3)
-(assert-eqv? (list-ref xs 3) 4)
+(assert-equal? (list-ref xs 2) 3)
+(assert-equal? (list-ref xs 3) 4)
 
-(assert-eqv? (list-tail xs 3) '(4 5))
+(assert-equal? (list-tail xs 3) '(4 5))
 
 (define alist '((a . 1) (b . 2)))
 
-(assert-eqv? (assoc 'a alist) '(a . 1))
-(assert-eqv? (assoc 'b alist) '(b . 2))
-(assert-eqv? (assoc 'c alist) #f)
+(assert-equal? (assoc 'a alist) '(a . 1))
+(assert-equal? (assoc 'b alist) '(b . 2))
+(assert-equal? (assoc 'c alist) #f)
 
 ;; 11.2.2. Syntax definitions
 
-(assert-eqv? (let ()
+(assert-equal? (let ()
                (define even?
                  (lambda (x)
                    (or (= x 0) (odd? (- x 1)))))
@@ -124,7 +124,7 @@
                (even? 10))
              #t)
 
-(assert-eqv? (let ()
+(assert-equal? (let ()
                (define-syntax bind-to-zero
                  (syntax-rules ()
                    ((bind-to-zero id) (define id 0))))
@@ -134,7 +134,7 @@
 
 ;; 11.3 Bodies
 
-(assert-eqv? (let ((x 5))
+(assert-equal? (let ((x 5))
                (define foo (lambda (y) (bar x y)))
                (define bar (lambda (a b) (+ (* a b) a)))
                (foo (+ x 3)))
@@ -145,7 +145,7 @@
 
 ;; (skipping a bunch of these because this stuff works)
 
-(assert-eqv? ((lambda (x)
+(assert-equal? ((lambda (x)
                 (define (p y)
                   (+ y 1))
                 (+ (p x) x))
@@ -154,31 +154,31 @@
 
 ;; 11.4.3 Conditionals
 
-(assert-eqv? (if (> 3 2) 'yes 'no) 'yes)
-(assert-eqv? (if (> 2 3) 'yes 'no) 'no)
-(assert-eqv? (if (> 3 2)
+(assert-equal? (if (> 3 2) 'yes 'no) 'yes)
+(assert-equal? (if (> 2 3) 'yes 'no) 'no)
+(assert-equal? (if (> 3 2)
                  (- 3 2)
                  (+ 3 2))
              1)
 
 ;; 11.4.5 Derived conditionals
 
-(assert-eqv? (cond ((> 3 2) 'greater)
+(assert-equal? (cond ((> 3 2) 'greater)
                    ((< 3 2) 'less))
              'greater)
-(assert-eqv? (cond ((> 3 3) 'greater)
+(assert-equal? (cond ((> 3 3) 'greater)
                    ((< 3 3) 'less)
                    (else 'equal))
              'equal)
-(assert-eqv? (cond ('(1 2 3) => cadr)
+(assert-equal? (cond ('(1 2 3) => cadr)
                    (else #f))
              2)
 
-(assert-eqv? (case (* 2 3)
+(assert-equal? (case (* 2 3)
                ((2 3 5 7) 'prime)
                ((1 4 6 8 9) 'composite))
              'composite)
-(assert-eqv? (case (car '(c d))
+(assert-equal? (case (car '(c d))
                ((a e i o u) 'vowel)
                ((w y) 'semivowel)
                (else 'consonant))
@@ -187,13 +187,13 @@
 
 ;; 11.4.6. Binding constructs
 
-(assert-eqv? (let ((x 2) (y 3))
+(assert-equal? (let ((x 2) (y 3))
                (let* ((x 7)
                       (z (+ x y)))
                  (* z x)))
              70)
 
-(assert-eqv? (letrec ((even?
+(assert-equal? (letrec ((even?
                        (lambda (n)
                          (if (zero? n)
                              #t
@@ -206,7 +206,7 @@
                (even? 88))
              #t)
 
-(assert-eqv? (letrec* ((p
+(assert-equal? (letrec* ((p
                         (lambda (x)
                           (+ 1 (q (- x 1)))))
                        (q
@@ -219,22 +219,22 @@
                y)
              5)
 
-(assert-eqv? (let-values (((a b) (values 1 2))
+(assert-equal? (let-values (((a b) (values 1 2))
                           ((c d) (values 3 4)))
                (list a b c d))
              '(1 2 3 4))
 
-(assert-eqv? (let-values (((a b . c) (values 1 2 3 4)))
+(assert-equal? (let-values (((a b . c) (values 1 2 3 4)))
                (list a b c))
              '(1 2 (3 4)))
 
-(assert-eqv? (let ((a 'a) (b 'b) (x 'x) (y 'y))
+(assert-equal? (let ((a 'a) (b 'b) (x 'x) (y 'y))
                (let-values (((a b) (values x y))
                             ((x y) (values a b)))
                  (list a b x y)))
              '(x y a b))
 
-(assert-eqv? (let ((a 'a) (b 'b) (x 'x) (y 'y))
+(assert-equal? (let ((a 'a) (b 'b) (x 'x) (y 'y))
                (let*-values (((a b) (values x y))
                              ((x y) (values a b)))
                  (list a b x y)))
@@ -245,14 +245,14 @@
 ;; Right now, constants have a new allocation per each instance. This is obviously
 ;; wrong, but a much deeper problem than one with the implementation of eq?
 
-(assert-eqv? (eq? (list 'a) (list 'a))
+(assert-equal? (eq? (list 'a) (list 'a))
              #f)
 
-(assert-eqv? (let ((x 1))
+(assert-equal? (let ((x 1))
                (eq? x x))
              #t)
 
-(assert-eqv? (let loopv ((n 1))
+(assert-equal? (let loopv ((n 1))
                (if (> n 10)
                    '()
                    (cons n (loopv (+ n 1)))))
@@ -268,7 +268,7 @@
             (lambda (break)
               (let f () e ... (f)))))])))
 
-(assert-eqv? (let ((n 3) (ls '()))
+(assert-equal? (let ((n 3) (ls '()))
                (loop
                 (if (= n 0) (break ls))
                 (set! ls (cons 'a ls))
@@ -277,12 +277,12 @@
 
 ;; 11.7 Arithmetic
 
-(assert-eqv? (/ 5) 1/5)
-(assert-eqv? (/ 5 10) 1/2)
+(assert-equal? (/ 5) 1/5)
+(assert-equal? (/ 5 10) 1/2)
 
 ;; 11.15 Control features
 
-(assert-eqv? (let ((path '())
+(assert-equal? (let ((path '())
                    (c #f))
                (let ((add (lambda (s)
                             (set! path (cons s path)))))
@@ -299,7 +299,7 @@
                      (reverse path))))
              '(connect talk1 disconnect connect talk2 disconnect))
 
-(assert-eqv? (let ((n 0))
+(assert-equal? (let ((n 0))
                (call-with-current-continuation
                 (lambda (k)
                   (dynamic-wind
@@ -314,7 +314,7 @@
              1)
 
 ;; 11.18 Binding constructs for syntactic-keywords
-(assert-eqv? (let-syntax ((when (syntax-rules ()
+(assert-equal? (let-syntax ((when (syntax-rules ()
                                   ((when test stmt1 stmt2 ...)
                                    (if test
                                        (begin stmt1
@@ -324,7 +324,7 @@
                  if))
              'now)
 
-(assert-eqv? (let ()
+(assert-equal? (let ()
                (let-syntax
                    ((def (syntax-rules ()
                            ((def stuff ...) (define stuff ...)))))
@@ -332,19 +332,19 @@
                foo)
              42)
 
-(assert-eqv? (let ((x 'outer))
+(assert-equal? (let ((x 'outer))
                (let-syntax ((m (syntax-rules () ((m) x))))
                  (let ((x 'inner))
                    (m))))
              'outer)
 
 ;; TODO: Fix parser for this, I guess.
-;; (assert-eqv? (let ()
+;; (assert-equal? (let ()
 ;;              (let-syntax ())
 ;;              5)
 ;;            5)
 
-(assert-eqv? (letrec-syntax
+(assert-equal? (letrec-syntax
                  ((my-or (syntax-rules ()
                            ((my-or) #f)
                            ((my-or e) e)
@@ -366,7 +366,7 @@
                         y)))
              7)
 
-(assert-eqv? (let ((f (lambda (x) (+ x 1))))
+(assert-equal? (let ((f (lambda (x) (+ x 1))))
                (let-syntax ((f (syntax-rules ()
                                  ((f x) x)))
                             (g (syntax-rules ()
@@ -374,7 +374,7 @@
                  (list (f 1) (g 1))))
              '(1 2))
 
-(assert-eqv? (let ((f (lambda (x) (+ x 1))))
+(assert-equal? (let ((f (lambda (x) (+ x 1))))
                (letrec-syntax ((f (syntax-rules ()
                                     ((f x) x)))
                                (g (syntax-rules ()
@@ -384,7 +384,7 @@
 
 ;; Extra stuff:
 
-(assert-eqv? (let ([x 1])
+(assert-equal? (let ([x 1])
                (syntax-case #'() ()
                  ([] x)))
              1)
@@ -406,8 +406,8 @@
 (defconst newfoo 42)
 (defconst newbar 70)
 
-(assert-eqv? (newfoo) 42)
-(assert-eqv? (newbar) 70)
+(assert-equal? (newfoo) 42)
+(assert-equal? (newbar) 70)
 
 ;; Realized this was an issue when doing escape analysis:
 (define (test a) (set! a '()))
@@ -433,11 +433,11 @@
 
 (define p1 (make-point 1 2))
 
-(assert-eqv? (point? p1) #t)
-(assert-eqv? (point-x p1) 1)
-(assert-eqv? (point-y p1) 2)
+(assert-equal? (point? p1) #t)
+(assert-equal? (point-x p1) 1)
+(assert-equal? (point-y p1) 2)
 (point-x-set! p1 5)
-(assert-eqv? (point-x p1) 5)
+(assert-equal? (point-x p1) 5)
 
 (define :point2
   (make-record-type-descriptor
@@ -452,11 +452,11 @@
 (define point2-yy (record-accessor :point2 1))
 
 (define p2 (make-point2 1 2 3 4))
-(assert-eqv? (point? p2) #t)
-(assert-eqv? (point-x p2) 1)
-(assert-eqv? (point-y p2) 2)
-(assert-eqv? (point2-xx p2) 3)
-(assert-eqv? (point2-yy p2) 4)
+(assert-equal? (point? p2) #t)
+(assert-equal? (point-x p2) 1)
+(assert-equal? (point-y p2) 2)
+(assert-equal? (point2-xx p2) 3)
+(assert-equal? (point2-yy p2) 4)
 
 (define :point-cd/abs
   (make-record-constructor-descriptor
@@ -468,8 +468,8 @@
 (define make-point/abs
   (record-constructor :point-cd/abs))
 
-(assert-eqv? (point-x (make-point/abs -1 -2)) 1)
-(assert-eqv? (point-y (make-point/abs -1 -2)) 2)
+(assert-equal? (point-x (make-point/abs -1 -2)) 1)
+(assert-equal? (point-y (make-point/abs -1 -2)) 2)
 
 ;; Test from make the define-record-type macro:
 (define (get-clause id ls)
@@ -485,4 +485,4 @@
     [(_ field-spec* ...) #t]
     [_ #f]))
 
-(assert-eqv? (test (get-clause #'fields #'((fields x y)))) #t)
+(assert-equal? (test (get-clause #'fields #'((fields x y)))) #t)

--- a/tests/r7rs.scm
+++ b/tests/r7rs.scm
@@ -5,58 +5,58 @@
 
 ;; 6.2 Numbers
 
-(assert-eqv? (positive? 1) #t)
-(assert-eqv? (positive? 0) #f)
-(assert-eqv? (positive? (- 1)) #f)
+(assert-equal? (positive? 1) #t)
+(assert-equal? (positive? 0) #f)
+(assert-equal? (positive? (- 1)) #f)
 
-(assert-eqv? (negative? 1) #f)
-(assert-eqv? (negative? 0) #f)
-(assert-eqv? (negative? -1) #t)
+(assert-equal? (negative? 1) #f)
+(assert-equal? (negative? 0) #f)
+(assert-equal? (negative? -1) #t)
 
-(assert-eqv? (abs 1) 1)
-(assert-eqv? (abs 0) 0)
-(assert-eqv? (abs -1) 1)
+(assert-equal? (abs 1) 1)
+(assert-equal? (abs 0) 0)
+(assert-equal? (abs -1) 1)
 
-(assert-eqv? (min 2 4 1 3) 1)
-(assert-eqv? (min 2 4 -1 3) -1)
-(assert-eqv? (min 2 4 3) 2)
+(assert-equal? (min 2 4 1 3) 1)
+(assert-equal? (min 2 4 -1 3) -1)
+(assert-equal? (min 2 4 3) 2)
 
-(assert-eqv? (max 2 4 1 3) 4)
-(assert-eqv? (max 2 4 3)   4)
-(assert-eqv? (max 3 2 1)   3)
+(assert-equal? (max 2 4 1 3) 4)
+(assert-equal? (max 2 4 3)   4)
+(assert-equal? (max 3 2 1)   3)
 
 ;; 6.6 Characters
-(assert-eqv? (char->integer #\a) 97)
-(assert-eqv? (integer->char 97) #\a)
+(assert-equal? (char->integer #\a) 97)
+(assert-equal? (integer->char 97) #\a)
 
 ;; 6.8 Vectors
 
-(assert-eqv? (make-vector 10 'a) #(a a a a a a a a a a))
+(assert-equal? (make-vector 10 'a) #(a a a a a a a a a a))
 
-(assert-eqv? (vector 'a 'b 'c) #(a b c))
+(assert-equal? (vector 'a 'b 'c) #(a b c))
 
-(assert-eqv? (vector-ref '#(1 1 2 3 5 8 13 21) 5) 8)
+(assert-equal? (vector-ref '#(1 1 2 3 5 8 13 21) 5) 8)
 
-(assert-eqv?
+(assert-equal?
   (let ((vec (vector 0 '(2 2 2 2) "Anna")))
     (vector-set! vec 1 '("Sue" "Sue"))
     vec)
   #(0 ("Sue" "Sue") "Anna"))
 
-(assert-eqv?
+(assert-equal?
   (vector->list '#(dah dah didah))
   '(dah dah didah))
-(assert-eqv?
+(assert-equal?
   (vector->list '#(dah dah didah) 1 2)
   '(dah))
-(assert-eqv?
+(assert-equal?
   (list->vector '(dididit dah))
   #(dididit dah))
 
- (assert-eqv?
+ (assert-equal?
    (string->vector "ABC")
    #(#\A #\B #\C))
- (assert-eqv? (vector->string #(#\A #\B #\C)) "ABC")
+ (assert-equal? (vector->string #(#\A #\B #\C)) "ABC")
 
 (let* ((a #(1 8 2 8))
        (b (vector-copy a))
@@ -64,18 +64,18 @@
 
   (vector-set! b 0 3)
 
-  (assert-eqv? b #(3 8 2 8))
-  (assert-eqv? c #(8 2)))
+  (assert-equal? b #(3 8 2 8))
+  (assert-equal? c #(8 2)))
 
 (let ((a (vector 1 2 3 4 5))
       (b (vector 10 20 30 40 50)))
 
   (vector-copy! b 1 a 0 2)
-  (assert-eqv? b #(10 1 2 40 50)))
+  (assert-equal? b #(10 1 2 40 50)))
 
-(assert-eqv? (vector-append #(a b c) #(d e f))
+(assert-equal? (vector-append #(a b c) #(d e f))
            #(a b c d e f))
 
 (let ((v (vector 1 2 3 4 5)))
   (vector-fill! v 'smash 2 4)
-  (assert-eqv? v #(1 2 smash smash 5)))
+  (assert-equal? v #(1 2 smash smash 5)))


### PR DESCRIPTION
This PR implements `equal?` using the method described in  Efficient Dondestructive Equality Checking for Trees and Graphs by Michael D. Adams and R. Kent Dybvig.

Additionally, attempting to display circular data structures no longer causes an infinite loop. The display method chosen is that the datum label syntax, although this syntax is currently unsupported by the reader. 