### PR TITLE
Implement `define-record-type` macro

### DIFF
--- a/scheme/rnrs.sls
+++ b/scheme/rnrs.sls
@@ -1,5 +1,6 @@
 (library (rnrs (6))
   (export (import (rnrs base))
           (import (rnrs syntax-case))
+          (import (rnrs records syntactic))
           (import (rnrs records procedural))))
    

--- a/scheme/rnrs/base.sls
+++ b/scheme/rnrs/base.sls
@@ -7,9 +7,7 @@
           (import (rnrs lists (6)))
           (import (rnrs base builtins (6))
                   (except (rnrs base special-keywords (6)) $call/cc $undefined)
-                  (rnrs syntax-case special-keywords (6)))
-          (import (rnrs records procedural (6)))
-          (import (rnrs records syntactic (6))))
+                  (rnrs syntax-case special-keywords (6))))
   (import (rnrs syntax-case (6))
           (only (rnrs base special-keywords (6)) $call/cc $undefined))
 

--- a/scheme/rnrs/base.sls
+++ b/scheme/rnrs/base.sls
@@ -7,7 +7,9 @@
           (import (rnrs lists (6)))
           (import (rnrs base builtins (6))
                   (except (rnrs base special-keywords (6)) $call/cc $undefined)
-                  (rnrs syntax-case special-keywords (6))))
+                  (rnrs syntax-case special-keywords (6)))
+          (import (rnrs records procedural (6)))
+          (import (rnrs records syntactic (6))))
   (import (rnrs syntax-case (6))
           (only (rnrs base special-keywords (6)) $call/cc $undefined))
 
