### PR TITLE
Implement eval

### DIFF
--- a/proc-macros/Cargo.toml
+++ b/proc-macros/Cargo.toml
@@ -14,6 +14,6 @@ repository = "https://github.com/maplant/scheme-rs"
 proc-macro = true
 
 [dependencies]
-syn = { version = "2", features = ["full"] }
-quote = "1"
 proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -527,7 +527,7 @@ impl ImportSpec {
     }
 }
 
-fn discard_for(syn: &Syntax) -> &Syntax {
+pub(crate) fn discard_for(syn: &Syntax) -> &Syntax {
     match syn.as_list() {
         Some(
             [
@@ -537,7 +537,7 @@ fn discard_for(syn: &Syntax) -> &Syntax {
                 Syntax::Null { .. },
             ],
         ) if for_kw == "for" => {
-            // We should eventually check the import levels for being well
+            // We should eventually check that the import levels are well
             // formed, even if we ignore them.
             import_set
         }
@@ -568,7 +568,7 @@ pub enum ImportSet {
 }
 
 impl ImportSet {
-    fn parse(syn: &Syntax) -> Result<Self, ParseAstError> {
+    pub fn parse(syn: &Syntax) -> Result<Self, ParseAstError> {
         match syn.as_list() {
             Some(
                 [
@@ -744,6 +744,20 @@ impl LibraryReference {
     }
 }
 
+pub struct ParseContext {
+    runtime: Runtime,
+    allow_imports: bool,
+}
+
+impl ParseContext {
+    pub fn new(runtime: &Runtime, allow_imports: bool) -> Self {
+        Self {
+            runtime: runtime.clone(),
+            allow_imports,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Trace)]
 pub enum Definition {
     DefineVar(DefineVar),
@@ -782,7 +796,7 @@ impl Definition {
 
     #[maybe_async]
     pub fn parse(
-        runtime: &Runtime,
+        ctxt: &ParseContext,
         syn: &[Syntax],
         env: &Environment,
         span: &Span,
@@ -795,7 +809,7 @@ impl Definition {
                 Syntax::Null { .. },
             ] => Ok(Definition::DefineVar(DefineVar {
                 var: maybe_await!(env.fetch_var(ident))?.unwrap(),
-                val: Arc::new(maybe_await!(Expression::parse(runtime, expr.clone(), env))?),
+                val: Arc::new(maybe_await!(Expression::parse(ctxt, expr.clone(), env))?),
                 next: None,
             })),
             [
@@ -885,9 +899,8 @@ impl Definition {
                         };
 
                         // Parse the body:
-                        let body = maybe_await!(DefinitionBody::parse(
-                            runtime, body, &new_env, func_span
-                        ))?;
+                        let body =
+                            maybe_await!(DefinitionBody::parse(ctxt, body, &new_env, func_span))?;
 
                         Ok(Self::DefineFunc(DefineFunc {
                             var,
@@ -907,7 +920,7 @@ impl Definition {
 
 #[maybe_async]
 pub(super) fn define_syntax(
-    runtime: &Runtime,
+    ctxt: &ParseContext,
     ident: Identifier,
     expr: Syntax,
     env: &Environment,
@@ -917,9 +930,9 @@ pub(super) fn define_syntax(
         expansion_env,
     } = maybe_await!(expr.expand(env))?;
 
-    let expr = maybe_await!(Expression::parse(runtime, expanded, &expansion_env))?;
+    let expr = maybe_await!(Expression::parse(ctxt, expanded, &expansion_env))?;
     let cps_expr = expr.compile_top_level();
-    let mac = maybe_await!(maybe_await!(runtime.compile_expr(cps_expr)).call(&[]))
+    let mac = maybe_await!(maybe_await!(ctxt.runtime.compile_expr(cps_expr)).call(&[]))
         .map_err(|err| ParseAstError::RaisedValue(err.into()))?;
     let transformer: Procedure = mac[0].clone().try_into()?;
     env.def_keyword(ident, transformer);
@@ -949,35 +962,39 @@ pub enum Expression {
 
 impl Expression {
     #[maybe_async]
-    pub fn parse(runtime: &Runtime, syn: Syntax, env: &Environment) -> Result<Self, ParseAstError> {
+    pub fn parse(
+        ctxt: &ParseContext,
+        syn: Syntax,
+        env: &Environment,
+    ) -> Result<Self, ParseAstError> {
         let FullyExpanded {
             expansion_env,
             expanded,
         } = maybe_await!(syn.expand(env))?;
-        maybe_await!(Self::parse_expanded(runtime, expanded, &expansion_env))
+        maybe_await!(Self::parse_expanded(ctxt, expanded, &expansion_env))
     }
 
     #[cfg(not(feature = "async"))]
     fn parse_expanded(
-        runtime: &Runtime,
+        ctxt: &ParseContext,
         syn: Syntax,
         env: &Environment,
     ) -> Result<Self, ParseAstError> {
-        Self::parse_expanded_inner(runtime, syn, env)
+        Self::parse_expanded_inner(ctxt, syn, env)
     }
 
     #[cfg(feature = "async")]
     fn parse_expanded<'a>(
-        runtime: &'a Runtime,
+        ctxt: &'a ParseContext,
         syn: Syntax,
         env: &'a Environment,
     ) -> BoxFuture<'a, Result<Self, ParseAstError>> {
-        Box::pin(Self::parse_expanded_inner(runtime, syn, env))
+        Box::pin(Self::parse_expanded_inner(ctxt, syn, env))
     }
 
     #[maybe_async]
     fn parse_expanded_inner(
-        runtime: &Runtime,
+        ctxt: &ParseContext,
         syn: Syntax,
         env: &Environment,
     ) -> Result<Self, ParseAstError> {
@@ -1024,23 +1041,22 @@ impl Expression {
                     Syntax::Null { .. },
                 ] => match maybe_await!(env.fetch_special_keyword_or_var(ident))? {
                     Some(Either::Left(SpecialKeyword::Begin)) => {
-                        maybe_await!(ExprBody::parse(runtime, tail, env)).map(Expression::Begin)
+                        maybe_await!(ExprBody::parse(ctxt, tail, env)).map(Expression::Begin)
                     }
                     Some(Either::Left(SpecialKeyword::Lambda)) => {
-                        maybe_await!(Lambda::parse(runtime, tail, env, span))
-                            .map(Expression::Lambda)
+                        maybe_await!(Lambda::parse(ctxt, tail, env, span)).map(Expression::Lambda)
                     }
                     Some(Either::Left(SpecialKeyword::Let)) => {
-                        maybe_await!(Let::parse(runtime, tail, env, span)).map(Expression::Let)
+                        maybe_await!(Let::parse(ctxt, tail, env, span)).map(Expression::Let)
                     }
                     Some(Either::Left(SpecialKeyword::If)) => {
-                        maybe_await!(If::parse(runtime, tail, env, span)).map(Expression::If)
+                        maybe_await!(If::parse(ctxt, tail, env, span)).map(Expression::If)
                     }
                     Some(Either::Left(SpecialKeyword::And)) => {
-                        maybe_await!(And::parse(runtime, tail, env)).map(Expression::And)
+                        maybe_await!(And::parse(ctxt, tail, env)).map(Expression::And)
                     }
                     Some(Either::Left(SpecialKeyword::Or)) => {
-                        maybe_await!(Or::parse(runtime, tail, env)).map(Expression::Or)
+                        maybe_await!(Or::parse(ctxt, tail, env)).map(Expression::Or)
                     }
                     Some(Either::Left(SpecialKeyword::Quote)) => {
                         Quote::parse(tail, span).map(Expression::Quote)
@@ -1049,25 +1065,24 @@ impl Expression {
                         SyntaxQuote::parse(tail, env, span).map(Expression::SyntaxQuote)
                     }
                     Some(Either::Left(SpecialKeyword::SyntaxCase)) => {
-                        maybe_await!(SyntaxCase::parse(runtime, tail, env, span))
+                        maybe_await!(SyntaxCase::parse(ctxt, tail, env, span))
                             .map(Expression::SyntaxCase)
                     }
                     Some(Either::Left(SpecialKeyword::Set)) => {
-                        maybe_await!(Set::parse(runtime, tail, env, span)).map(Expression::Set)
+                        maybe_await!(Set::parse(ctxt, tail, env, span)).map(Expression::Set)
                     }
                     Some(Either::Left(SpecialKeyword::LetSyntax)) if tail.len() > 1 => {
-                        let new_env =
-                            maybe_await!(parse_let_syntax(runtime, false, &tail[0], env))?;
-                        maybe_await!(ExprBody::parse(runtime, &tail[1..], &new_env))
+                        let new_env = maybe_await!(parse_let_syntax(ctxt, false, &tail[0], env))?;
+                        maybe_await!(ExprBody::parse(ctxt, &tail[1..], &new_env))
                             .map(Expression::Begin)
                     }
                     Some(Either::Left(SpecialKeyword::LetRecSyntax)) if tail.len() > 1 => {
-                        let new_env = maybe_await!(parse_let_syntax(runtime, true, &tail[0], env))?;
-                        maybe_await!(ExprBody::parse(runtime, &tail[1..], &new_env))
+                        let new_env = maybe_await!(parse_let_syntax(ctxt, true, &tail[0], env))?;
+                        maybe_await!(ExprBody::parse(ctxt, &tail[1..], &new_env))
                             .map(Expression::Begin)
                     }
                     Some(Either::Right(var)) => {
-                        maybe_await!(Apply::parse(runtime, Expression::Var(var), tail, env, span))
+                        maybe_await!(Apply::parse(ctxt, Expression::Var(var), tail, env, span))
                             .map(Expression::Apply)
                     }
                     Some(Either::Left(SpecialKeyword::DefineSyntax)) => unreachable!(),
@@ -1084,8 +1099,8 @@ impl Expression {
                     _ => Err(ParseAstError::BadForm(span.clone())),
                 },
                 [expr, args @ .., Syntax::Null { .. }] => maybe_await!(Apply::parse(
-                    runtime,
-                    maybe_await!(Expression::parse(runtime, expr.clone(), env))?,
+                    ctxt,
+                    maybe_await!(Expression::parse(ctxt, expr.clone(), env))?,
                     args,
                     env,
                     expr.span(),
@@ -1213,7 +1228,7 @@ pub struct Apply {
 impl Apply {
     #[maybe_async]
     fn parse(
-        rt: &Runtime,
+        ctxt: &ParseContext,
         operator: Expression,
         args: &[Syntax],
         env: &Environment,
@@ -1221,7 +1236,7 @@ impl Apply {
     ) -> Result<Self, ParseAstError> {
         let mut parsed_args = Vec::new();
         for arg in args {
-            parsed_args.push(maybe_await!(Expression::parse(rt, arg.clone(), env))?);
+            parsed_args.push(maybe_await!(Expression::parse(ctxt, arg.clone(), env))?);
         }
         Ok(Apply {
             operator: Box::new(operator),
@@ -1241,21 +1256,21 @@ pub struct Lambda {
 impl Lambda {
     #[maybe_async]
     fn parse(
-        runtime: &Runtime,
+        ctxt: &ParseContext,
         sexprs: &[Syntax],
         env: &Environment,
         span: &Span,
     ) -> Result<Self, ParseAstError> {
         match sexprs {
             [Syntax::Null { .. }, body @ ..] => {
-                maybe_await!(parse_lambda(runtime, &[], body, env, span))
+                maybe_await!(parse_lambda(ctxt, &[], body, env, span))
             }
             [Syntax::List { list: args, .. }, body @ ..] => {
-                maybe_await!(parse_lambda(runtime, args, body, env, span))
+                maybe_await!(parse_lambda(ctxt, args, body, env, span))
             }
             [ident @ Syntax::Identifier { .. }, body @ ..] => {
                 maybe_await!(parse_lambda(
-                    runtime,
+                    ctxt,
                     std::slice::from_ref(ident),
                     body,
                     env,
@@ -1269,7 +1284,7 @@ impl Lambda {
 
 #[maybe_async]
 fn parse_lambda(
-    runtime: &Runtime,
+    ctxt: &ParseContext,
     args: &[Syntax],
     body: &[Syntax],
     env: &Environment,
@@ -1330,7 +1345,7 @@ fn parse_lambda(
         Formals::FixedArgs(Vec::new())
     };
 
-    let body = maybe_await!(DefinitionBody::parse(runtime, body, &new_contour, span))?;
+    let body = maybe_await!(DefinitionBody::parse(ctxt, body, &new_contour, span))?;
 
     Ok(Lambda {
         args,
@@ -1352,29 +1367,29 @@ impl Let {
 
     #[maybe_async]
     fn parse(
-        runtime: &Runtime,
+        ctxt: &ParseContext,
         syn: &[Syntax],
         env: &Environment,
         span: &Span,
     ) -> Result<Self, ParseAstError> {
         match syn {
             [Syntax::Null { .. }, body @ ..] => {
-                maybe_await!(parse_let(runtime, &[], body, env, span))
+                maybe_await!(parse_let(ctxt, &[], body, env, span))
             }
             [Syntax::List { list: bindings, .. }, body @ ..] => {
-                maybe_await!(parse_let(runtime, bindings, body, env, span))
+                maybe_await!(parse_let(ctxt, bindings, body, env, span))
             }
             // Named let:
             [
                 Syntax::Identifier { ident, .. },
                 Syntax::List { list: bindings, .. },
                 body @ ..,
-            ] => maybe_await!(parse_named_let(runtime, ident, bindings, body, env, span)),
+            ] => maybe_await!(parse_named_let(ctxt, ident, bindings, body, env, span)),
             [
                 Syntax::Identifier { ident, .. },
                 Syntax::Null { .. },
                 body @ ..,
-            ] => maybe_await!(parse_named_let(runtime, ident, &[], body, env, span)),
+            ] => maybe_await!(parse_named_let(ctxt, ident, &[], body, env, span)),
             _ => Err(ParseAstError::BadForm(span.clone())),
         }
     }
@@ -1382,7 +1397,7 @@ impl Let {
 
 #[maybe_async]
 fn parse_let(
-    runtime: &Runtime,
+    ctxt: &ParseContext,
     bindings: &[Syntax],
     body: &[Syntax],
     env: &Environment,
@@ -1399,7 +1414,7 @@ fn parse_let(
         [bindings @ .., Syntax::Null { .. }] => {
             for binding in bindings {
                 let binding =
-                    maybe_await!(LetBinding::parse(runtime, binding, env, &previously_bound))?;
+                    maybe_await!(LetBinding::parse(ctxt, binding, env, &previously_bound))?;
                 previously_bound.insert(binding.ident.clone(), binding.span.clone());
                 let Var::Local(var) = new_contour.def_var(binding.ident.clone()) else {
                     unreachable!()
@@ -1413,7 +1428,7 @@ fn parse_let(
         }
     }
 
-    let ast_body = maybe_await!(DefinitionBody::parse(runtime, body, &new_contour, span))?;
+    let ast_body = maybe_await!(DefinitionBody::parse(ctxt, body, &new_contour, span))?;
 
     // TODO: Lot of unnecessary cloning here, fix that.
     let bindings: Vec<_> = parsed_bindings
@@ -1429,7 +1444,7 @@ fn parse_let(
 
 #[maybe_async]
 fn parse_named_let(
-    runtime: &Runtime,
+    ctxt: &ParseContext,
     name: &Identifier,
     bindings: &[Syntax],
     body: &[Syntax],
@@ -1451,7 +1466,7 @@ fn parse_named_let(
         [bindings @ .., Syntax::Null { .. }] => {
             for binding in bindings {
                 let binding =
-                    maybe_await!(LetBinding::parse(runtime, binding, env, &previously_bound))?;
+                    maybe_await!(LetBinding::parse(ctxt, binding, env, &previously_bound))?;
                 previously_bound.insert(binding.ident.clone(), binding.span.clone());
                 let Var::Local(var) = body_contour.def_var(binding.ident.clone()) else {
                     unreachable!()
@@ -1465,7 +1480,7 @@ fn parse_named_let(
         }
     }
 
-    let body = maybe_await!(DefinitionBody::parse(runtime, body, &body_contour, span))?;
+    let body = maybe_await!(DefinitionBody::parse(ctxt, body, &body_contour, span))?;
 
     let func = DefineFunc {
         var: func.clone(),
@@ -1496,7 +1511,7 @@ struct LetBinding {
 impl LetBinding {
     #[maybe_async]
     fn parse(
-        runtime: &Runtime,
+        ctxt: &ParseContext,
         form: &Syntax,
         env: &Environment,
         previously_bound: &HashMap<Identifier, Span>,
@@ -1521,7 +1536,7 @@ impl LetBinding {
                 });
             }
 
-            let expr = maybe_await!(Expression::parse(runtime, expr.clone(), env))?;
+            let expr = maybe_await!(Expression::parse(ctxt, expr.clone(), env))?;
 
             Ok(LetBinding {
                 ident: ident.clone(),
@@ -1543,7 +1558,7 @@ pub struct Set {
 impl Set {
     #[maybe_async]
     fn parse(
-        runtime: &Runtime,
+        ctxt: &ParseContext,
         exprs: &[Syntax],
         env: &Environment,
         span: &Span,
@@ -1566,7 +1581,7 @@ impl Set {
                         });
                     }
                 },
-                val: Arc::new(maybe_await!(Expression::parse(runtime, expr.clone(), env))?),
+                val: Arc::new(maybe_await!(Expression::parse(ctxt, expr.clone(), env))?),
             }),
             [arg1, _] => Err(ParseAstError::ExpectedIdentifier(arg1.span().clone())),
             [_, _, arg3, ..] => Err(ParseAstError::UnexpectedArgument(arg3.span().clone())),
@@ -1585,30 +1600,22 @@ pub struct If {
 impl If {
     #[maybe_async]
     fn parse(
-        runtime: &Runtime,
+        ctxt: &ParseContext,
         exprs: &[Syntax],
         env: &Environment,
         span: &Span,
     ) -> Result<Self, ParseAstError> {
         match exprs {
             [cond, success] => Ok(If {
-                cond: Arc::new(maybe_await!(Expression::parse(runtime, cond.clone(), env))?),
-                success: Arc::new(maybe_await!(Expression::parse(
-                    runtime,
-                    success.clone(),
-                    env
-                ))?),
+                cond: Arc::new(maybe_await!(Expression::parse(ctxt, cond.clone(), env))?),
+                success: Arc::new(maybe_await!(Expression::parse(ctxt, success.clone(), env))?),
                 failure: None,
             }),
             [cond, success, failure] => Ok(If {
-                cond: Arc::new(maybe_await!(Expression::parse(runtime, cond.clone(), env))?),
-                success: Arc::new(maybe_await!(Expression::parse(
-                    runtime,
-                    success.clone(),
-                    env
-                ))?),
+                cond: Arc::new(maybe_await!(Expression::parse(ctxt, cond.clone(), env))?),
+                success: Arc::new(maybe_await!(Expression::parse(ctxt, success.clone(), env))?),
                 failure: Some(Arc::new(maybe_await!(Expression::parse(
-                    runtime,
+                    ctxt,
                     failure.clone(),
                     env
                 ))?)),
@@ -1663,50 +1670,52 @@ impl DefinitionBody {
         env: &Environment,
         span: &Span,
     ) -> Result<Self, ParseAstError> {
-        maybe_await!(Self::parse_helper(runtime, body, true, env, span))
+        let ctxt = ParseContext {
+            runtime: runtime.clone(),
+            allow_imports: true,
+        };
+        maybe_await!(Self::parse_helper(&ctxt, body, true, env, span))
     }
 
     #[maybe_async]
     pub fn parse(
-        runtime: &Runtime,
+        ctxt: &ParseContext,
         body: &[Syntax],
         env: &Environment,
         span: &Span,
     ) -> Result<Self, ParseAstError> {
-        maybe_await!(Self::parse_helper(runtime, body, false, env, span))
+        maybe_await!(Self::parse_helper(ctxt, body, false, env, span))
     }
 
     /// Parse the body. body is expected to be a list of valid syntax objects, and should not include
     /// _any_ nulls, including one at the end.
     #[cfg(not(feature = "async"))]
     fn parse_helper(
-        runtime: &Runtime,
+        ctxt: &ParseContext,
         body: &[Syntax],
         permissive: bool,
         env: &Environment,
         span: &Span,
     ) -> Result<Self, ParseAstError> {
-        Self::parse_helper_inner(runtime, body, permissive, env, span)
+        Self::parse_helper_inner(ctxt, body, permissive, env, span)
     }
 
     /// Parse the body. body is expected to be a list of valid syntax objects, and should not include
     /// _any_ nulls, including one at the end.
     #[cfg(feature = "async")]
     fn parse_helper<'a>(
-        runtime: &'a Runtime,
+        ctxt: &'a ParseContext,
         body: &'a [Syntax],
         permissive: bool,
         env: &'a Environment,
         span: &'a Span,
     ) -> BoxFuture<'a, Result<Self, ParseAstError>> {
-        Box::pin(Self::parse_helper_inner(
-            runtime, body, permissive, env, span,
-        ))
+        Box::pin(Self::parse_helper_inner(ctxt, body, permissive, env, span))
     }
 
     #[maybe_async]
     fn parse_helper_inner(
-        runtime: &Runtime,
+        runtime: &ParseContext,
         body: &[Syntax],
         permissive: bool,
         env: &Environment,
@@ -1779,10 +1788,14 @@ impl ExprBody {
 
     /// Differs from Body by being purely expression based. No definitions allowed.
     #[maybe_async]
-    fn parse(runtime: &Runtime, body: &[Syntax], env: &Environment) -> Result<Self, ParseAstError> {
+    fn parse(
+        ctxt: &ParseContext,
+        body: &[Syntax],
+        env: &Environment,
+    ) -> Result<Self, ParseAstError> {
         let mut exprs = Vec::new();
         for sexpr in body {
-            let parsed = maybe_await!(Expression::parse(runtime, sexpr.clone(), env))?;
+            let parsed = maybe_await!(Expression::parse(ctxt, sexpr.clone(), env))?;
             exprs.push(parsed);
         }
         Ok(Self { exprs })
@@ -1791,7 +1804,7 @@ impl ExprBody {
 
 #[cfg(not(feature = "async"))]
 fn splice_in(
-    runtime: &Runtime,
+    ctxt: &ParseContext,
     permissive: bool,
     body: &[Syntax],
     env: &Environment,
@@ -1799,12 +1812,12 @@ fn splice_in(
     defs: &mut Vec<FullyExpanded>,
     exprs: &mut Vec<FullyExpanded>,
 ) -> Result<(), ParseAstError> {
-    splice_in_inner(runtime, permissive, body, env, span, defs, exprs)
+    splice_in_inner(ctxt, permissive, body, env, span, defs, exprs)
 }
 
 #[cfg(feature = "async")]
 fn splice_in<'a>(
-    runtime: &'a Runtime,
+    ctxt: &'a ParseContext,
     permissive: bool,
     body: &'a [Syntax],
     env: &'a Environment,
@@ -1813,13 +1826,13 @@ fn splice_in<'a>(
     exprs: &'a mut Vec<FullyExpanded>,
 ) -> BoxFuture<'a, Result<(), ParseAstError>> {
     Box::pin(splice_in_inner(
-        runtime, permissive, body, env, span, defs, exprs,
+        ctxt, permissive, body, env, span, defs, exprs,
     ))
 }
 
 #[maybe_async]
 fn splice_in_inner(
-    runtime: &Runtime,
+    ctxt: &ParseContext,
     permissive: bool,
     body: &[Syntax],
     env: &Environment,
@@ -1851,7 +1864,7 @@ fn splice_in_inner(
                     }
                     (Some(Either::Left(SpecialKeyword::Begin)), body) => {
                         maybe_await!(splice_in(
-                            runtime,
+                            ctxt,
                             permissive,
                             body,
                             &expansion_env,
@@ -1866,7 +1879,7 @@ fn splice_in_inner(
                         [Syntax::Identifier { ident: name, .. }, expr],
                     ) => {
                         maybe_await!(define_syntax(
-                            runtime,
+                            ctxt,
                             name.clone(),
                             expr.clone(),
                             &expansion_env
@@ -1877,31 +1890,23 @@ fn splice_in_inner(
                         return Err(ParseAstError::BadForm(span.clone()));
                     }
                     (Some(Either::Left(SpecialKeyword::LetSyntax)), [bindings, form @ ..]) => {
-                        let new_env = maybe_await!(parse_let_syntax(
-                            runtime,
-                            false,
-                            bindings,
-                            &expansion_env
-                        ))?;
+                        let new_env =
+                            maybe_await!(parse_let_syntax(ctxt, false, bindings, &expansion_env))?;
                         maybe_await!(splice_in(
-                            runtime, permissive, form, &new_env, span, defs, exprs
+                            ctxt, permissive, form, &new_env, span, defs, exprs
                         ))?;
                         continue;
                     }
                     (Some(Either::Left(SpecialKeyword::LetRecSyntax)), [bindings, form @ ..]) => {
-                        let new_env = maybe_await!(parse_let_syntax(
-                            runtime,
-                            true,
-                            bindings,
-                            &expansion_env
-                        ))?;
+                        let new_env =
+                            maybe_await!(parse_let_syntax(ctxt, true, bindings, &expansion_env))?;
                         maybe_await!(splice_in(
-                            runtime, permissive, form, &new_env, span, defs, exprs
+                            ctxt, permissive, form, &new_env, span, defs, exprs
                         ))?;
                         continue;
                     }
                     (Some(Either::Left(SpecialKeyword::Import)), imports) => {
-                        if !permissive && !exprs.is_empty() {
+                        if !permissive && !exprs.is_empty() || !ctxt.allow_imports {
                             return Err(ParseAstError::UnexpectedImport(span.clone()));
                         }
                         for import in imports {
@@ -1941,7 +1946,7 @@ fn splice_in_inner(
 
 #[maybe_async]
 fn parse_let_syntax(
-    runtime: &Runtime,
+    ctxt: &ParseContext,
     recursive: bool,
     bindings: &Syntax,
     env: &Environment,
@@ -1961,12 +1966,7 @@ fn parse_let_syntax(
             ],
         ) = binding.as_list()
         {
-            maybe_await!(define_syntax(
-                runtime,
-                keyword.clone(),
-                expr.clone(),
-                &new_env
-            ))?;
+            maybe_await!(define_syntax(ctxt, keyword.clone(), expr.clone(), &new_env))?;
         } else {
             return Err(ParseAstError::BadForm(binding.span().clone()));
         }
@@ -1989,13 +1989,13 @@ impl And {
 impl And {
     #[maybe_async]
     fn parse(
-        runtime: &Runtime,
+        ctxt: &ParseContext,
         exprs: &[Syntax],
         env: &Environment,
     ) -> Result<Self, ParseAstError> {
         let mut output = Vec::new();
         for expr in exprs {
-            let expr = maybe_await!(Expression::parse(runtime, expr.clone(), env))?;
+            let expr = maybe_await!(Expression::parse(ctxt, expr.clone(), env))?;
             output.push(expr);
         }
         Ok(Self::new(output))
@@ -2014,13 +2014,13 @@ impl Or {
 
     #[maybe_async]
     fn parse(
-        runtime: &Runtime,
+        ctxt: &ParseContext,
         exprs: &[Syntax],
         env: &Environment,
     ) -> Result<Self, ParseAstError> {
         let mut output = Vec::new();
         for expr in exprs {
-            let expr = maybe_await!(Expression::parse(runtime, expr.clone(), env))?;
+            let expr = maybe_await!(Expression::parse(ctxt, expr.clone(), env))?;
             output.push(expr);
         }
         Ok(Self::new(output))
@@ -2052,7 +2052,7 @@ pub struct SyntaxCase {
 impl SyntaxCase {
     #[maybe_async]
     fn parse(
-        runtime: &Runtime,
+        ctxt: &ParseContext,
         exprs: &[Syntax],
         env: &Environment,
         span: &Span,
@@ -2080,7 +2080,7 @@ impl SyntaxCase {
                 [Syntax::List { list, .. }, tail @ ..] => match &list[..] {
                     [pattern, output_expression, Syntax::Null { .. }] => {
                         syntax_rules.push(maybe_await!(SyntaxRule::compile(
-                            runtime,
+                            ctxt,
                             &keywords,
                             pattern,
                             None,
@@ -2091,7 +2091,7 @@ impl SyntaxCase {
                     }
                     [pattern, fender, output_expression, Syntax::Null { .. }] => {
                         syntax_rules.push(maybe_await!(SyntaxRule::compile(
-                            runtime,
+                            ctxt,
                             &keywords,
                             pattern,
                             Some(fender),
@@ -2106,7 +2106,7 @@ impl SyntaxCase {
             }
         }
         Ok(SyntaxCase {
-            arg: Arc::new(maybe_await!(Expression::parse(runtime, arg.clone(), env))?),
+            arg: Arc::new(maybe_await!(Expression::parse(ctxt, arg.clone(), env))?),
             rules: syntax_rules,
         })
     }

--- a/src/env.rs
+++ b/src/env.rs
@@ -699,6 +699,12 @@ impl Clone for Environment {
     }
 }
 
+impl fmt::Debug for Environment {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Ok(())
+    }
+}
+
 #[derive(Copy, Clone, Trace)]
 pub struct Local {
     pub(crate) id: usize,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,0 +1,73 @@
+//! Support for dynamic evaluation library (rnrs eval (6))
+
+use std::{collections::BTreeSet, sync::Arc};
+
+use scheme_rs_macros::{maybe_async, maybe_await};
+
+use crate::{
+    ast::{Expression, ImportSet, ParseContext, discard_for},
+    cps::Compile,
+    env::Environment,
+    exceptions::Condition,
+    proc::{Application, DynStack},
+    records::{Record, RecordTypeDescriptor, SchemeCompatible, rtd},
+    registry::{Library, cps_bridge},
+    runtime::Runtime,
+    syntax::Syntax,
+    value::Value,
+};
+
+#[maybe_async]
+#[cps_bridge(def = "eval expression environment", lib = "(rnrs eval (6))")]
+pub fn eval(
+    runtime: &Runtime,
+    _env: &[Value],
+    args: &[Value],
+    _rest_args: &[Value],
+    _dyn_stack: &mut DynStack,
+    k: Value,
+) -> Result<Application, Condition> {
+    let [expression, environment] = args else {
+        unreachable!()
+    };
+    let env = environment.try_into_rust_type::<Environment>()?;
+    let expr = Syntax::syntax_from_datum(&BTreeSet::default(), expression.clone());
+    let ctxt = ParseContext::new(runtime, false);
+    let expr = maybe_await!(Expression::parse(&ctxt, expr, &env))?;
+    let compiled = expr.compile_top_level();
+    let proc = maybe_await!(runtime.compile_expr(compiled));
+    Ok(Application::new(proc, vec![k], None))
+}
+
+impl SchemeCompatible for Environment {
+    fn rtd() -> Arc<RecordTypeDescriptor> {
+        rtd!(name: "environment", sealed: true, opaque: true)
+    }
+}
+
+#[maybe_async]
+#[cps_bridge(def = "environment . import-spec", lib = "(rnrs eval (6))")]
+pub fn environment(
+    runtime: &Runtime,
+    _env: &[Value],
+    _args: &[Value],
+    import_spec: &[Value],
+    _dyn_stack: &mut DynStack,
+    k: Value,
+) -> Result<Application, Condition> {
+    let marks = BTreeSet::default();
+    let import_sets = import_spec
+        .iter()
+        .cloned()
+        .map(|spec| {
+            let syntax = Syntax::syntax_from_datum(&marks, spec);
+            ImportSet::parse(discard_for(&syntax))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let env = Environment::Top(Library::new_repl(runtime));
+    for import_set in import_sets {
+        maybe_await!(env.import(import_set))?;
+    }
+    let env = Value::from(Record::from_rust_type(env));
+    Ok(Application::new(k.try_into().unwrap(), vec![env], None))
+}

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -1,11 +1,10 @@
 use crate::{
-    ast::{Expression, Literal, ParseAstError},
+    ast::{Expression, Literal, ParseAstError, ParseContext},
     env::{Environment, Local},
     exceptions::Condition,
     gc::{Gc, Trace},
     proc::Procedure,
     records::{Record, RecordTypeDescriptor, SchemeCompatible, rtd},
-    runtime::Runtime,
     symbols::Symbol,
     syntax::{Identifier, Span, Syntax},
     value::Value,
@@ -31,7 +30,7 @@ pub struct SyntaxRule {
 impl SyntaxRule {
     #[maybe_async]
     pub fn compile(
-        rt: &Runtime,
+        ctxt: &ParseContext,
         keywords: &HashSet<Symbol>,
         pattern: &Syntax,
         fender: Option<&Syntax>,
@@ -43,12 +42,12 @@ impl SyntaxRule {
         let binds = Local::gensym();
         let env = env.new_syntax_case_expr(binds, variables);
         let fender = if let Some(fender) = fender {
-            Some(maybe_await!(Expression::parse(rt, fender.clone(), &env))?)
+            Some(maybe_await!(Expression::parse(ctxt, fender.clone(), &env))?)
         } else {
             None
         };
         let output_expression =
-            maybe_await!(Expression::parse(rt, output_expression.clone(), &env))?;
+            maybe_await!(Expression::parse(ctxt, output_expression.clone(), &env))?;
         Ok(Self {
             pattern,
             binds,

--- a/src/gc/collection.rs
+++ b/src/gc/collection.rs
@@ -13,6 +13,7 @@ use std::{
         atomic::{AtomicPtr, AtomicUsize, Ordering},
     },
     thread::JoinHandle,
+    time::Duration,
 };
 
 use rustc_hash::FxHashSet as HashSet;
@@ -287,7 +288,6 @@ impl Collector {
         let mut new_live_objects = 0;
         while let Some(curr_heap_object) = unsafe { OpaqueGcPtr::from_ptr(next) } {
             unsafe {
-                // curr_heap_object.set_prev(prev);
                 if !curr_heap_object.prev().is_null() {
                     break;
                 }
@@ -301,7 +301,7 @@ impl Collector {
         }
 
         if new_live_objects == 1 {
-            std::thread::yield_now();
+            std::thread::sleep(Duration::from_millis(10));
         }
 
         self.next = self.start;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod ast;
 pub mod character;
 pub mod cps;
 pub mod env;
+pub mod eval;
 pub mod exceptions;
 pub mod expand;
 pub mod gc;

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -263,11 +263,7 @@ pub fn append(list: &Value, to_append: &Value) -> Result<Vec<Value>, Condition> 
     Ok(vec![list])
 }
 
-#[cps_bridge(
-    name = "map",
-    lib = "(rnrs base builtins (6))",
-    args = "proc list1 . listn"
-)]
+#[cps_bridge(def = "map proc list1 . listn", lib = "(rnrs base builtins (6))")]
 pub fn map(
     runtime: &Runtime,
     _env: &[Value],

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use rustyline::{
     validate::{ValidationContext, ValidationResult, Validator},
 };
 use scheme_rs::{
-    ast::{DefinitionBody, ImportSet, ParseAstError},
+    ast::{DefinitionBody, ImportSet, ParseAstError, ParseContext},
     cps::Compile,
     env::Environment,
     exceptions::Exception,
@@ -121,7 +121,8 @@ fn compile_and_run_str(
 ) -> Result<Vec<Value>, EvalError> {
     let env = Environment::Top(repl.clone());
     let span = sexpr.span().clone();
-    let expr = maybe_await!(DefinitionBody::parse(runtime, &[sexpr], &env, &span))?;
+    let ctxt = ParseContext::new(runtime, true);
+    let expr = maybe_await!(DefinitionBody::parse(&ctxt, &[sexpr], &env, &span))?;
     let compiled = expr.compile_top_level();
     let closure = maybe_await!(runtime.compile_expr(compiled));
     let result =

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -1846,11 +1846,7 @@ pub fn standard_input_port() -> Result<Vec<Value>, Condition> {
     Ok(vec![Value::from(port)])
 }
 
-#[cps_bridge(
-    name = "current-input-port",
-    lib = "(rnrs base builtins (6))",
-    args = ""
-)]
+#[cps_bridge(def = "current-input-port", lib = "(rnrs base builtins (6))")]
 pub fn current_input_port(
     _runtime: &Runtime,
     _env: &[Value],

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -627,7 +627,7 @@ impl FuncDebugInfo {
     }
 }
 
-#[cps_bridge(name = "apply", lib = "(rnrs base builtins (6))", args = "arg1 . args")]
+#[cps_bridge(def = "apply arg1 . args", lib = "(rnrs base builtins (6))")]
 pub fn apply(
     _runtime: &Runtime,
     _env: &[Value],
@@ -746,9 +746,8 @@ pub(crate) unsafe extern "C" fn pop_dyn_stack(
 //
 
 #[cps_bridge(
-    name = "call-with-current-continuation",
-    lib = "(rnrs base builtins (6))",
-    args = "proc"
+    def = "call-with-current-continuation proc",
+    lib = "(rnrs base builtins (6))"
 )]
 pub fn call_with_current_continuation(
     runtime: &Runtime,
@@ -1018,9 +1017,8 @@ unsafe extern "C" fn call_consumer_with_values(
 }
 
 #[cps_bridge(
-    name = "call-with-values",
-    lib = "(rnrs base builtins (6))",
-    args = "producer consumer"
+    def = "call-with-values producer consumer",
+    lib = "(rnrs base builtins (6))"
 )]
 pub fn call_with_values(
     runtime: &Runtime,
@@ -1073,11 +1071,7 @@ impl SchemeCompatible for Winder {
     }
 }
 
-#[cps_bridge(
-    name = "dynamic-wind",
-    lib = "(rnrs base builtins (6))",
-    args = "in body out"
-)]
+#[cps_bridge(def = "dynamic-wind in body out", lib = "(rnrs base builtins (6))")]
 pub fn dynamic_wind(
     runtime: &Runtime,
     _env: &[Value],
@@ -1232,9 +1226,8 @@ pub struct PromptBarrier {
 static BARRIER_ID: AtomicUsize = AtomicUsize::new(0);
 
 #[cps_bridge(
-    name = "call-with-prompt",
-    lib = "(rnrs base builtins (6))",
-    args = "tag thunk handler"
+    def = "call-with-prompt tag thunk handler",
+    lib = "(rnrs base builtins (6))"
 )]
 pub fn call_with_prompt(
     runtime: &Runtime,
@@ -1280,11 +1273,7 @@ pub fn call_with_prompt(
     ))
 }
 
-#[cps_bridge(
-    name = "abort-to-prompt",
-    lib = "(rnrs base builtins (6))",
-    args = "tag"
-)]
+#[cps_bridge(def = "abort-to-prompt tag", lib = "(rnrs base builtins (6))")]
 pub fn abort_to_prompt(
     runtime: &Runtime,
     _env: &[Value],

--- a/src/records.rs
+++ b/src/records.rs
@@ -252,9 +252,8 @@ fn make_default_record_constructor_descriptor(
 }
 
 #[cps_bridge(
-    name = "make-record-constructor-descriptor",
-    lib = "(rnrs records procedural (6))",
-    args = "rtd parent-constructor-descriptor protocol"
+    def = "make-record-constructor-descriptor rtd parent-constructor-descriptor protocol",
+    lib = "(rnrs records procedural (6))"
 )]
 pub fn make_record_constructor_descriptor(
     runtime: &Runtime,
@@ -316,11 +315,7 @@ pub fn make_record_constructor_descriptor(
     ))
 }
 
-#[cps_bridge(
-    name = "record-constructor",
-    lib = "(rnrs records procedural (6))",
-    args = "rcd"
-)]
+#[cps_bridge(def = "record-constructor rcd", lib = "(rnrs records procedural (6))")]
 pub fn record_constructor(
     runtime: &Runtime,
     _env: &[Value],
@@ -757,11 +752,7 @@ fn record_predicate_fn(
     ))
 }
 
-#[cps_bridge(
-    name = "record-predicate",
-    lib = "(rnrs records procedural (6))",
-    args = "rtd"
-)]
+#[cps_bridge(def = "record-predicate rtd", lib = "(rnrs records procedural (6))")]
 pub fn record_predicate(
     runtime: &Runtime,
     _env: &[Value],
@@ -811,11 +802,7 @@ fn record_accessor_fn(
     Ok(Application::new(k, vec![val], None))
 }
 
-#[cps_bridge(
-    name = "record-accessor",
-    lib = "(rnrs records procedural (6))",
-    args = "rtd k"
-)]
+#[cps_bridge(def = "record-accessor rtd k", lib = "(rnrs records procedural (6))")]
 pub fn record_accessor(
     runtime: &Runtime,
     _env: &[Value],
@@ -873,11 +860,7 @@ fn record_mutator_fn(
     Ok(Application::new(k, vec![], None))
 }
 
-#[cps_bridge(
-    name = "record-mutator",
-    lib = "(rnrs records procedural (6))",
-    args = "rtd k"
-)]
+#[cps_bridge(def = "record-mutator rtd k", lib = "(rnrs records procedural (6))")]
 pub fn record_mutator(
     runtime: &Runtime,
     _env: &[Value],

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -282,6 +282,11 @@ fn compilation_task(mut compilation_queue_rx: CompilationBufferRx) {
 
         let _ = completion_tx.send(proc);
     }
+
+    // Free the JITed memory
+    unsafe {
+        module.free_memory();
+    }
 }
 
 pub(crate) struct RuntimeFn {


### PR DESCRIPTION
This PR implements the classic `eval` procedure. It was pretty easy to implement, but some care had to be made to ensure that imports are not allowed in unexpected places. This gives users more control over running untrusted user code.