### PR TITLE
WIP: Properly implement `SchemeCompatible` trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ homepage = "https://github.com/maplant/scheme-rs"
 repository = "https://github.com/maplant/scheme-rs"
 
 [dependencies]
-ahash = "0.8"
 async-trait = "0.1"
 by_address = "1.2"
 derive_builder = "0.20"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -17,10 +17,13 @@ use crate::{
 };
 use either::Either;
 
-use ahash::{AHashMap, AHashSet};
 use derive_more::From;
 use futures::future::BoxFuture;
-use std::{fmt, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+    sync::Arc,
+};
 
 #[derive(Debug)]
 pub enum ParseAstError {
@@ -566,11 +569,11 @@ pub enum ImportSet {
     Library(LibraryReference),
     Only {
         set: Box<ImportSet>,
-        allowed: AHashSet<Identifier>,
+        allowed: HashSet<Identifier>,
     },
     Except {
         set: Box<ImportSet>,
-        disallowed: AHashSet<Identifier>,
+        disallowed: HashSet<Identifier>,
     },
     Prefix {
         set: Box<ImportSet>,
@@ -579,7 +582,7 @@ pub enum ImportSet {
     Rename {
         set: Box<ImportSet>,
         /// Imported identifiers to rename (from, to).
-        renames: AHashMap<Identifier, Identifier>,
+        renames: HashMap<Identifier, Identifier>,
     },
 }
 
@@ -612,7 +615,7 @@ impl ImportSet {
                         Syntax::Identifier { ident, .. } => Ok(ident.clone()),
                         _ => Err(ParseAstError::ExpectedIdentifier(allowed.span().clone())),
                     })
-                    .collect::<Result<AHashSet<_>, _>>()?;
+                    .collect::<Result<HashSet<_>, _>>()?;
                 Ok(Self::Only {
                     set: Box::new(import_set),
                     allowed,
@@ -635,7 +638,7 @@ impl ImportSet {
                         Syntax::Identifier { ident, .. } => Ok(ident.clone()),
                         _ => Err(ParseAstError::ExpectedIdentifier(disallowed.span().clone())),
                     })
-                    .collect::<Result<AHashSet<_>, _>>()?;
+                    .collect::<Result<HashSet<_>, _>>()?;
                 Ok(Self::Except {
                     set: Box::new(import_set),
                     disallowed,
@@ -680,7 +683,7 @@ impl ImportSet {
                         ) => Ok((from.clone(), to.clone())),
                         _ => Err(ParseAstError::BadForm(rename.span().clone())),
                     })
-                    .collect::<Result<AHashMap<_, _>, _>>()?;
+                    .collect::<Result<HashMap<_, _>, _>>()?;
                 Ok(Self::Rename {
                     set: Box::new(import_set),
                     renames,
@@ -832,7 +835,7 @@ impl Definition {
                     ] => {
                         let var = env.fetch_var(func_name).await?.unwrap();
 
-                        let mut bound = AHashMap::<Identifier, Span>::new();
+                        let mut bound = HashMap::<Identifier, Span>::new();
                         let mut fixed = Vec::new();
                         let new_env = env.new_lexical_contour();
                         let mut arg_names = Vec::new();
@@ -1202,7 +1205,7 @@ impl Quote {
 #[derive(Debug, Clone, Trace)]
 pub struct SyntaxQuote {
     pub template: Template,
-    pub expansions: AHashMap<Identifier, Local>,
+    pub expansions: HashMap<Identifier, Local>,
 }
 
 impl SyntaxQuote {
@@ -1210,7 +1213,7 @@ impl SyntaxQuote {
         match exprs {
             [] => Err(ParseAstError::ExpectedArgument(span.clone())),
             [expr] => {
-                let mut expansions = AHashMap::new();
+                let mut expansions = HashMap::new();
                 let template = Template::compile(expr, env, &mut expansions);
                 Ok(SyntaxQuote {
                     template,
@@ -1284,7 +1287,7 @@ async fn parse_lambda(
     env: &Environment,
     span: &Span,
 ) -> Result<Lambda, ParseAstError> {
-    let mut bound = AHashMap::<Identifier, Span>::new();
+    let mut bound = HashMap::<Identifier, Span>::new();
     let mut fixed = Vec::new();
     let new_contour = env.new_lexical_contour();
     let mut arg_names = Vec::new();
@@ -1396,7 +1399,7 @@ async fn parse_let(
     env: &Environment,
     span: &Span,
 ) -> Result<Let, ParseAstError> {
-    let mut previously_bound = AHashMap::new();
+    let mut previously_bound = HashMap::new();
     let mut parsed_bindings = Vec::new();
     let mut binding_names = Vec::new();
     let new_contour = env.new_lexical_contour();
@@ -1468,7 +1471,7 @@ impl LetBinding {
         runtime: &Runtime,
         form: &Syntax,
         env: &Environment,
-        previously_bound: &AHashMap<Identifier, Span>,
+        previously_bound: &HashMap<Identifier, Span>,
     ) -> Result<LetBinding, ParseAstError> {
         if let Some(
             [
@@ -1933,7 +1936,7 @@ impl SyntaxCase {
     ) -> Result<Self, ParseAstError> {
         let (arg, keywords, mut rules) = match exprs {
             [arg, Syntax::List { list, .. }, rules @ ..] => {
-                let mut keywords = AHashSet::default();
+                let mut keywords = HashSet::default();
                 // TODO: ensure keywords_list is proper
                 for keyword in &list[..list.len() - 1] {
                     if let Syntax::Identifier { ident, .. } = keyword {
@@ -1944,7 +1947,7 @@ impl SyntaxCase {
                 }
                 (arg, keywords, rules)
             }
-            [arg, Syntax::Null { .. }, rules @ ..] => (arg, AHashSet::default(), rules),
+            [arg, Syntax::Null { .. }, rules @ ..] => (arg, HashSet::default(), rules),
             _ => return Err(ParseAstError::BadForm(span.clone())),
         };
         let mut syntax_rules = Vec::new();

--- a/src/cps/analysis.rs
+++ b/src/cps/analysis.rs
@@ -21,7 +21,7 @@ use super::*;
 
 impl Cps {
     // TODO: Have this function return a Cow<'_, HashSet<Local>>
-    pub(super) fn free_variables(&self) -> AHashSet<Local> {
+    pub(super) fn free_variables(&self) -> HashSet<Local> {
         match self {
             Cps::PrimOp(PrimOp::AllocCell, _, bind, cexpr) => {
                 let mut free = cexpr.free_variables();
@@ -34,7 +34,7 @@ impl Cps {
                 free.union(&values_to_locals(args)).copied().collect()
             }
             Cps::If(cond, success, failure) => {
-                let mut free: AHashSet<_> = success
+                let mut free: HashSet<_> = success
                     .free_variables()
                     .union(&failure.free_variables())
                     .copied()
@@ -62,7 +62,7 @@ impl Cps {
                 for arg in args.iter() {
                     free_body.remove(arg);
                 }
-                let mut free_variables: AHashSet<_> =
+                let mut free_variables: HashSet<_> =
                     free_body.union(&cexp.free_variables()).copied().collect();
                 free_variables.remove(val);
                 free_variables
@@ -72,7 +72,7 @@ impl Cps {
     }
 
     // TODO: Have this function return a Cow<'_, HashSet<Local>>
-    pub(super) fn globals(&self) -> AHashSet<Global> {
+    pub(super) fn globals(&self) -> HashSet<Global> {
         match self {
             Cps::PrimOp(PrimOp::AllocCell, _, _, cexpr) => cexpr.globals(),
             Cps::PrimOp(_, args, _, cexpr) => cexpr
@@ -81,7 +81,7 @@ impl Cps {
                 .cloned()
                 .collect(),
             Cps::If(cond, success, failure) => {
-                let mut globals: AHashSet<_> = success
+                let mut globals: HashSet<_> = success
                     .globals()
                     .union(&failure.globals())
                     .cloned()
@@ -108,8 +108,8 @@ impl Cps {
     // TODO: Have this function return a Cow
     pub(super) fn uses(
         &self,
-        uses_cache: &mut AHashMap<Local, AHashMap<Local, usize>>,
-    ) -> AHashMap<Local, usize> {
+        uses_cache: &mut HashMap<Local, HashMap<Local, usize>>,
+    ) -> HashMap<Local, usize> {
         match self {
             // Cps::AllocCell(_, cexpr) => cexpr.uses(uses_cache).clone(),
             Cps::PrimOp(_, args, _, cexpr) => {
@@ -123,7 +123,7 @@ impl Cps {
                 let uses = values_to_uses(vals);
                 add_value_use(uses, op)
             }
-            Cps::Forward(op, arg) => add_value_use(add_value_use(AHashMap::new(), op), arg),
+            Cps::Forward(op, arg) => add_value_use(add_value_use(HashMap::new(), op), arg),
             Cps::Lambda {
                 body, val, cexp, ..
             } => {
@@ -133,7 +133,7 @@ impl Cps {
                 }
                 uses_cache.get(val).unwrap().clone()
             }
-            Cps::Halt(value) => add_value_use(AHashMap::new(), value),
+            Cps::Halt(value) => add_value_use(HashMap::new(), value),
         }
     }
 
@@ -181,9 +181,9 @@ impl Cps {
     // TODO: Clean up this function!
     pub(super) fn need_cells(
         &self,
-        local_args: &AHashSet<Local>,
-        escaping_arg_cache: &mut AHashMap<Local, AHashSet<Local>>,
-    ) -> AHashSet<Local> {
+        local_args: &HashSet<Local>,
+        escaping_arg_cache: &mut HashMap<Local, HashSet<Local>>,
+    ) -> HashSet<Local> {
         match self {
             Cps::PrimOp(PrimOp::Set, args, _, cexp) => {
                 let [to, from] = args.as_slice() else {
@@ -204,12 +204,12 @@ impl Cps {
             Cps::PrimOp(_, args, _, cexp) => values_to_locals(args)
                 .difference(local_args)
                 .copied()
-                .collect::<AHashSet<_>>()
+                .collect::<HashSet<_>>()
                 .union(&cexp.need_cells(local_args, escaping_arg_cache))
                 .copied()
-                .collect::<AHashSet<_>>(),
+                .collect::<HashSet<_>>(),
             Cps::If(cond, success, failure) => {
-                let mut escaping_args: AHashSet<_> = success
+                let mut escaping_args: HashSet<_> = success
                     .need_cells(local_args, escaping_arg_cache)
                     .union(&failure.need_cells(local_args, escaping_arg_cache))
                     .copied()
@@ -222,7 +222,7 @@ impl Cps {
                 escaping_args
             }
             Cps::App(op, vals, _) => {
-                let mut escaping_args: AHashSet<_> = values_to_locals(vals)
+                let mut escaping_args: HashSet<_> = values_to_locals(vals)
                     .difference(local_args)
                     .copied()
                     .collect();
@@ -235,7 +235,7 @@ impl Cps {
                 escaping_args
             }
             Cps::Forward(op, val) => {
-                let mut escaping_args = AHashSet::new();
+                let mut escaping_args = HashSet::new();
                 if let Some(local) = val.to_local()
                     && !local_args.contains(&local)
                 {
@@ -249,7 +249,7 @@ impl Cps {
                 escaping_args
             }
             Cps::Halt(val) => {
-                let mut escaping_args = AHashSet::new();
+                let mut escaping_args = HashSet::new();
                 if let Some(local) = val.to_local()
                     && !local_args.contains(&local)
                 {
@@ -265,7 +265,7 @@ impl Cps {
                 ..
             } => {
                 if !escaping_arg_cache.contains_key(val) {
-                    let new_local_args: AHashSet<_> = args.iter().copied().collect();
+                    let new_local_args: HashSet<_> = args.iter().copied().collect();
                     let escaping_args = body
                         .need_cells(&new_local_args, escaping_arg_cache)
                         .union(&cexp.need_cells(local_args, escaping_arg_cache))
@@ -280,26 +280,26 @@ impl Cps {
     }
 }
 
-fn values_to_locals(vals: &[Value]) -> AHashSet<Local> {
+fn values_to_locals(vals: &[Value]) -> HashSet<Local> {
     vals.iter().flat_map(|val| val.to_local()).collect()
 }
 
-fn values_to_uses(vals: &[Value]) -> AHashMap<Local, usize> {
-    let mut uses = AHashMap::new();
+fn values_to_uses(vals: &[Value]) -> HashMap<Local, usize> {
+    let mut uses = HashMap::new();
     for local in vals.iter().flat_map(|val| val.to_local()) {
         *uses.entry(local).or_default() += 1;
     }
     uses
 }
 
-fn values_to_globals(vals: &[Value]) -> AHashSet<Global> {
+fn values_to_globals(vals: &[Value]) -> HashSet<Global> {
     vals.iter().flat_map(|val| val.to_global()).collect()
 }
 
 fn merge_uses(
-    mut l: AHashMap<Local, usize>,
-    mut r: AHashMap<Local, usize>,
-) -> AHashMap<Local, usize> {
+    mut l: HashMap<Local, usize>,
+    mut r: HashMap<Local, usize>,
+) -> HashMap<Local, usize> {
     if r.len() > l.len() {
         for (local, uses) in l.into_iter() {
             *r.entry(local).or_default() += uses;
@@ -312,7 +312,7 @@ fn merge_uses(
         l
     }
 }
-fn add_value_use(mut uses: AHashMap<Local, usize>, value: &Value) -> AHashMap<Local, usize> {
+fn add_value_use(mut uses: HashMap<Local, usize>, value: &Value) -> HashMap<Local, usize> {
     if let Some(local) = value.to_local() {
         *uses.entry(local).or_default() += 1;
     }

--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -1,13 +1,12 @@
 //! Cranelift Codegen from CPS.
 
-use ahash::AHashMap;
 use cranelift::{
     codegen::ir::{StackSlot, entities::Value},
     prelude::*,
 };
 use cranelift_jit::JITModule;
 use cranelift_module::{FuncId, Linkage, Module};
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use crate::{
     cps::{Value as CpsValue, analysis::MaxDrops},
@@ -25,7 +24,7 @@ enum IrValue {
 }
 
 struct Rebinds {
-    rebinds: AHashMap<Var, IrValue>,
+    rebinds: HashMap<Var, IrValue>,
 }
 
 impl Rebinds {
@@ -41,7 +40,7 @@ impl Rebinds {
 
     fn new() -> Self {
         Self {
-            rebinds: AHashMap::default(),
+            rebinds: HashMap::default(),
         }
     }
 }
@@ -922,7 +921,7 @@ impl ClosureBundle {
 
         let env = body
             .free_variables()
-            .difference(&args.iter().cloned().collect::<AHashSet<_>>())
+            .difference(&args.iter().cloned().collect::<HashSet<_>>())
             .cloned()
             .collect::<Vec<_>>();
         let globals = body.globals().into_iter().collect::<Vec<_>>();

--- a/src/cps/compile.rs
+++ b/src/cps/compile.rs
@@ -3,6 +3,7 @@ use crate::{
     ast::*,
     expand::{ExpansionCombiner, SyntaxRule},
     gc::Gc,
+    records::Record,
     value::Value as RuntimeValue,
 };
 use either::Either;
@@ -27,7 +28,7 @@ pub trait Compile: std::fmt::Debug {
             span: None,
         }
         .reduce()
-        .args_to_cells(&mut AHashMap::default())
+        .args_to_cells(&mut HashMap::default())
     }
 }
 
@@ -754,7 +755,7 @@ impl Compile for SyntaxQuote {
         let expanded = Local::gensym();
 
         let mut expansions_seen = IndexSet::new();
-        let mut uses = AHashMap::new();
+        let mut uses = HashMap::new();
 
         for (ident, expansion) in self.expansions.iter() {
             let (idx, _) = expansions_seen.insert_full(expansion);
@@ -762,12 +763,12 @@ impl Compile for SyntaxQuote {
         }
 
         let mut args = vec![
-            Value::from(RuntimeValue::from(Gc::new(Gc::into_any(Gc::new(
+            Value::from(RuntimeValue::from(Record::from_rust_type(
                 self.template.clone(),
-            ))))),
-            Value::from(RuntimeValue::from(Gc::new(Gc::into_any(Gc::new(
+            ))),
+            Value::from(RuntimeValue::from(Record::from_rust_type(
                 ExpansionCombiner { uses },
-            ))))),
+            ))),
         ];
 
         for expansion in expansions_seen.iter() {
@@ -833,7 +834,7 @@ fn compile_syntax_rules(
                 Box::new(Cps::App(Value::from(k2), Vec::new(), None)),
             )),
             [rule, tail @ ..] => {
-                let pattern = Gc::new(Gc::into_any(Gc::new(rule.pattern.clone())));
+                let pattern = Record::from_rust_type(rule.pattern.clone());
                 Box::new(Cps::PrimOp(
                     PrimOp::Matches,
                     vec![Value::from(RuntimeValue::from(pattern)), Value::from(arg)],
@@ -929,7 +930,7 @@ impl Compile for Vec<u8> {
 
 impl Cps {
     /// Convert arguments for closures into cells if they are written to or escape.
-    fn args_to_cells(self, needs_cell_cache: &mut AHashMap<Local, AHashSet<Local>>) -> Self {
+    fn args_to_cells(self, needs_cell_cache: &mut HashMap<Local, HashSet<Local>>) -> Self {
         match self {
             Self::PrimOp(PrimOp::AllocCell, vals, local, cexpr) => Self::PrimOp(
                 PrimOp::AllocCell,
@@ -960,7 +961,7 @@ impl Cps {
                 cexp,
                 span: loc,
             } => {
-                let local_args: AHashSet<_> = args.iter().copied().collect();
+                let local_args: HashSet<_> = args.iter().copied().collect();
                 let escaping_args = body.need_cells(&local_args, needs_cell_cache);
 
                 let mut body = Box::new(body.args_to_cells(needs_cell_cache));

--- a/src/cps/mod.rs
+++ b/src/cps/mod.rs
@@ -19,8 +19,7 @@ use crate::{
     syntax::Span,
     value::Value as RuntimeValue,
 };
-use ahash::{AHashMap, AHashSet};
-use std::fmt;
+use std::{collections::{HashMap, HashSet}, fmt};
 
 mod analysis;
 pub(crate) mod codegen;
@@ -198,7 +197,7 @@ pub enum Cps {
 
 impl Cps {
     /// Perform substitutions on local variables.
-    fn substitute(&mut self, substitutions: &AHashMap<Local, Value>) {
+    fn substitute(&mut self, substitutions: &HashMap<Local, Value>) {
         match self {
             Self::PrimOp(_, args, _, cexp) => {
                 substitute_values(args, substitutions);
@@ -228,7 +227,7 @@ impl Cps {
     }
 }
 
-fn substitute_value(value: &mut Value, substitutions: &AHashMap<Local, Value>) {
+fn substitute_value(value: &mut Value, substitutions: &HashMap<Local, Value>) {
     if let Some(local) = value.to_local()
         && let Some(substitution) = substitutions.get(&local)
     {
@@ -236,7 +235,7 @@ fn substitute_value(value: &mut Value, substitutions: &AHashMap<Local, Value>) {
     }
 }
 
-fn substitute_values(values: &mut [Value], substitutions: &AHashMap<Local, Value>) {
+fn substitute_values(values: &mut [Value], substitutions: &HashMap<Local, Value>) {
     values
         .iter_mut()
         .for_each(|value| substitute_value(value, substitutions))

--- a/src/cps/reduce.rs
+++ b/src/cps/reduce.rs
@@ -6,7 +6,7 @@ use super::*;
 impl Cps {
     pub(super) fn reduce(self) -> Self {
         // Perform beta reduction twice. This seems like the sweet spot for now
-        let mut uses_cache = AHashMap::default();
+        let mut uses_cache = HashMap::default();
         self.beta_reduction(&mut uses_cache)
             .beta_reduction(&mut uses_cache)
             .dead_code_elimination(&mut uses_cache)
@@ -21,7 +21,7 @@ impl Cps {
     ///
     /// The uses analysis cache is absolutely demolished and dangerous to use by
     /// the end of this function.
-    fn beta_reduction(self, uses_cache: &mut AHashMap<Local, AHashMap<Local, usize>>) -> Self {
+    fn beta_reduction(self, uses_cache: &mut HashMap<Local, HashMap<Local, usize>>) -> Self {
         match self {
             Cps::PrimOp(prim_op, values, result, cexp) => Cps::PrimOp(
                 prim_op,
@@ -76,7 +76,7 @@ impl Cps {
         func: Local,
         args: &ClosureArgs,
         func_body: &Cps,
-        uses_cache: &mut AHashMap<Local, AHashMap<Local, usize>>,
+        uses_cache: &mut HashMap<Local, HashMap<Local, usize>>,
     ) -> bool {
         let new = match self {
             Cps::PrimOp(_, _, _, cexp) => {
@@ -97,7 +97,7 @@ impl Cps {
                 return reduced;
             }
             Cps::App(Value::Var(Var::Local(operator)), applied, _) if *operator == func => {
-                let substitutions: AHashMap<_, _> =
+                let substitutions: HashMap<_, _> =
                     args.iter().copied().zip(applied.iter().cloned()).collect();
                 let mut body = func_body.clone();
                 body.substitute(&substitutions);
@@ -113,7 +113,7 @@ impl Cps {
     #[allow(dead_code)]
     fn dead_code_elimination(
         self,
-        uses_cache: &mut AHashMap<Local, AHashMap<Local, usize>>,
+        uses_cache: &mut HashMap<Local, HashMap<Local, usize>>,
     ) -> Self {
         match self {
             Cps::Lambda { val, cexp, .. } if !cexp.uses(uses_cache).contains_key(&val) => {

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,11 +1,10 @@
 use std::{
-    collections::hash_map::Entry,
+    collections::{hash_map::Entry, HashMap, HashSet},
     fmt,
     hash::{Hash, Hasher},
     sync::atomic::{AtomicUsize, Ordering},
 };
 
-use ahash::{AHashMap, AHashSet};
 use either::Either;
 use futures::future::BoxFuture;
 
@@ -27,9 +26,9 @@ use crate::{
 #[derive(Trace)]
 pub struct LexicalContour {
     up: Environment,
-    vars: AHashMap<Identifier, Local>,
-    keywords: AHashMap<Identifier, Closure>,
-    imports: AHashMap<Identifier, Import>,
+    vars: HashMap<Identifier, Local>,
+    keywords: HashMap<Identifier, Closure>,
+    imports: HashMap<Identifier, Import>,
 }
 
 impl LexicalContour {
@@ -142,7 +141,7 @@ impl Gc<LexicalContour> {
 #[derive(Trace)]
 pub struct LetSyntaxContour {
     up: Environment,
-    keywords: AHashMap<Identifier, Closure>,
+    keywords: HashMap<Identifier, Closure>,
     recursive: bool,
 }
 
@@ -377,11 +376,11 @@ pub struct SyntaxCaseExpr {
     #[debug(skip)]
     up: Environment,
     expansions_store: Local,
-    pattern_vars: AHashSet<Identifier>,
+    pattern_vars: HashSet<Identifier>,
 }
 
 impl SyntaxCaseExpr {
-    fn new(env: &Environment, expansions_store: Local, pattern_vars: AHashSet<Identifier>) -> Self {
+    fn new(env: &Environment, expansions_store: Local, pattern_vars: HashSet<Identifier>) -> Self {
         Self {
             up: env.clone(),
             expansions_store,
@@ -625,7 +624,7 @@ impl Environment {
     pub fn new_syntax_case_expr(
         &self,
         expansions_store: Local,
-        pattern_vars: AHashSet<Identifier>,
+        pattern_vars: HashSet<Identifier>,
     ) -> Self {
         let syntax_case_expr = SyntaxCaseExpr::new(self, expansions_store, pattern_vars);
         Self::SyntaxCaseExpr(Gc::new(syntax_case_expr))

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -7,6 +7,7 @@ use crate::{
     gc::{Gc, GcInner, Trace},
     lists,
     proc::{Application, Closure, DynamicWind, FuncPtr},
+    records::{RecordTypeDescriptor, SchemeCompatible},
     runtime::{Runtime, RuntimeInner},
     symbols::Symbol,
     syntax::{Identifier, Span, Syntax},
@@ -131,16 +132,25 @@ impl Condition {
     }
 }
 
+impl fmt::Display for Condition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Self as fmt::Debug>::fmt(self, f)
+    }
+}
+
+impl SchemeCompatible for Condition {
+    fn rtd(&self) -> Arc<RecordTypeDescriptor> {
+        todo!()
+    }
+}
+
 impl From<Exception> for Condition {
     fn from(e: Exception) -> Self {
         // For now just drop the back trace:
-        let Ok(v) = Gc::<Gc<dyn std::any::Any>>::try_from(e.obj) else {
+        let Ok(v) = Gc::<Self>::try_from(e.obj) else {
             return Condition::Error;
         };
-        let Ok(c) = v.read().clone().downcast::<Self>() else {
-            return Condition::Error;
-        };
-        c.read().clone()
+        v.read().clone()
     }
 }
 

--- a/src/futures.rs
+++ b/src/futures.rs
@@ -12,23 +12,29 @@ use tokio::{
 };
 
 use crate::{
-    exception::Condition, gc::Gc, num::Number, proc::Closure, strings::AlignedString, value::Value,
-    vectors::AlignedVector,
+    exception::Condition, gc::Gc, num::Number, proc::Closure, records::{Record, RecordTypeDescriptor, SchemeCompatible}, strings::AlignedString, value::Value, vectors::AlignedVector
 };
 
 type Future = Shared<BoxFuture<'static, Result<Vec<Value>, Condition>>>;
+
+impl SchemeCompatible for Future {
+    fn rtd(&self) -> Arc<RecordTypeDescriptor> {
+        todo!()
+    }
+}
 
 #[bridge(name = "spawn", lib = "(base)")]
 pub async fn spawn(task: &Value) -> Result<Vec<Value>, Condition> {
     let task: Closure = task.clone().try_into()?;
     let task = tokio::task::spawn(async move { Ok(task.call(&[]).await?) });
     let future: Future = async move { task.await.unwrap() }.boxed().shared();
-    let future = Value::from(Gc::new(Gc::into_any(Gc::new(future))));
+    let future = Value::from(Record::from_rust_type(future));
     Ok(vec![future])
 }
 
 #[bridge(name = "await", lib = "(base)")]
 pub async fn await_future(future: &Value) -> Result<Vec<Value>, Condition> {
+    /*
     let future = {
         let any: Gc<Gc<dyn Any>> = future.clone().try_into()?;
         let future: Gc<Future> = any
@@ -39,20 +45,27 @@ pub async fn await_future(future: &Value) -> Result<Vec<Value>, Condition> {
         future.read().clone()
     };
     future.await
+     */
+    todo!()
 }
 
 #[bridge(name = "bind-tcp", lib = "(base)")]
 pub async fn bind_tcp(addr: &Value) -> Result<Vec<Value>, Condition> {
+    /*
     let addr: Arc<AlignedString> = addr.clone().try_into()?;
     let listener = TcpListener::bind(addr.as_str())
         .await
         .map_err(|e| Condition::error(format!("failed to bind to address: {e:?}")))?;
     let listener = Value::from(Gc::new(Gc::into_any(Gc::new(Arc::new(listener)))));
     Ok(vec![listener])
+     */
+    todo!()
+
 }
 
 #[bridge(name = "accept", lib = "(base)")]
 pub async fn accept(listener: &Value) -> Result<Vec<Value>, Condition> {
+    /*
     let listener = {
         let any: Gc<Gc<dyn Any>> = listener.clone().try_into()?;
         let listener: Gc<Arc<TcpListener>> = any
@@ -69,10 +82,14 @@ pub async fn accept(listener: &Value) -> Result<Vec<Value>, Condition> {
     let socket = Value::from(Gc::new(Gc::into_any(Gc::new(Arc::new(Mutex::new(socket))))));
     let addr = Value::from(addr.to_string());
     Ok(vec![socket, addr])
+     */
+    todo!()
+
 }
 
 #[bridge(name = "read", lib = "(base)")]
 pub async fn read(socket: &Value, buff_size: &Value) -> Result<Vec<Value>, Condition> {
+    /*
     let buff_size: Arc<Number> = buff_size.clone().try_into()?;
     let buff_size: usize = buff_size.as_ref().try_into()?;
     let mut buffer = vec![0u8; buff_size];
@@ -96,10 +113,13 @@ pub async fn read(socket: &Value, buff_size: &Value) -> Result<Vec<Value>, Condi
     buffer.resize(len, 0);
 
     Ok(vec![Value::from(buffer)])
+     */
+    todo!()
 }
 
 #[bridge(name = "write", lib = "(base)")]
 pub async fn write(socket: &Value, buffer: &Value) -> Result<Vec<Value>, Condition> {
+    /*
     let buffer: Arc<AlignedVector<u8>> = buffer.clone().try_into()?;
     let socket = {
         let any: Gc<Gc<dyn Any>> = socket.clone().try_into()?;
@@ -119,4 +139,6 @@ pub async fn write(socket: &Value, buffer: &Value) -> Result<Vec<Value>, Conditi
         .map_err(|e| Condition::error(format!("failed to read from socket: {e:?}")))?;
 
     Ok(vec![Value::from(buffer)])
+     */
+    todo!()
 }

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -36,8 +36,8 @@ use std::{
 
 /// A Garbage-Collected smart pointer with interior mutability.
 pub struct Gc<T: ?Sized> {
-    ptr: NonNull<GcInner<T>>,
-    marker: PhantomData<GcInner<T>>,
+    pub(crate) ptr: NonNull<GcInner<T>>,
+    pub(crate) marker: PhantomData<GcInner<T>>,
 }
 
 #[allow(private_bounds)]

--- a/src/value.rs
+++ b/src/value.rs
@@ -7,15 +7,15 @@ use crate::{
     lists,
     num::{Number, ReflexiveNumber},
     proc::{Closure, ClosureInner},
-    records::{Record, RecordTypeDescriptor},
+    records::{Record, RecordInner, RecordTypeDescriptor, SchemeCompatible},
     registry::bridge,
     strings, symbols,
     syntax::Syntax,
     vectors,
 };
 use std::{
-    any::Any, collections::HashMap, fmt, hash::Hash, io::Write, marker::PhantomData,
-    mem::ManuallyDrop, ops::Deref, sync::Arc,
+    collections::HashMap, fmt, hash::Hash, io::Write, marker::PhantomData, mem::ManuallyDrop,
+    ops::Deref, sync::Arc,
 };
 
 const ALIGNMENT: u64 = 16;
@@ -71,7 +71,7 @@ impl Value {
                     Gc::increment_reference_count(untagged as *mut GcInner<ClosureInner>)
                 }
                 ValueType::Record => {
-                    Gc::increment_reference_count(untagged as *mut GcInner<Record>)
+                    Gc::increment_reference_count(untagged as *mut GcInner<RecordInner>)
                 }
                 ValueType::RecordTypeDescriptor => {
                     Arc::increment_strong_count(untagged as *const RecordTypeDescriptor)
@@ -79,9 +79,7 @@ impl Value {
                 ValueType::Pair => {
                     Gc::increment_reference_count(untagged as *mut GcInner<lists::Pair>)
                 }
-                ValueType::Any => {
-                    Gc::increment_reference_count(untagged as *mut GcInner<Gc<dyn Any>>)
-                }
+                ValueType::HashTable => todo!(),
                 ValueType::Reserved => todo!(),
                 ValueType::Undefined
                 | ValueType::Symbol
@@ -165,6 +163,18 @@ impl Value {
         }
     }
 
+    pub fn try_into_rust_type<T: SchemeCompatible>(&self) -> Result<Gc<T>, Condition> {
+        let this = self.clone().unpack();
+        let record = match this {
+            UnpackedValue::Record(record) => record,
+            e => return Err(Condition::invalid_type("record-todo", e.type_name())),
+        };
+
+        record
+            .try_into_rust_type::<T>()
+            .ok_or_else(|| Condition::invalid_type("record-todo", "record"))
+    }
+
     pub fn unpack(self) -> UnpackedValue {
         let raw = ManuallyDrop::new(self).0;
         let tag = ValueType::from(raw & TAG);
@@ -210,8 +220,8 @@ impl Value {
                 UnpackedValue::Closure(Closure(clos))
             }
             ValueType::Record => {
-                let rec = unsafe { Gc::from_raw(untagged as *mut GcInner<Record>) };
-                UnpackedValue::Record(rec)
+                let rec = unsafe { Gc::from_raw(untagged as *mut GcInner<RecordInner>) };
+                UnpackedValue::Record(Record(rec))
             }
             ValueType::RecordTypeDescriptor => {
                 let rt = unsafe { Arc::from_raw(untagged as *const RecordTypeDescriptor) };
@@ -221,10 +231,7 @@ impl Value {
                 let pair = unsafe { Gc::from_raw(untagged as *mut GcInner<lists::Pair>) };
                 UnpackedValue::Pair(pair)
             }
-            ValueType::Any => {
-                let any = unsafe { Gc::from_raw(untagged as *mut GcInner<Gc<dyn Any>>) };
-                UnpackedValue::Any(any)
-            }
+            ValueType::HashTable => todo!(),
             ValueType::Reserved => todo!(),
         }
     }
@@ -340,7 +347,7 @@ pub enum ValueType {
     Record = 11,
     RecordTypeDescriptor = 12,
     Pair = 13,
-    Any = 14,
+    HashTable = 14,
     Reserved = 15,
 }
 
@@ -362,7 +369,6 @@ impl From<u64> for ValueType {
             11 => Self::Record,
             12 => Self::RecordTypeDescriptor,
             13 => Self::Pair,
-            14 => Self::Any,
             tag => panic!("Invalid tag: {tag}"),
         }
     }
@@ -386,10 +392,9 @@ pub enum UnpackedValue {
     ByteVector(Arc<vectors::AlignedVector<u8>>),
     Syntax(Arc<Syntax>),
     Closure(Closure),
-    Record(Gc<Record>),
+    Record(Record),
     RecordTypeDescriptor(Arc<RecordTypeDescriptor>),
     Pair(Gc<lists::Pair>),
-    Any(Gc<Gc<dyn Any>>),
 }
 
 impl UnpackedValue {
@@ -425,7 +430,7 @@ impl UnpackedValue {
                 Value::from_mut_ptr_and_tag(untagged, ValueType::Closure)
             }
             Self::Record(rec) => {
-                let untagged = Gc::into_raw(rec);
+                let untagged = Gc::into_raw(rec.0);
                 Value::from_mut_ptr_and_tag(untagged, ValueType::Record)
             }
             Self::RecordTypeDescriptor(rt) => {
@@ -435,10 +440,6 @@ impl UnpackedValue {
             Self::Pair(pair) => {
                 let untagged = Gc::into_raw(pair);
                 Value::from_mut_ptr_and_tag(untagged, ValueType::Pair)
-            }
-            Self::Any(any) => {
-                let untagged = Gc::into_raw(any);
-                Value::from_mut_ptr_and_tag(untagged, ValueType::Any)
             }
         }
     }
@@ -457,7 +458,7 @@ impl UnpackedValue {
             (Self::ByteVector(a), Self::ByteVector(b)) => Arc::ptr_eq(a, b),
             (Self::Closure(a), Self::Closure(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::Syntax(a), Self::Syntax(b)) => Arc::ptr_eq(a, b),
-            (Self::Record(a), Self::Record(b)) => Gc::ptr_eq(a, b),
+            (Self::Record(a), Self::Record(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::RecordTypeDescriptor(a), Self::RecordTypeDescriptor(b)) => Arc::ptr_eq(a, b),
             _ => false,
         }
@@ -482,7 +483,7 @@ impl UnpackedValue {
             (Self::ByteVector(a), Self::ByteVector(b)) => Arc::ptr_eq(a, b),
             (Self::Closure(a), Self::Closure(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::Syntax(a), Self::Syntax(b)) => Arc::ptr_eq(a, b),
-            (Self::Record(a), Self::Record(b)) => Gc::ptr_eq(a, b),
+            (Self::Record(a), Self::Record(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::RecordTypeDescriptor(a), Self::RecordTypeDescriptor(b)) => Arc::ptr_eq(a, b),
             _ => false,
         }
@@ -501,7 +502,7 @@ impl UnpackedValue {
             Self::ByteVector(_) => "byte vector",
             Self::Syntax(_) => "syntax",
             Self::Closure(_) => "procedure",
-            Self::Record(_) | Self::RecordTypeDescriptor(_) | Self::Any(_) => "record",
+            Self::Record(_) | Self::RecordTypeDescriptor(_) => "record",
         }
     }
 }
@@ -748,9 +749,8 @@ impl_try_from_value_for!(Arc<vectors::AlignedVector<u8>>, ByteVector, "byte-vect
 impl_try_from_value_for!(Arc<Syntax>, Syntax, "syntax");
 impl_try_from_value_for!(Closure, Closure, "procedure");
 impl_try_from_value_for!(Gc<lists::Pair>, Pair, "pair");
-impl_try_from_value_for!(Gc<Record>, Record, "record");
+impl_try_from_value_for!(Record, Record, "record");
 impl_try_from_value_for!(Arc<RecordTypeDescriptor>, RecordTypeDescriptor, "rt");
-impl_try_from_value_for!(Gc<Gc<dyn Any>>, Any, "record");
 
 macro_rules! impl_from_wrapped_for {
     ($ty:ty, $variant:ident, $wrapper:expr_2021) => {
@@ -788,7 +788,7 @@ macro_rules! impl_try_from_for_any {
     ($ty:ty, $name:literal) => {
         impl From<$ty> for UnpackedValue {
             fn from(val: $ty) -> Self {
-                Self::Any(Gc::new(Gc::into_any(Gc::new(val))))
+                Self::Record(Record::from_rust_type(val))
             }
         }
 
@@ -802,6 +802,15 @@ macro_rules! impl_try_from_for_any {
             type Error = Condition;
 
             fn try_from(val: UnpackedValue) -> Result<Self, Self::Error> {
+                let record = match val {
+                    UnpackedValue::Record(record) => record,
+                    e => return Err(Condition::invalid_type($name, e.type_name())),
+                };
+
+                record
+                    .try_into_rust_type::<$ty>()
+                    .ok_or_else(|| Condition::invalid_type($name, "record"))
+                /*
                 let any = match val {
                     UnpackedValue::Any(v) => v,
                     e => return Err(Condition::invalid_type($name, e.type_name())),
@@ -811,6 +820,7 @@ macro_rules! impl_try_from_for_any {
                     Ok(ok) => Ok(ok),
                     Err(_) => Err(Condition::invalid_type($name, "record")),
                 }
+                */
             }
         }
 
@@ -867,9 +877,8 @@ impl Hash for EqvValue {
             UnpackedValue::ByteVector(v) => v.hash(state),
             UnpackedValue::Syntax(s) => Arc::as_ptr(s).hash(state),
             UnpackedValue::Closure(c) => Gc::as_ptr(&c.0).hash(state),
-            UnpackedValue::Record(r) => Gc::as_ptr(r).hash(state),
+            UnpackedValue::Record(r) => Gc::as_ptr(&r.0).hash(state),
             UnpackedValue::RecordTypeDescriptor(rt) => Arc::as_ptr(rt).hash(state),
-            UnpackedValue::Any(a) => Gc::as_ptr(a).hash(state),
             UnpackedValue::Pair(p) => Gc::as_ptr(p).hash(state),
             UnpackedValue::Vector(v) => Gc::as_ptr(v).hash(state),
         }
@@ -908,9 +917,9 @@ impl Hash for ReflexiveValue {
             UnpackedValue::ByteVector(v) => v.hash(state),
             UnpackedValue::Syntax(s) => Arc::as_ptr(s).hash(state),
             UnpackedValue::Closure(c) => Gc::as_ptr(&c.0).hash(state),
-            UnpackedValue::Record(r) => Gc::as_ptr(r).hash(state),
+            UnpackedValue::Record(r) => Gc::as_ptr(&r.0).hash(state),
             UnpackedValue::RecordTypeDescriptor(rt) => Arc::as_ptr(rt).hash(state),
-            UnpackedValue::Any(a) => Gc::as_ptr(a).hash(state),
+            // UnpackedValue::Any(a) => Gc::as_ptr(a).hash(state),
             // UnpackedValue::Condition(c) => Gc::as_ptr(c).hash(state),
             // UnpackedValue::OtherData(o) => Gc::as_ptr(o).hash(state),
             // TODO: We can make this better by checking the vectors and list
@@ -942,11 +951,10 @@ impl PartialEq for ReflexiveValue {
             (UnpackedValue::ByteVector(a), UnpackedValue::ByteVector(b)) => a == b,
             (UnpackedValue::Syntax(a), UnpackedValue::Syntax(b)) => Arc::ptr_eq(a, b),
             (UnpackedValue::Closure(a), UnpackedValue::Closure(b)) => Gc::ptr_eq(&a.0, &b.0),
-            (UnpackedValue::Record(a), UnpackedValue::Record(b)) => Gc::ptr_eq(a, b),
+            (UnpackedValue::Record(a), UnpackedValue::Record(b)) => Gc::ptr_eq(&a.0, &b.0),
             (UnpackedValue::RecordTypeDescriptor(a), UnpackedValue::RecordTypeDescriptor(b)) => {
                 Arc::ptr_eq(a, b)
             }
-            (UnpackedValue::Any(a), UnpackedValue::Any(b)) => Gc::ptr_eq(a, b),
             _ => false,
         }
     }
@@ -1032,13 +1040,6 @@ fn display_value(
         UnpackedValue::Record(record) => write!(f, "<{record:?}>"),
         UnpackedValue::Syntax(syntax) => write!(f, "{syntax:#?}"),
         UnpackedValue::RecordTypeDescriptor(rtd) => write!(f, "<{rtd:?}>"),
-        UnpackedValue::Any(any) => {
-            let any = any.read().clone();
-            let Ok(cond) = any.downcast::<Condition>() else {
-                return write!(f, "<record>");
-            };
-            write!(f, "<{cond:?}>")
-        }
     }
 }
 
@@ -1067,13 +1068,6 @@ fn debug_value(
         UnpackedValue::Closure(proc) => write!(f, "#<procedure {proc:?}>"),
         UnpackedValue::Record(record) => write!(f, "<{record:#?}>"),
         UnpackedValue::RecordTypeDescriptor(rtd) => write!(f, "<{rtd:?}>"),
-        UnpackedValue::Any(any) => {
-            let any = any.read().clone();
-            let Ok(cond) = any.downcast::<Condition>() else {
-                return write!(f, "<record>");
-            };
-            write!(f, "<{cond:?}>")
-        }
     }
 }
 #[bridge(name = "not", lib = "(rnrs base builtins (6))")]


### PR DESCRIPTION
This PR removes the separate "Any" value type and moves those into Record, and additionally adds a lot of nice functions to make using them easier. 