@@ -26,7 +28,7 @@
       (syntax-case x ()
         ((_ ((p e0) ...) e1 e2 ...)
          (syntax (syntax-case (list e0 ...) ()
-		   ((p ...) (let () e1 e2 ...))))))))
+                   ((p ...) (let () e1 e2 ...))))))))
 
   (define-syntax cond
     (syntax-rules (else =>)

--- a/scheme/rnrs/records/syntactic.sls
+++ b/scheme/rnrs/records/syntactic.sls
@@ -1,0 +1,113 @@
+
+(library (rnrs records syntactic (6))
+  (export define-record-type)
+  (import (rnrs lists (6))
+          (rnrs base builtins (6))
+          (rnrs base special-keywords (6))
+          (rnrs syntax-case (6))
+          (rnrs records procedural (6)))
+
+  (define-syntax with-syntax
+    (lambda (x)
+      (syntax-case x ()
+        ((_ ((p e0) ...) e1 e2 ...)
+         (syntax (syntax-case (list e0 ...) ()
+                   ((p ...) (let () e1 e2 ...))))))))
+
+  (define-syntax define-record-type
+    (lambda (x)
+      (define (id ctxt . str*)
+        (datum->syntax ctxt 
+          (string->symbol 
+            (apply string-append 
+              (map (lambda (x) 
+                     (if (symbol? x)
+                         (symbol->string x)
+                         (if (string? x) x)))
+                   str*)))))
+      (define (get-record-name spec)
+        (syntax-case spec ()
+          [(foo make-foo foo?) #'foo]
+          [foo #'foo]))
+      (define (get-record-constructor-name spec ctxt)
+        (syntax-case spec ()
+          [(foo make-foo foo?) #'make-foo]
+          [foo (id ctxt "make-" (syntax->datum #'foo))]))
+      (define (get-record-predicate-name spec ctxt)
+        (syntax-case spec ()
+          [(foo make-foo foo?) #'foo?]
+          [foo (id ctxt (syntax->datum #'foo) "?")]))
+      (define (get-clause id ls)
+        (syntax-case ls ()
+          [() #f]
+          [((x . rest) . ls)
+           (if (free-identifier=? id #'x) 
+               #'(x . rest)
+               (get-clause id #'ls))]))
+      (define (foo-rtd-code ctxt name clause*) 
+        (define (convert-field-spec* ls)
+          (list #'quote
+            (list->vector
+              (map (lambda (x) 
+                     (syntax-case x (mutable immutable)
+                       [(mutable name . rest) #'(mutable name)]
+                       [(immutable name . rest) #'(immutable name)]
+                       [name #'(immutable name)]))
+                   ls))))
+        (with-syntax ([name name]
+                      [parent-rtd-code 
+                       (syntax-case (get-clause #'parent clause*) ()
+                         [(_ name) #'(record-type-descriptor name)]
+                         [_ #'#f])]
+                      [uid-code 
+                       (syntax-case (get-clause #'nongenerative clause*) ()
+                         [(_) (datum->syntax ctxt (gensym))]
+                         [(_ uid) #''uid]
+                         [_ #'#f])]
+                      [sealed?
+                       (syntax-case (get-clause #'sealed? clause*) ()
+                         [(_ #t) #'#t]
+                         [_      #'#f])]
+                      [opaque?
+                       (syntax-case (get-clause #'opaque? clause*) ()
+                         [(_ #t) #'#t]
+                         [_      #'#f])]
+                      [fields 
+                       (syntax-case (get-clause #'fields clause*) ()
+                         [(_ field-spec* ...) 
+                          (convert-field-spec* #'(field-spec* ...))]
+                         [_ #''#()])])
+          #'(make-record-type-descriptor 'name
+               parent-rtd-code 
+               uid-code sealed? opaque? fields)))
+      (define (foo-rcd-code clause*) 
+        (with-syntax ([parent-rcd-code 
+                       (syntax-case (get-clause #'parent clause*) ()
+                         [(_ name) #'(record-constructor-descriptor name)]
+                         [_ #'#f])])
+          #'(make-record-constructor-descriptor foo-rtd
+               parent-rcd-code protocol)))
+      (define (get-protocol-code clause*)
+        (syntax-case (get-clause #'protocol clause*) ()
+          [(_ expr) #'expr]
+          [_        #'#f]))
+      (define (do-define-record ctxt namespec clause*)
+        (let ([name (get-record-name namespec)])
+          (with-syntax ([make-foo (get-record-constructor-name namespec ctxt)] 
+                        [foo? (get-record-predicate-name namespec ctxt)]
+                        [foo-rtd-code (foo-rtd-code ctxt name clause*)]
+                        [protocol-code (get-protocol-code clause*)])
+            #'(begin
+                (define foo-rtd foo-rtd-code)
+                (define protocol protocol-code)
+                (define foo-rcd foo-rcd-code)
+                (define-syntax foo (list '$rtd #'foo-rtd #'foo-rcd))
+                (define foo? (record-predicate foo-rtd))
+                (define make-foo (record-constructor foo-rcd))
+                (define foo-x* (record-accessor foo-rtd idx*))
+                ...
+                (define set-foo-x!* (record-mutator foo-rtd mutable-idx*))
+                ...))))
+      (syntax-case x ()
+        [(ctxt namespec clause* ...)
+         (do-define-record #'ctxt #'namespec #'(clause* ...))]))))

--- a/scheme/rnrs/syntax-case.sls
+++ b/scheme/rnrs/syntax-case.sls
@@ -10,7 +10,7 @@
       (syntax-case x ()
         ((_ ((p e0) ...) e1 e2 ...)
          (syntax (syntax-case (list e0 ...) ()
-		   ((p ...) (let () e1 e2 ...))))))))
+                   ((p ...) (let () e1 e2 ...))))))))
 
   ;; Quasisyntax adapted from Larceny Scheme with modifications:
   ;;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -273,6 +273,7 @@ impl<const N: usize> From<[usize; N]> for Version {
     }
 }
 
+#[derive(Debug)]
 pub enum VersionReference {
     SubVersions(Vec<SubVersionReference>),
     And(Vec<VersionReference>),
@@ -332,6 +333,7 @@ impl VersionReference {
     }
 }
 
+#[derive(Debug)]
 pub enum SubVersionReference {
     SubVersion(usize),
     Gte(usize),
@@ -562,6 +564,7 @@ fn discard_for(syn: &Syntax) -> &Syntax {
     }
 }
 
+#[derive(Debug)]
 pub enum ImportSet {
     Library(LibraryReference),
     Only {
@@ -715,6 +718,7 @@ impl From<ParseAstError> for ParseImportSetError<'_> {
     }
 }
 
+#[derive(Debug)]
 pub struct LibraryReference {
     pub(crate) name: Vec<Symbol>,
     pub(crate) _version_ref: VersionReference,
@@ -937,7 +941,7 @@ pub(super) async fn define_syntax(
         .call(&[])
         .await
         .map_err(|err| ParseAstError::RaisedValue(err.into()))?;
-    let transformer: Closure = mac[0].clone().try_into().unwrap();
+    let transformer: Closure = mac[0].clone().try_into()?;
     env.def_keyword(ident, transformer);
 
     Ok(())
@@ -1732,7 +1736,6 @@ fn splice_in<'a>(
         if body.is_empty() {
             return Err(ParseAstError::ExpectedBody(span.clone()));
         }
-
         for unexpanded in body {
             let FullyExpanded {
                 expansion_env,
@@ -1749,6 +1752,9 @@ fn splice_in<'a>(
                 {
                     let keyword = expansion_env.fetch_special_keyword_or_var(ident).await?;
                     match (keyword, tail) {
+                        (Some(Either::Left(SpecialKeyword::Begin)), body) if body.is_empty() => {
+                            continue;
+                        }
                         (Some(Either::Left(SpecialKeyword::Begin)), body) => {
                             splice_in(runtime, permissive, body, &expansion_env, span, defs, exprs)
                                 .await?;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1752,7 +1752,7 @@ fn splice_in<'a>(
                 {
                     let keyword = expansion_env.fetch_special_keyword_or_var(ident).await?;
                     match (keyword, tail) {
-                        (Some(Either::Left(SpecialKeyword::Begin)), body) if body.is_empty() => {
+                        (Some(Either::Left(SpecialKeyword::Begin)), []) => {
                             continue;
                         }
                         (Some(Either::Left(SpecialKeyword::Begin)), body) => {

--- a/src/records.rs
+++ b/src/records.rs
@@ -78,7 +78,7 @@ pub static RECORD_TYPE_DESCRIPTOR_RTD: LazyLock<Arc<RecordTypeDescriptor>> = Laz
     })
 });
 
-#[bridge(name = "make-record-type-descriptor", lib = "(rnrs base builtins (6))")]
+#[bridge(name = "make-record-type-descriptor", lib = "(rnrs records procedural (6))")]
 pub async fn make_record_type_descriptor(
     name: &Value,
     parent: &Value,

--- a/src/records.rs
+++ b/src/records.rs
@@ -78,7 +78,10 @@ pub static RECORD_TYPE_DESCRIPTOR_RTD: LazyLock<Arc<RecordTypeDescriptor>> = Laz
     })
 });
 
-#[bridge(name = "make-record-type-descriptor", lib = "(rnrs records procedural (6))")]
+#[bridge(
+    name = "make-record-type-descriptor",
+    lib = "(rnrs records procedural (6))"
+)]
 pub async fn make_record_type_descriptor(
     name: &Value,
     parent: &Value,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -17,7 +17,6 @@ use crate::{
 };
 use std::{
     collections::{HashMap, HashSet, hash_map::Entry},
-    fmt,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -97,7 +96,7 @@ pub struct Initializer {
 inventory::collect!(Initializer);
 */
 
-#[derive(Trace, Default)]
+#[derive(Trace, Default, Debug)]
 pub(crate) struct RegistryInner {
     libs: HashMap<Vec<Symbol>, Library>,
     loading: HashSet<Vec<Symbol>>,
@@ -270,7 +269,7 @@ impl RegistryInner {
     }
 }
 
-#[derive(Trace, Clone)]
+#[derive(Trace, Clone, Debug)]
 pub struct Registry(pub(crate) Gc<RegistryInner>);
 
 impl Registry {
@@ -513,20 +512,22 @@ pub enum LibraryKind {
     Program { path: PathBuf },
 }
 
-#[derive(Trace, Debug)]
+#[derive(Trace, derive_more::Debug)]
 pub struct Import {
     /// The original name of the identifier before being renamed.
     pub(crate) rename: Identifier,
+    #[debug(skip)]
     pub(crate) origin: Library,
 }
 
-#[derive(Trace, Clone, Debug)]
+#[derive(Trace, Clone, derive_more::Debug)]
 pub struct Export {
     pub(crate) rename: Identifier,
+    #[debug(skip)]
     pub(crate) origin: Option<Library>,
 }
 
-#[derive(Trace, Clone)]
+#[derive(Trace, Clone, Debug)]
 pub struct Library(pub(crate) Gc<LibraryInner>);
 
 impl PartialEq for Library {
@@ -535,11 +536,13 @@ impl PartialEq for Library {
     }
 }
 
+/*
 impl fmt::Debug for Library {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Library({:p})", Gc::as_ptr(&self.0))
     }
 }
+*/
 
 impl Library {
     pub fn new_repl(rt: &Runtime) -> Self {

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use indexmap::IndexSet;
+use rand::distr::{Alphabetic, SampleString};
 use scheme_rs_macros::{Trace, bridge};
 
 use crate::{exception::Condition, strings, value::Value};
@@ -63,4 +64,10 @@ pub async fn string_to_symbol(s: &Value) -> Result<Vec<Value>, Condition> {
 pub async fn symbol_to_string(s: &Value) -> Result<Vec<Value>, Condition> {
     let sym: Symbol = s.clone().try_into()?;
     Ok(vec![Value::from(sym.to_str().to_string())])
+}
+
+#[bridge(name = "gensym", lib = "(rnrs base builtins (6))")]
+pub async fn gensym() -> Result<Vec<Value>, Condition> {
+    let string = Alphabetic.sample_string(&mut rand::rng(), 32);
+    Ok(vec![Value::from(Symbol::intern(&string))])
 }


### PR DESCRIPTION
This PR implements the `define-record-type` macro, i.e. the syntactic layer of R6RS records.

It's based on a macro I found in Ikarus Scheme by Abdulaziz Ghuloum, but vastly modified and extended.
