### PR TITLE
MVP/WIP LSP Implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ futures = { version = "0.3", optional = true }
 hashbrown = "0.16.1"
 indexmap = "2"
 inventory = "0.3"
-lsp-server = "0.7.9"
-lsp-types = "0.97.0"
+lsp-server = { version = "0.7.9", optional = true }
+lsp-types = { version = "0.97.0", optional = true }
 malachite = { version = "0.9", features = ["floats"] }
 memchr = "2.7"
 num = "0.4"
@@ -31,8 +31,8 @@ rust-embed = { version = "8", features = ["debug-embed"] }
 rustc-hash = "2.1"
 rustyline = { version = "17", features = ["derive"] }
 scheme-rs-macros = { version = "0.2.0", path = "proc-macros" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { version = "1", features = ["derive"], optional = true }
+serde_json = { version = "1", optional = true }
 unicode_categories = "0.1"
 
 # TODO: Remove this dependency
@@ -50,6 +50,7 @@ tokio = { version = "1.47", features = ["full"], optional = true }
 [features]
 default = ["load-libraries-from-fs"]
 async = ["dep:futures", "dep:async-stream"]
+lsp = ["dep:lsp-server", "dep:lsp-types", "dep:serde", "dep:serde_json"]
 load-libraries-from-fs = []
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ futures = { version = "0.3", optional = true }
 hashbrown = "0.16.1"
 indexmap = "2"
 inventory = "0.3"
+lsp-server = "0.7.9"
+lsp-types = "0.97.0"
 malachite = { version = "0.9", features = ["floats"] }
 memchr = "2.7"
 num = "0.4"
@@ -29,6 +31,8 @@ rust-embed = { version = "8", features = ["debug-embed"] }
 rustc-hash = "2.1"
 rustyline = { version = "17", features = ["derive"] }
 scheme-rs-macros = { version = "0.2.0", path = "proc-macros" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 unicode_categories = "0.1"
 
 # TODO: Remove this dependency

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Scheme-rs is safe, fast, and does not sacrifice modern conveniences.
   misuse.
 - **Supports both async and sync Rust**: by enabling the `async` feature flag 
   it becomes possible (and easy) to define async scheme functions in Rust. 
+- **Language server protocol**: scheme-rs includes a language server protocol
+  implementation for editor agnostic tooling
 
 ## Getting started:
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Scheme-rs is safe, fast, and does not sacrifice modern conveniences.
   it becomes possible (and easy) to define async scheme functions in Rust. 
 - **Language server protocol**: scheme-rs includes a language server
   protocol implementation for editor agnostic tooling, requires
-  enabling the `lsp` feature
+  enabling the `lsp` feature. The LSP only reports read/parse diagnostics
+  by default; macro-expanding diagnostics require passing
+  `--dangerously-allow-macro-expansion-in-lsp`.
 
 ## Getting started:
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ Scheme-rs is safe, fast, and does not sacrifice modern conveniences.
   misuse.
 - **Supports both async and sync Rust**: by enabling the `async` feature flag 
   it becomes possible (and easy) to define async scheme functions in Rust. 
-- **Language server protocol**: scheme-rs includes a language server protocol
-  implementation for editor agnostic tooling
+- **Language server protocol**: scheme-rs includes a language server
+  protocol implementation for editor agnostic tooling, requires
+  enabling the `lsp` feature
 
 ## Getting started:
 

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -3,9 +3,9 @@ use proc_macro2::{Literal, Span};
 use quote::{format_ident, quote};
 use syn::{
     Attribute, DataEnum, DataStruct, DeriveInput, Error, Expr, ExprClosure, Fields, FnArg,
-    GenericParam, Generics, Ident, ItemFn, LitBool, LitStr, Member, Meta, Pat, PatIdent, PatType,
-    Result, Token, Type, TypePath, TypeReference, Visibility, braced, bracketed, parenthesized,
-    parse::{Parse, ParseStream},
+    GenericParam, Generics, Ident, ItemFn, Lit, LitBool, LitStr, Member, Meta, Pat, PatIdent,
+    PatType, Result, Token, Type, TypePath, TypeReference, Visibility, braced, bracketed,
+    parenthesized, parse::{Parse, ParseStream},
     parse_macro_input, parse_quote,
     punctuated::Punctuated,
     spanned::Spanned,
@@ -50,6 +50,7 @@ pub fn bridge(args: TokenStream, item: TokenStream) -> TokenStream {
     let name = name.unwrap().value();
     let lib = lib.unwrap().value();
     let bridge = parse_macro_input!(item as ItemFn);
+    let docs = doc_string(&bridge.attrs);
 
     let impl_name = bridge.sig.ident.clone();
     let wrapper_name = impl_name.to_string();
@@ -146,6 +147,7 @@ pub fn bridge(args: TokenStream, item: TokenStream) -> TokenStream {
                         ::std::column!(),
                         0,
                         &[ #( #arg_names, )* ],
+                        #docs,
                     )
                 )
             }
@@ -206,6 +208,7 @@ pub fn bridge(args: TokenStream, item: TokenStream) -> TokenStream {
                         ::std::column!(),
                         0,
                         &[ #( #arg_names, )* ],
+                        #docs,
                     )
                 )
             }
@@ -285,6 +288,7 @@ pub fn cps_bridge(args: TokenStream, item: TokenStream) -> TokenStream {
     parse_macro_input!(args with bridge_attr_parser);
 
     let mut bridge = parse_macro_input!(item as ItemFn);
+    let docs = doc_string(&bridge.attrs);
     let wrapper_name = Ident::new(&bridge.sig.ident.to_string(), Span::call_site());
     bridge.sig.ident = Ident::new("inner", Span::call_site());
     let impl_name = bridge.sig.ident.clone();
@@ -333,6 +337,7 @@ pub fn cps_bridge(args: TokenStream, item: TokenStream) -> TokenStream {
                         ::std::column!(),
                         0,
                         &[ #( #def, )* ],
+                        #docs,
                     )
                 )
             }
@@ -429,6 +434,28 @@ pub fn cps_bridge(args: TokenStream, item: TokenStream) -> TokenStream {
 
 fn is_slice(arg: &FnArg) -> bool {
     matches!(arg, FnArg::Typed(PatType { ty, ..}) if matches!(ty.as_ref(), Type::Reference(TypeReference { elem, .. }) if matches!(elem.as_ref(), Type::Slice(_))))
+}
+
+fn doc_string(attrs: &[Attribute]) -> String {
+    attrs
+        .iter()
+        .filter_map(|attr| {
+            if !attr.path().is_ident("doc") {
+                return None;
+            }
+            let Meta::NameValue(name_value) = &attr.meta else {
+                return None;
+            };
+            let Expr::Lit(expr_lit) = &name_value.value else {
+                return None;
+            };
+            let Lit::Str(lit) = &expr_lit.lit else {
+                return None;
+            };
+            Some(lit.value().trim_start().to_string())
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Derive the `Trace` trait for a type.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub(crate) mod expand;
 pub mod gc;
 pub mod hashtables;
 pub mod lists;
+pub mod lsp;
 pub mod num;
 pub mod ports;
 pub mod proc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub(crate) mod expand;
 pub mod gc;
 pub mod hashtables;
 pub mod lists;
+#[cfg(feature = "lsp")]
 pub mod lsp;
 pub mod num;
 pub mod ports;

--- a/src/lsp/completion.rs
+++ b/src/lsp/completion.rs
@@ -1,0 +1,114 @@
+use lsp_types::{CompletionItem, CompletionItemKind, CompletionResponse, Position, Uri};
+use scheme_rs_macros::{maybe_async, maybe_await};
+
+use crate::{
+    env::{Binding, Environment, GLOBAL_BINDING_TABLE, Var},
+    proc::Procedure,
+    runtime::Runtime,
+    symbols::Symbol,
+};
+
+use super::document::{completion_prefix, import_visible_libraries, parse_document};
+
+#[maybe_async]
+pub(super) fn completions_for_document(
+    runtime: &Runtime,
+    uri: &Uri,
+    text: &str,
+    position: Position,
+) -> CompletionResponse {
+    // PERF: This reparses and rebuilds imports on every completion request.
+    // Cache document analysis on open/change if completion starts feeling slow.
+    let prefix = completion_prefix(text, position);
+    let mut items = if let Ok((form, env)) = parse_document(runtime, uri, text)
+        && maybe_await!(import_visible_libraries(&form, &env)).is_ok()
+    {
+        maybe_await!(environment_completion_items(&env, &prefix))
+    } else {
+        Vec::new()
+    };
+
+    items.sort_by(|left, right| left.label.cmp(&right.label));
+    items.dedup_by(|left, right| left.label == right.label);
+    CompletionResponse::Array(items)
+}
+
+#[maybe_async]
+fn environment_completion_items(env: &Environment, prefix: &str) -> Vec<CompletionItem> {
+    let mut items = Vec::new();
+    for (name, binding) in imported_bindings(env) {
+        let label = name.to_string();
+        if !label.starts_with(prefix) {
+            continue;
+        }
+
+        if env.lookup_primitive(binding).is_some() {
+            items.push(completion_item(
+                label,
+                CompletionItemKind::KEYWORD,
+                "primitive syntax",
+            ));
+        } else if maybe_await!(env.lookup_keyword(binding))
+            .ok()
+            .flatten()
+            .is_some()
+        {
+            items.push(completion_item(
+                label,
+                CompletionItemKind::KEYWORD,
+                "syntax keyword",
+            ));
+        } else if let Some(var) = maybe_await!(env.lookup_var(binding)).ok().flatten() {
+            items.push(var_completion_item(label, var));
+        }
+    }
+    items
+}
+
+fn imported_bindings(env: &Environment) -> Vec<(Symbol, Binding)> {
+    let top = env.fetch_top();
+    let imported = top.0.read().imports.keys().copied().collect::<Vec<_>>();
+    let scope_set = env.get_scope_set();
+
+    GLOBAL_BINDING_TABLE
+        .lock()
+        .iter()
+        .flat_map(|(symbol, bindings)| {
+            bindings
+                .iter()
+                .filter_map(|(scopes, binding)| {
+                    (imported.contains(binding) && scopes.is_subset(&scope_set))
+                        .then_some((*symbol, *binding))
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn var_completion_item(label: String, var: Var) -> CompletionItem {
+    match var {
+        Var::Global(global) => {
+            let value = global.read();
+            if value.cast_to_scheme_type::<Procedure>().is_some() {
+                completion_item(label, CompletionItemKind::FUNCTION, "procedure")
+            } else {
+                CompletionItem {
+                    label,
+                    kind: Some(CompletionItemKind::VARIABLE),
+                    detail: (!value.is_undefined()).then(|| value.type_name().to_string()),
+                    ..Default::default()
+                }
+            }
+        }
+        Var::Local(_) => completion_item(label, CompletionItemKind::VARIABLE, "local variable"),
+    }
+}
+
+fn completion_item(label: String, kind: CompletionItemKind, detail: &str) -> CompletionItem {
+    CompletionItem {
+        label,
+        kind: Some(kind),
+        detail: Some(detail.to_string()),
+        ..Default::default()
+    }
+}

--- a/src/lsp/completion.rs
+++ b/src/lsp/completion.rs
@@ -1,4 +1,7 @@
-use lsp_types::{CompletionItem, CompletionItemKind, CompletionResponse, Position, Uri};
+use lsp_types::{
+    CompletionItem, CompletionItemKind, CompletionResponse, Documentation, InsertTextFormat,
+    Position, Uri,
+};
 use scheme_rs_macros::{maybe_async, maybe_await};
 
 use crate::{
@@ -8,7 +11,10 @@ use crate::{
     symbols::Symbol,
 };
 
-use super::document::{completion_prefix, import_visible_libraries, parse_document};
+use super::{
+    document::{completion_prefix, import_visible_libraries, parse_document},
+    procedure::procedure_info,
+};
 
 #[maybe_async]
 pub(super) fn completions_for_document(
@@ -89,8 +95,8 @@ fn var_completion_item(label: String, var: Var) -> CompletionItem {
     match var {
         Var::Global(global) => {
             let value = global.read();
-            if value.cast_to_scheme_type::<Procedure>().is_some() {
-                completion_item(label, CompletionItemKind::FUNCTION, "procedure")
+            if let Some(procedure) = value.cast_to_scheme_type::<Procedure>() {
+                procedure_completion_item(label, &procedure)
             } else {
                 CompletionItem {
                     label,
@@ -109,6 +115,23 @@ fn completion_item(label: String, kind: CompletionItemKind, detail: &str) -> Com
         label,
         kind: Some(kind),
         detail: Some(detail.to_string()),
+        ..Default::default()
+    }
+}
+
+fn procedure_completion_item(label: String, procedure: &Procedure) -> CompletionItem {
+    let info = procedure_info(label.clone(), procedure);
+    CompletionItem {
+        label,
+        kind: Some(CompletionItemKind::FUNCTION),
+        detail: Some(info.signature),
+        documentation: info
+            .docs
+            .map(|docs| docs.trim().to_string())
+            .filter(|docs| !docs.is_empty())
+            .map(Documentation::String),
+        insert_text: info.snippet,
+        insert_text_format: Some(InsertTextFormat::SNIPPET),
         ..Default::default()
     }
 }

--- a/src/lsp/document.rs
+++ b/src/lsp/document.rs
@@ -1,0 +1,130 @@
+use lsp_types::{Position, Range, Uri};
+use scheme_rs_macros::{maybe_async, maybe_await};
+
+use crate::{
+    ast::{ImportSpec, Primitive},
+    env::{Environment, TopLevelEnvironment},
+    exceptions::Exception,
+    runtime::Runtime,
+    syntax::{Span, Syntax, parse::ParseSyntaxError},
+};
+
+pub(super) fn parse_document(
+    runtime: &Runtime,
+    uri: &Uri,
+    text: &str,
+) -> Result<(Syntax, Environment), ParseSyntaxError> {
+    let file_name = document_file_name(uri);
+    let mut form = Syntax::from_str(text, Some(&file_name))?;
+    let program = TopLevelEnvironment::new_program(runtime, file_name.as_ref());
+    let env = Environment::Top(program.clone());
+    form.add_scope(program.scope());
+    Ok((form, env))
+}
+
+fn document_file_name(uri: &Uri) -> String {
+    uri.as_str()
+        .strip_prefix("file://")
+        .unwrap_or(uri.as_str())
+        .to_string()
+}
+
+#[maybe_async]
+pub(super) fn import_visible_libraries(form: &Syntax, env: &Environment) -> Result<(), Exception> {
+    if starts_with_import(form, env) {
+        maybe_await!(import_document_imports(form, env))?;
+    } else {
+        maybe_await!(env.import("(library (rnrs))".parse().unwrap()))?;
+    }
+
+    Ok(())
+}
+
+fn starts_with_import(form: &Syntax, env: &Environment) -> bool {
+    if let Some(first_form) = form.car()
+        && let Some(Syntax::Identifier { ident, .. }) = first_form.car()
+        && let Some(binding) = ident.resolve()
+    {
+        env.lookup_primitive(binding) == Some(Primitive::Import)
+    } else {
+        false
+    }
+}
+
+#[maybe_async]
+fn import_document_imports(form: &Syntax, env: &Environment) -> Result<(), Exception> {
+    let Some(forms) = form.as_list() else {
+        return Ok(());
+    };
+
+    for form in forms.iter().take_while(|form| !form.is_null()) {
+        if !form.has_car("import") {
+            continue;
+        }
+        for import_set in ImportSpec::parse(form)?.import_sets {
+            maybe_await!(env.import(import_set))?;
+        }
+    }
+
+    Ok(())
+}
+
+pub(super) fn completion_prefix(text: &str, position: Position) -> String {
+    let Some(line) = text.lines().nth(position.line as usize) else {
+        return String::new();
+    };
+    let end = line
+        .char_indices()
+        .nth(position.character as usize)
+        .map(|(idx, _)| idx)
+        .unwrap_or(line.len());
+    line[..end]
+        .split(is_token_delimiter)
+        .next_back()
+        .unwrap_or("")
+        .to_string()
+}
+
+pub(super) fn token_range(text: &str, span: &Span) -> Range {
+    let mut range = range_from_span(span);
+    if let Some(token) = token_at(text, &range) {
+        range.end.character = range.start.character + token.chars().count() as u32;
+    }
+    range
+}
+
+pub(super) fn token_at<'a>(text: &'a str, range: &Range) -> Option<&'a str> {
+    let line = text.lines().nth(range.start.line as usize)?;
+    let start = line
+        .char_indices()
+        .nth(range.start.character as usize)
+        .map(|(idx, _)| idx)
+        .unwrap_or(line.len());
+    line[start..]
+        .split(is_token_delimiter)
+        .next()
+        .filter(|token| !token.is_empty())
+}
+
+fn is_token_delimiter(chr: char) -> bool {
+    chr.is_whitespace() || matches!(chr, '(' | ')' | '[' | ']' | '"' | ';')
+}
+
+pub(super) fn range_from_span(span: &Span) -> Range {
+    let line = span.line.saturating_sub(1);
+    let character = span.column as u32;
+
+    Range::new(
+        Position { line, character },
+        Position {
+            line,
+            character: character.saturating_add(1),
+        },
+    )
+}
+
+pub(super) fn eof_range(text: &str) -> Range {
+    let line = text.matches('\n').count() as u32;
+    let character = text.rsplit('\n').next().unwrap_or("").chars().count() as u32;
+    Range::new(Position { line, character }, Position { line, character })
+}

--- a/src/lsp/error.rs
+++ b/src/lsp/error.rs
@@ -1,11 +1,13 @@
-use lsp_server::{ExtractError, Notification, ProtocolError};
+use lsp_server::{ExtractError, Notification, ProtocolError, Request};
 
 #[derive(Debug)]
 pub enum LspError {
     Protocol(ProtocolError),
     SerializeCapabilities(serde_json::Error),
     ExtractNotification(ExtractError<Notification>),
+    ExtractRequest(ExtractError<Request>),
     PublishDiagnostics,
+    SendResponse,
     JoinIoThreads,
 }
 
@@ -17,7 +19,9 @@ impl std::fmt::Display for LspError {
                 write!(f, "failed to serialize server capabilities: {err}")
             }
             Self::ExtractNotification(err) => write!(f, "failed to extract notification: {err}"),
+            Self::ExtractRequest(err) => write!(f, "failed to extract request: {err}"),
             Self::PublishDiagnostics => write!(f, "failed to publish diagnostics"),
+            Self::SendResponse => write!(f, "failed to send LSP response"),
             Self::JoinIoThreads => write!(f, "failed to join LSP IO threads"),
         }
     }

--- a/src/lsp/error.rs
+++ b/src/lsp/error.rs
@@ -1,0 +1,32 @@
+use lsp_server::{ExtractError, Notification, ProtocolError};
+
+#[derive(Debug)]
+pub enum LspError {
+    Protocol(ProtocolError),
+    SerializeCapabilities(serde_json::Error),
+    ExtractNotification(ExtractError<Notification>),
+    PublishDiagnostics,
+    JoinIoThreads,
+}
+
+impl std::fmt::Display for LspError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Protocol(err) => write!(f, "LSP protocol error: {err}"),
+            Self::SerializeCapabilities(err) => {
+                write!(f, "failed to serialize server capabilities: {err}")
+            }
+            Self::ExtractNotification(err) => write!(f, "failed to extract notification: {err}"),
+            Self::PublishDiagnostics => write!(f, "failed to publish diagnostics"),
+            Self::JoinIoThreads => write!(f, "failed to join LSP IO threads"),
+        }
+    }
+}
+
+impl std::error::Error for LspError {}
+
+impl From<ProtocolError> for LspError {
+    fn from(value: ProtocolError) -> Self {
+        Self::Protocol(value)
+    }
+}

--- a/src/lsp/hover.rs
+++ b/src/lsp/hover.rs
@@ -12,6 +12,7 @@ use crate::{
 use super::{
     LspConfig,
     document::{import_visible_libraries, parse_document, token_range},
+    procedure::procedure_info,
 };
 
 #[maybe_async]
@@ -107,50 +108,11 @@ fn var_hover(var: Var) -> String {
 }
 
 fn procedure_hover(kind: &str, fallback_name: String, procedure: &Procedure) -> String {
-    let (required, variadic) = procedure.get_formals();
-    let (name, args, docs) = procedure.get_debug_info().map_or_else(
-        || {
-            (
-                fallback_name,
-                (0..required + usize::from(variadic))
-                    .map(|idx| format!("${idx}"))
-                    .collect(),
-                None,
-            )
-        },
-        |debug_info| {
-            (
-                debug_info.name.to_string(),
-                debug_info.args.iter().map(ToString::to_string).collect(),
-                debug_info.docs.clone(),
-            )
-        },
-    );
-
-    let mut hover = format!(
-        "{}\n\n{kind}",
-        format_signature(name, args, required, variadic)
-    );
-    if let Some(docs) = docs {
+    let info = procedure_info(fallback_name, procedure);
+    let mut hover = format!("{}\n\n{kind}", info.signature);
+    if let Some(docs) = info.docs {
         hover.push_str("\n\n");
         hover.push_str(docs.trim());
     }
     hover
-}
-
-fn format_signature(name: String, args: Vec<String>, required: usize, variadic: bool) -> String {
-    if args.is_empty() {
-        return format!("({name})");
-    }
-
-    let mut output = format!("({name}");
-    for (idx, arg) in args.iter().enumerate() {
-        if variadic && idx == required {
-            output.push_str(" .");
-        }
-        output.push(' ');
-        output.push_str(arg);
-    }
-    output.push(')');
-    output
 }

--- a/src/lsp/hover.rs
+++ b/src/lsp/hover.rs
@@ -1,0 +1,149 @@
+use lsp_types::{Hover, HoverContents, MarkedString, Position, Range, Uri};
+use scheme_rs_macros::{maybe_async, maybe_await};
+
+use crate::{
+    ast::{DefinitionBody, Primitive},
+    env::{Environment, Var},
+    proc::Procedure,
+    runtime::Runtime,
+    syntax::{Identifier, Syntax},
+};
+
+use super::{
+    LspConfig,
+    document::{import_visible_libraries, parse_document, token_range},
+};
+
+#[maybe_async]
+pub(super) fn hover_for_document(
+    runtime: &Runtime,
+    config: LspConfig,
+    uri: &Uri,
+    text: &str,
+    position: Position,
+) -> Option<Hover> {
+    let (form, env) = parse_document(runtime, uri, text).ok()?;
+    maybe_await!(import_visible_libraries(&form, &env)).ok()?;
+    if config.allow_macro_expansion {
+        let _ = maybe_await!(DefinitionBody::parse_lib_body(runtime, &form, &env));
+    }
+
+    let (ident, range) = identifier_at(&form, text, position)?;
+    let contents = maybe_await!(hover_contents_for_identifier(&ident, &env))?;
+
+    Some(Hover {
+        contents: HoverContents::Scalar(MarkedString::String(contents)),
+        range: Some(range),
+    })
+}
+
+#[maybe_async]
+fn hover_contents_for_identifier(ident: &Identifier, env: &Environment) -> Option<String> {
+    let binding = ident.resolve()?;
+    if let Some(primitive) = env.lookup_primitive(binding) {
+        return Some(primitive_hover(ident.symbol().to_string(), primitive));
+    }
+    if maybe_await!(env.lookup_keyword(binding))
+        .ok()
+        .flatten()
+        .is_some()
+    {
+        return Some(format!("{}\n\nsyntax keyword", ident.symbol()));
+    }
+    if let Some(var) = maybe_await!(env.lookup_var(binding)).ok().flatten() {
+        return Some(var_hover(var));
+    }
+    None
+}
+
+fn identifier_at(syntax: &Syntax, text: &str, position: Position) -> Option<(Identifier, Range)> {
+    match syntax {
+        Syntax::Identifier { ident, span } => {
+            let range = token_range(text, span);
+            range_contains_position(&range, position).then(|| (ident.clone(), range))
+        }
+        Syntax::List { list, .. } => list
+            .iter()
+            .find_map(|item| identifier_at(item, text, position)),
+        Syntax::Vector { vector, .. } => vector
+            .iter()
+            .find_map(|item| identifier_at(item, text, position)),
+        Syntax::Wrapped { .. } => None,
+    }
+}
+
+fn range_contains_position(range: &Range, position: Position) -> bool {
+    (position.line, position.character) >= (range.start.line, range.start.character)
+        && (position.line, position.character) < (range.end.line, range.end.character)
+}
+
+fn primitive_hover(name: String, primitive: Primitive) -> String {
+    let kind = if primitive == Primitive::Undefined {
+        "primitive value"
+    } else {
+        "primitive syntax"
+    };
+    format!("{name}\n\n{kind}")
+}
+
+fn var_hover(var: Var) -> String {
+    match var {
+        Var::Local(local) => format!("{local}\n\nlocal variable"),
+        Var::Global(global) => {
+            let name = global.name.to_string();
+            let mut hover = format!("{name}\n\nglobal variable");
+            let value = global.read();
+            if let Some(procedure) = value.cast_to_scheme_type::<Procedure>() {
+                hover = procedure_hover("global procedure", name, &procedure);
+            } else if !value.is_undefined() {
+                hover.push_str(&format!("\n\ntype: {}", value.type_name()));
+            }
+            if global.is_mutable() {
+                hover.push_str("\n\nmutable");
+            }
+            hover
+        }
+    }
+}
+
+fn procedure_hover(kind: &str, fallback_name: String, procedure: &Procedure) -> String {
+    let (required, variadic) = procedure.get_formals();
+    let (name, args) = procedure.get_debug_info().map_or_else(
+        || {
+            (
+                fallback_name,
+                (0..required + usize::from(variadic))
+                    .map(|idx| format!("${idx}"))
+                    .collect(),
+            )
+        },
+        |debug_info| {
+            (
+                debug_info.name.to_string(),
+                debug_info.args.iter().map(ToString::to_string).collect(),
+            )
+        },
+    );
+
+    format!(
+        "{}\n\n{kind}",
+        format_signature(name, args, required, variadic)
+    )
+}
+
+fn format_signature(name: String, args: Vec<String>, required: usize, variadic: bool) -> String {
+    if args.is_empty() {
+        return format!("({name})");
+    }
+
+    let mut output = format!("({name}");
+    for (idx, arg) in args.iter().enumerate() {
+        if variadic && idx == required {
+            output.push_str(" .");
+        }
+        output.push(' ');
+        output.push_str(arg);
+    }
+    output.push(')');
+    output
+}

--- a/src/lsp/hover.rs
+++ b/src/lsp/hover.rs
@@ -108,27 +108,34 @@ fn var_hover(var: Var) -> String {
 
 fn procedure_hover(kind: &str, fallback_name: String, procedure: &Procedure) -> String {
     let (required, variadic) = procedure.get_formals();
-    let (name, args) = procedure.get_debug_info().map_or_else(
+    let (name, args, docs) = procedure.get_debug_info().map_or_else(
         || {
             (
                 fallback_name,
                 (0..required + usize::from(variadic))
                     .map(|idx| format!("${idx}"))
                     .collect(),
+                None,
             )
         },
         |debug_info| {
             (
                 debug_info.name.to_string(),
                 debug_info.args.iter().map(ToString::to_string).collect(),
+                debug_info.docs.clone(),
             )
         },
     );
 
-    format!(
+    let mut hover = format!(
         "{}\n\n{kind}",
         format_signature(name, args, required, variadic)
-    )
+    );
+    if let Some(docs) = docs {
+        hover.push_str("\n\n");
+        hover.push_str(docs.trim());
+    }
+    hover
 }
 
 fn format_signature(name: String, args: Vec<String>, required: usize, variadic: bool) -> String {

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -3,30 +3,39 @@
 //! Adapted from sqleibniz's small stdio LSP: full-document sync,
 //! stdio transport, and parse-on-open/change diagnostics.
 
+/// completion collection/classification.
+mod completion;
+/// parse/import setup, token/range helpers.
+mod document;
 mod error;
+/// hover resolution/formatting
+mod hover;
 
 pub use error::LspError;
 use lsp_server::{Connection, ErrorCode, Message, Notification, Request, Response};
 use lsp_types::{
-    Diagnostic, DiagnosticSeverity, Hover, HoverContents, HoverProviderCapability, MarkedString,
-    Position, PublishDiagnosticsParams, Range, ServerCapabilities, TextDocumentSyncKind,
+    CompletionOptions, CompletionResponse, Diagnostic, DiagnosticSeverity, HoverProviderCapability,
+    PublishDiagnosticsParams, Range, ServerCapabilities, TextDocumentSyncKind,
     TextDocumentSyncOptions, Uri,
     notification::{
         DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument, Notification as _,
     },
-    request::{HoverRequest, Request as _},
+    request::{Completion, HoverRequest, Request as _},
 };
 use scheme_rs_macros::{maybe_async, maybe_await};
 
 use crate::{
-    ast::{DefinitionBody, Primitive},
-    env::{Environment, TopLevelEnvironment, Var},
+    ast::DefinitionBody,
     exceptions::{Exception, Message as SchemeMessage, PrettyCondition, SyntaxViolation},
-    proc::Procedure,
     runtime::Runtime,
-    syntax::{Identifier, Span, Syntax, lex::LexerError, parse::ParseSyntaxError},
+    syntax::{Span, lex::LexerError, parse::ParseSyntaxError},
 };
 
+use completion::completions_for_document;
+use document::{
+    eof_range, import_visible_libraries, parse_document, range_from_span, token_at, token_range,
+};
+use hover::hover_for_document;
 use rustc_hash::FxHashMap as HashMap;
 
 macro_rules! lsp_log {
@@ -53,6 +62,7 @@ pub fn start(config: LspConfig) -> Result<(), LspError> {
                 ..Default::default()
             },
         )),
+        completion_provider: Some(CompletionOptions::default()),
         hover_provider: Some(HoverProviderCapability::Simple(true)),
         ..Default::default()
     })
@@ -148,6 +158,26 @@ fn handle_request(
     request: Request,
 ) -> Result<(), LspError> {
     match request.method.as_str() {
+        Completion::METHOD => {
+            let (id, params) = request
+                .extract::<lsp_types::CompletionParams>(Completion::METHOD)
+                .map_err(LspError::ExtractRequest)?;
+            let uri = params.text_document_position.text_document.uri;
+            let completions = if let Some(text) = documents.get(&uri) {
+                maybe_await!(completions_for_document(
+                    runtime,
+                    &uri,
+                    text,
+                    params.text_document_position.position,
+                ))
+            } else {
+                CompletionResponse::Array(Vec::new())
+            };
+            connection
+                .sender
+                .send(Message::Response(Response::new_ok(id, completions)))
+                .map_err(|_| LspError::SendResponse)?;
+        }
         HoverRequest::METHOD => {
             let (id, params) = request
                 .extract::<lsp_types::HoverParams>(HoverRequest::METHOD)
@@ -225,7 +255,7 @@ fn diagnostics_for_document(
         return Vec::new();
     }
 
-    if let Err(err) = maybe_await!(import_default_rnrs(&form, &env)) {
+    if let Err(err) = maybe_await!(import_visible_libraries(&form, &env)) {
         return vec![diagnostic_from_exception(err, text)];
     }
 
@@ -233,178 +263,6 @@ fn diagnostics_for_document(
         Ok(_) => Vec::new(),
         Err(err) => vec![diagnostic_from_exception(err, text)],
     }
-}
-
-#[maybe_async]
-fn hover_for_document(
-    runtime: &Runtime,
-    config: LspConfig,
-    uri: &Uri,
-    text: &str,
-    position: Position,
-) -> Option<Hover> {
-    let (form, env) = parse_document(runtime, uri, text).ok()?;
-    maybe_await!(import_default_rnrs(&form, &env)).ok()?;
-    if config.allow_macro_expansion {
-        let _ = maybe_await!(DefinitionBody::parse_lib_body(runtime, &form, &env));
-    }
-
-    let (ident, range) = identifier_at(&form, text, position)?;
-    let contents = maybe_await!(hover_contents_for_identifier(&ident, &env))?;
-
-    Some(Hover {
-        contents: HoverContents::Scalar(MarkedString::String(contents)),
-        range: Some(range),
-    })
-}
-
-fn parse_document(
-    runtime: &Runtime,
-    uri: &Uri,
-    text: &str,
-) -> Result<(Syntax, Environment), ParseSyntaxError> {
-    let file_name = document_file_name(uri);
-    let mut form = Syntax::from_str(text, Some(&file_name))?;
-    let program = TopLevelEnvironment::new_program(runtime, file_name.as_ref());
-    let env = Environment::Top(program.clone());
-    form.add_scope(program.scope());
-    Ok((form, env))
-}
-
-fn document_file_name(uri: &Uri) -> String {
-    uri.as_str()
-        .strip_prefix("file://")
-        .unwrap_or(uri.as_str())
-        .to_string()
-}
-
-#[maybe_async]
-fn import_default_rnrs(form: &Syntax, env: &Environment) -> Result<(), Exception> {
-    let starts_with_import = if let Some(first_form) = form.car()
-        && let Some(Syntax::Identifier { ident, .. }) = first_form.car()
-        && let Some(binding) = ident.resolve()
-    {
-        env.lookup_primitive(binding) == Some(Primitive::Import)
-    } else {
-        false
-    };
-
-    if !starts_with_import {
-        maybe_await!(env.import("(library (rnrs))".parse().unwrap()))?;
-    }
-
-    Ok(())
-}
-
-#[maybe_async]
-fn hover_contents_for_identifier(ident: &Identifier, env: &Environment) -> Option<String> {
-    let binding = ident.resolve()?;
-    if let Some(primitive) = env.lookup_primitive(binding) {
-        return Some(primitive_hover(ident.symbol().to_string(), primitive));
-    }
-    if maybe_await!(env.lookup_keyword(binding))
-        .ok()
-        .flatten()
-        .is_some()
-    {
-        return Some(format!("{}\n\nsyntax keyword", ident.symbol()));
-    }
-    if let Some(var) = maybe_await!(env.lookup_var(binding)).ok().flatten() {
-        return Some(var_hover(var));
-    }
-    None
-}
-
-fn identifier_at(syntax: &Syntax, text: &str, position: Position) -> Option<(Identifier, Range)> {
-    match syntax {
-        Syntax::Identifier { ident, span } => {
-            let range = token_range(text, span);
-            range_contains_position(&range, position).then(|| (ident.clone(), range))
-        }
-        Syntax::List { list, .. } => list
-            .iter()
-            .find_map(|item| identifier_at(item, text, position)),
-        Syntax::Vector { vector, .. } => vector
-            .iter()
-            .find_map(|item| identifier_at(item, text, position)),
-        Syntax::Wrapped { .. } => None,
-    }
-}
-
-fn range_contains_position(range: &Range, position: Position) -> bool {
-    (position.line, position.character) >= (range.start.line, range.start.character)
-        && (position.line, position.character) < (range.end.line, range.end.character)
-}
-
-fn primitive_hover(name: String, primitive: Primitive) -> String {
-    let kind = if primitive == Primitive::Undefined {
-        "primitive value"
-    } else {
-        "primitive syntax"
-    };
-    format!("{name}\n\n{kind}")
-}
-
-fn var_hover(var: Var) -> String {
-    match var {
-        Var::Local(local) => format!("{local}\n\nlocal variable"),
-        Var::Global(global) => {
-            let name = global.name.to_string();
-            let mut hover = format!("{name}\n\nglobal variable");
-            let value = global.read();
-            if let Some(procedure) = value.cast_to_scheme_type::<Procedure>() {
-                hover = procedure_hover("global procedure", name, &procedure);
-            } else if !value.is_undefined() {
-                hover.push_str(&format!("\n\ntype: {}", value.type_name()));
-            }
-            if global.is_mutable() {
-                hover.push_str("\n\nmutable");
-            }
-            hover
-        }
-    }
-}
-
-fn procedure_hover(kind: &str, fallback_name: String, procedure: &Procedure) -> String {
-    let (required, variadic) = procedure.get_formals();
-    let (name, args) = procedure.get_debug_info().map_or_else(
-        || {
-            (
-                fallback_name,
-                (0..required + usize::from(variadic))
-                    .map(|idx| format!("${idx}"))
-                    .collect(),
-            )
-        },
-        |debug_info| {
-            (
-                debug_info.name.to_string(),
-                debug_info.args.iter().map(ToString::to_string).collect(),
-            )
-        },
-    );
-
-    format!(
-        "{}\n\n{kind}",
-        format_signature(name, args, required, variadic)
-    )
-}
-
-fn format_signature(name: String, args: Vec<String>, required: usize, variadic: bool) -> String {
-    if args.is_empty() {
-        return format!("({name})");
-    }
-
-    let mut output = format!("({name}");
-    for (idx, arg) in args.iter().enumerate() {
-        if variadic && idx == required {
-            output.push_str(" .");
-        }
-        output.push(' ');
-        output.push_str(arg);
-    }
-    output.push(')');
-    output
 }
 
 fn diagnostic_from_parse_error(err: ParseSyntaxError, text: &str) -> Diagnostic {
@@ -447,27 +305,6 @@ fn diagnostic(message: String, range: Range) -> Diagnostic {
     }
 }
 
-fn token_range(text: &str, span: &Span) -> Range {
-    let mut range = range_from_span(span);
-    if let Some(token) = token_at(text, &range) {
-        range.end.character = range.start.character + token.chars().count() as u32;
-    }
-    range
-}
-
-fn token_at<'a>(text: &'a str, range: &Range) -> Option<&'a str> {
-    let line = text.lines().nth(range.start.line as usize)?;
-    let start = line
-        .char_indices()
-        .nth(range.start.character as usize)
-        .map(|(idx, _)| idx)
-        .unwrap_or(line.len());
-    line[start..]
-        .split(|chr: char| chr.is_whitespace() || matches!(chr, '(' | ')' | '[' | ']' | '"' | ';'))
-        .next()
-        .filter(|token| !token.is_empty())
-}
-
 fn parse_error_span(err: &ParseSyntaxError) -> Option<&Span> {
     match err {
         ParseSyntaxError::ExpectedClosingParen { span }
@@ -486,25 +323,6 @@ fn parse_error_span(err: &ParseSyntaxError) -> Option<&Span> {
         | ParseSyntaxError::CharTryFrom(_)
         | ParseSyntaxError::ParseNumberError(_) => None,
     }
-}
-
-fn range_from_span(span: &Span) -> Range {
-    let line = span.line.saturating_sub(1);
-    let character = span.column as u32;
-
-    Range::new(
-        Position { line, character },
-        Position {
-            line,
-            character: character.saturating_add(1),
-        },
-    )
-}
-
-fn eof_range(text: &str) -> Range {
-    let line = text.matches('\n').count() as u32;
-    let character = text.rsplit('\n').next().unwrap_or("").chars().count() as u32;
-    Range::new(Position { line, character }, Position { line, character })
 }
 
 fn cast_notification<N>(notification: Notification) -> Result<N::Params, LspError>

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -6,21 +6,28 @@
 mod error;
 
 pub use error::LspError;
-use lsp_server::{Connection, Message, Notification};
+use lsp_server::{Connection, ErrorCode, Message, Notification, Request, Response};
 use lsp_types::{
-    Diagnostic, DiagnosticSeverity, Position, PublishDiagnosticsParams, Range, ServerCapabilities,
-    TextDocumentSyncKind, TextDocumentSyncOptions, Uri,
-    notification::{DidChangeTextDocument, DidOpenTextDocument, Notification as _},
+    Diagnostic, DiagnosticSeverity, Hover, HoverContents, HoverProviderCapability, MarkedString,
+    Position, PublishDiagnosticsParams, Range, ServerCapabilities, TextDocumentSyncKind,
+    TextDocumentSyncOptions, Uri,
+    notification::{
+        DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument, Notification as _,
+    },
+    request::{HoverRequest, Request as _},
 };
 use scheme_rs_macros::{maybe_async, maybe_await};
 
 use crate::{
     ast::{DefinitionBody, Primitive},
-    env::{Environment, TopLevelEnvironment},
+    env::{Environment, TopLevelEnvironment, Var},
     exceptions::{Exception, Message as SchemeMessage, PrettyCondition, SyntaxViolation},
+    proc::Procedure,
     runtime::Runtime,
-    syntax::{Span, Syntax, lex::LexerError, parse::ParseSyntaxError},
+    syntax::{Identifier, Span, Syntax, lex::LexerError, parse::ParseSyntaxError},
 };
+
+use rustc_hash::FxHashMap as HashMap;
 
 macro_rules! lsp_log {
     ($($arg:tt)*) => {
@@ -46,6 +53,7 @@ pub fn start(config: LspConfig) -> Result<(), LspError> {
                 ..Default::default()
             },
         )),
+        hover_provider: Some(HoverProviderCapability::Simple(true)),
         ..Default::default()
     })
     .map_err(LspError::SerializeCapabilities)?;
@@ -74,18 +82,30 @@ fn event_loop(
     runtime: &Runtime,
     config: LspConfig,
 ) -> Result<(), LspError> {
+    let mut documents = HashMap::<Uri, String>::default();
+
     for msg in &connection.receiver {
         match msg {
             Message::Request(req) => {
                 if connection.handle_shutdown(&req)? {
                     return Ok(());
                 }
-                lsp_log!("unsupported request: {}", req.method);
+                maybe_await!(handle_request(
+                    &connection,
+                    runtime,
+                    config,
+                    &documents,
+                    req
+                ))?;
             }
             Message::Response(_) => {}
             Message::Notification(notification) => match notification.method.as_str() {
                 DidOpenTextDocument::METHOD => {
                     let params = cast_notification::<DidOpenTextDocument>(notification)?;
+                    documents.insert(
+                        params.text_document.uri.clone(),
+                        params.text_document.text.clone(),
+                    );
                     maybe_await!(publish_diagnostics(
                         &connection,
                         runtime,
@@ -97,6 +117,7 @@ fn event_loop(
                 DidChangeTextDocument::METHOD => {
                     let params = cast_notification::<DidChangeTextDocument>(notification)?;
                     if let Some(change) = params.content_changes.first() {
+                        documents.insert(params.text_document.uri.clone(), change.text.clone());
                         maybe_await!(publish_diagnostics(
                             &connection,
                             runtime,
@@ -106,8 +127,58 @@ fn event_loop(
                         ))?;
                     }
                 }
+                DidCloseTextDocument::METHOD => {
+                    let params = cast_notification::<DidCloseTextDocument>(notification)?;
+                    documents.remove(&params.text_document.uri);
+                }
                 method => lsp_log!("unsupported notification: {method}"),
             },
+        }
+    }
+
+    Ok(())
+}
+
+#[maybe_async]
+fn handle_request(
+    connection: &Connection,
+    runtime: &Runtime,
+    config: LspConfig,
+    documents: &HashMap<Uri, String>,
+    request: Request,
+) -> Result<(), LspError> {
+    match request.method.as_str() {
+        HoverRequest::METHOD => {
+            let (id, params) = request
+                .extract::<lsp_types::HoverParams>(HoverRequest::METHOD)
+                .map_err(LspError::ExtractRequest)?;
+            let uri = params.text_document_position_params.text_document.uri;
+            let hover = if let Some(text) = documents.get(&uri) {
+                maybe_await!(hover_for_document(
+                    runtime,
+                    config,
+                    &uri,
+                    text,
+                    params.text_document_position_params.position,
+                ))
+            } else {
+                None
+            };
+            connection
+                .sender
+                .send(Message::Response(Response::new_ok(id, hover)))
+                .map_err(|_| LspError::SendResponse)?;
+        }
+        method => {
+            lsp_log!("unsupported request: {method}");
+            connection
+                .sender
+                .send(Message::Response(Response::new_err(
+                    request.id,
+                    ErrorCode::MethodNotFound as i32,
+                    format!("unsupported request: {method}"),
+                )))
+                .map_err(|_| LspError::SendResponse)?;
         }
     }
 
@@ -145,14 +216,8 @@ fn diagnostics_for_document(
     uri: &Uri,
     text: &str,
 ) -> Vec<Diagnostic> {
-    let file_name = uri
-        .as_str()
-        .strip_prefix("file://")
-        .unwrap_or(uri.as_str())
-        .to_string();
-
-    let mut form = match Syntax::from_str(text, Some(&file_name)) {
-        Ok(form) => form,
+    let (form, env) = match parse_document(runtime, uri, text) {
+        Ok(context) => context,
         Err(err) => return vec![diagnostic_from_parse_error(err, text)],
     };
 
@@ -160,22 +225,7 @@ fn diagnostics_for_document(
         return Vec::new();
     }
 
-    let program = TopLevelEnvironment::new_program(runtime, file_name.as_ref());
-    let env = Environment::Top(program.clone());
-    form.add_scope(program.scope());
-
-    let add_rnrs_import = if let Some(first_form) = form.car()
-        && let Some(Syntax::Identifier { ident, .. }) = first_form.car()
-        && let Some(binding) = ident.resolve()
-    {
-        env.lookup_primitive(binding) != Some(Primitive::Import)
-    } else {
-        true
-    };
-
-    if add_rnrs_import
-        && let Err(err) = maybe_await!(env.import("(library (rnrs))".parse().unwrap()))
-    {
+    if let Err(err) = maybe_await!(import_default_rnrs(&form, &env)) {
         return vec![diagnostic_from_exception(err, text)];
     }
 
@@ -183,6 +233,178 @@ fn diagnostics_for_document(
         Ok(_) => Vec::new(),
         Err(err) => vec![diagnostic_from_exception(err, text)],
     }
+}
+
+#[maybe_async]
+fn hover_for_document(
+    runtime: &Runtime,
+    config: LspConfig,
+    uri: &Uri,
+    text: &str,
+    position: Position,
+) -> Option<Hover> {
+    let (form, env) = parse_document(runtime, uri, text).ok()?;
+    maybe_await!(import_default_rnrs(&form, &env)).ok()?;
+    if config.allow_macro_expansion {
+        let _ = maybe_await!(DefinitionBody::parse_lib_body(runtime, &form, &env));
+    }
+
+    let (ident, range) = identifier_at(&form, text, position)?;
+    let contents = maybe_await!(hover_contents_for_identifier(&ident, &env))?;
+
+    Some(Hover {
+        contents: HoverContents::Scalar(MarkedString::String(contents)),
+        range: Some(range),
+    })
+}
+
+fn parse_document(
+    runtime: &Runtime,
+    uri: &Uri,
+    text: &str,
+) -> Result<(Syntax, Environment), ParseSyntaxError> {
+    let file_name = document_file_name(uri);
+    let mut form = Syntax::from_str(text, Some(&file_name))?;
+    let program = TopLevelEnvironment::new_program(runtime, file_name.as_ref());
+    let env = Environment::Top(program.clone());
+    form.add_scope(program.scope());
+    Ok((form, env))
+}
+
+fn document_file_name(uri: &Uri) -> String {
+    uri.as_str()
+        .strip_prefix("file://")
+        .unwrap_or(uri.as_str())
+        .to_string()
+}
+
+#[maybe_async]
+fn import_default_rnrs(form: &Syntax, env: &Environment) -> Result<(), Exception> {
+    let starts_with_import = if let Some(first_form) = form.car()
+        && let Some(Syntax::Identifier { ident, .. }) = first_form.car()
+        && let Some(binding) = ident.resolve()
+    {
+        env.lookup_primitive(binding) == Some(Primitive::Import)
+    } else {
+        false
+    };
+
+    if !starts_with_import {
+        maybe_await!(env.import("(library (rnrs))".parse().unwrap()))?;
+    }
+
+    Ok(())
+}
+
+#[maybe_async]
+fn hover_contents_for_identifier(ident: &Identifier, env: &Environment) -> Option<String> {
+    let binding = ident.resolve()?;
+    if let Some(primitive) = env.lookup_primitive(binding) {
+        return Some(primitive_hover(ident.symbol().to_string(), primitive));
+    }
+    if maybe_await!(env.lookup_keyword(binding))
+        .ok()
+        .flatten()
+        .is_some()
+    {
+        return Some(format!("{}\n\nsyntax keyword", ident.symbol()));
+    }
+    if let Some(var) = maybe_await!(env.lookup_var(binding)).ok().flatten() {
+        return Some(var_hover(var));
+    }
+    None
+}
+
+fn identifier_at(syntax: &Syntax, text: &str, position: Position) -> Option<(Identifier, Range)> {
+    match syntax {
+        Syntax::Identifier { ident, span } => {
+            let range = token_range(text, span);
+            range_contains_position(&range, position).then(|| (ident.clone(), range))
+        }
+        Syntax::List { list, .. } => list
+            .iter()
+            .find_map(|item| identifier_at(item, text, position)),
+        Syntax::Vector { vector, .. } => vector
+            .iter()
+            .find_map(|item| identifier_at(item, text, position)),
+        Syntax::Wrapped { .. } => None,
+    }
+}
+
+fn range_contains_position(range: &Range, position: Position) -> bool {
+    (position.line, position.character) >= (range.start.line, range.start.character)
+        && (position.line, position.character) < (range.end.line, range.end.character)
+}
+
+fn primitive_hover(name: String, primitive: Primitive) -> String {
+    let kind = if primitive == Primitive::Undefined {
+        "primitive value"
+    } else {
+        "primitive syntax"
+    };
+    format!("{name}\n\n{kind}")
+}
+
+fn var_hover(var: Var) -> String {
+    match var {
+        Var::Local(local) => format!("{local}\n\nlocal variable"),
+        Var::Global(global) => {
+            let name = global.name.to_string();
+            let mut hover = format!("{name}\n\nglobal variable");
+            let value = global.read();
+            if let Some(procedure) = value.cast_to_scheme_type::<Procedure>() {
+                hover = procedure_hover("global procedure", name, &procedure);
+            } else if !value.is_undefined() {
+                hover.push_str(&format!("\n\ntype: {}", value.type_name()));
+            }
+            if global.is_mutable() {
+                hover.push_str("\n\nmutable");
+            }
+            hover
+        }
+    }
+}
+
+fn procedure_hover(kind: &str, fallback_name: String, procedure: &Procedure) -> String {
+    let (required, variadic) = procedure.get_formals();
+    let (name, args) = procedure.get_debug_info().map_or_else(
+        || {
+            (
+                fallback_name,
+                (0..required + usize::from(variadic))
+                    .map(|idx| format!("${idx}"))
+                    .collect(),
+            )
+        },
+        |debug_info| {
+            (
+                debug_info.name.to_string(),
+                debug_info.args.iter().map(ToString::to_string).collect(),
+            )
+        },
+    );
+
+    format!(
+        "{}\n\n{kind}",
+        format_signature(name, args, required, variadic)
+    )
+}
+
+fn format_signature(name: String, args: Vec<String>, required: usize, variadic: bool) -> String {
+    if args.is_empty() {
+        return format!("({name})");
+    }
+
+    let mut output = format!("({name}");
+    for (idx, arg) in args.iter().enumerate() {
+        if variadic && idx == required {
+            output.push_str(" .");
+        }
+        output.push(' ');
+        output.push_str(arg);
+    }
+    output.push(')');
+    output
 }
 
 fn diagnostic_from_parse_error(err: ParseSyntaxError, text: &str) -> Diagnostic {

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -1,0 +1,6 @@
+//! MVP Language Server Protocol support for Scheme.
+//!
+//! Adapted from the small stdio LSP included in sqleibniz. Full-document sync, document state, and
+//! parse-on-open/change diagnostics.
+
+mod error;

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -10,6 +10,7 @@ mod document;
 mod error;
 /// hover resolution/formatting
 mod hover;
+mod procedure;
 
 pub use error::LspError;
 use lsp_server::{Connection, ErrorCode, Message, Notification, Request, Response};

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -1,6 +1,275 @@
 //! MVP Language Server Protocol support for Scheme.
 //!
-//! Adapted from the small stdio LSP included in sqleibniz. Full-document sync, document state, and
-//! parse-on-open/change diagnostics.
+//! Adapted from sqleibniz's small stdio LSP: full-document sync,
+//! stdio transport, and parse-on-open/change diagnostics.
 
 mod error;
+
+pub use error::LspError;
+use lsp_server::{Connection, Message, Notification};
+use lsp_types::{
+    Diagnostic, DiagnosticSeverity, Position, PublishDiagnosticsParams, Range, ServerCapabilities,
+    TextDocumentSyncKind, TextDocumentSyncOptions, Uri,
+    notification::{DidChangeTextDocument, DidOpenTextDocument, Notification as _},
+};
+use scheme_rs_macros::{maybe_async, maybe_await};
+
+use crate::{
+    ast::{DefinitionBody, Primitive},
+    env::{Environment, TopLevelEnvironment},
+    exceptions::{Exception, Message as SchemeMessage, PrettyCondition, SyntaxViolation},
+    runtime::Runtime,
+    syntax::{Span, Syntax, lex::LexerError, parse::ParseSyntaxError},
+};
+
+macro_rules! lsp_log {
+    ($($arg:tt)*) => {
+        eprintln!("[scheme-rs-lsp]: {}", format_args!($($arg)*))
+    };
+}
+
+#[maybe_async]
+pub fn start() -> Result<(), LspError> {
+    lsp_log!("starting language server");
+
+    let (connection, io_threads) = Connection::stdio();
+    let capabilities = serde_json::to_value(&ServerCapabilities {
+        text_document_sync: Some(lsp_types::TextDocumentSyncCapability::Options(
+            TextDocumentSyncOptions {
+                open_close: Some(true),
+                change: Some(TextDocumentSyncKind::FULL),
+                ..Default::default()
+            },
+        )),
+        ..Default::default()
+    })
+    .map_err(LspError::SerializeCapabilities)?;
+
+    match connection.initialize(capabilities) {
+        Ok(_) => {}
+        Err(err) => {
+            if err.channel_is_disconnected() {
+                io_threads.join().map_err(|_| LspError::JoinIoThreads)?;
+            }
+            return Err(err.into());
+        }
+    };
+
+    let runtime = Runtime::new();
+    maybe_await!(event_loop(connection, &runtime))?;
+
+    io_threads.join().map_err(|_| LspError::JoinIoThreads)?;
+    lsp_log!("shutting down language server");
+    Ok(())
+}
+
+#[maybe_async]
+fn event_loop(connection: Connection, runtime: &Runtime) -> Result<(), LspError> {
+    for msg in &connection.receiver {
+        match msg {
+            Message::Request(req) => {
+                if connection.handle_shutdown(&req)? {
+                    return Ok(());
+                }
+                lsp_log!("unsupported request: {}", req.method);
+            }
+            Message::Response(_) => {}
+            Message::Notification(notification) => match notification.method.as_str() {
+                DidOpenTextDocument::METHOD => {
+                    let params = cast_notification::<DidOpenTextDocument>(notification)?;
+                    maybe_await!(publish_diagnostics(
+                        &connection,
+                        runtime,
+                        params.text_document.uri,
+                        &params.text_document.text,
+                    ))?;
+                }
+                DidChangeTextDocument::METHOD => {
+                    let params = cast_notification::<DidChangeTextDocument>(notification)?;
+                    if let Some(change) = params.content_changes.first() {
+                        maybe_await!(publish_diagnostics(
+                            &connection,
+                            runtime,
+                            params.text_document.uri,
+                            &change.text
+                        ))?;
+                    }
+                }
+                method => lsp_log!("unsupported notification: {method}"),
+            },
+        }
+    }
+
+    Ok(())
+}
+
+#[maybe_async]
+fn publish_diagnostics(
+    connection: &Connection,
+    runtime: &Runtime,
+    uri: Uri,
+    text: &str,
+) -> Result<(), LspError> {
+    let diagnostics = maybe_await!(diagnostics_for_document(runtime, &uri, text));
+    connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "textDocument/publishDiagnostics".to_string(),
+            PublishDiagnosticsParams {
+                diagnostics,
+                uri,
+                version: None,
+            },
+        )))
+        .map_err(|_| LspError::PublishDiagnostics)?;
+
+    Ok(())
+}
+
+#[maybe_async]
+fn diagnostics_for_document(runtime: &Runtime, uri: &Uri, text: &str) -> Vec<Diagnostic> {
+    let file_name = uri
+        .as_str()
+        .strip_prefix("file://")
+        .unwrap_or(uri.as_str())
+        .to_string();
+
+    let mut form = match Syntax::from_str(text, Some(&file_name)) {
+        Ok(form) => form,
+        Err(err) => return vec![diagnostic_from_parse_error(err, text)],
+    };
+
+    let program = TopLevelEnvironment::new_program(runtime, file_name.as_ref());
+    let env = Environment::Top(program.clone());
+    form.add_scope(program.scope());
+
+    let add_rnrs_import = if let Some(first_form) = form.car()
+        && let Some(Syntax::Identifier { ident, .. }) = first_form.car()
+        && let Some(binding) = ident.resolve()
+    {
+        env.lookup_primitive(binding) != Some(Primitive::Import)
+    } else {
+        true
+    };
+
+    if add_rnrs_import
+        && let Err(err) = maybe_await!(env.import("(library (rnrs))".parse().unwrap()))
+    {
+        return vec![diagnostic_from_exception(err, text)];
+    }
+
+    match maybe_await!(DefinitionBody::parse_lib_body(runtime, &form, &env)) {
+        Ok(_) => Vec::new(),
+        Err(err) => vec![diagnostic_from_exception(err, text)],
+    }
+}
+
+fn diagnostic_from_parse_error(err: ParseSyntaxError, text: &str) -> Diagnostic {
+    diagnostic(
+        err.to_string(),
+        parse_error_span(&err)
+            .map(range_from_span)
+            .unwrap_or_else(|| eof_range(text)),
+    )
+}
+
+fn diagnostic_from_exception(err: Exception, text: &str) -> Diagnostic {
+    let range = err
+        .condition::<SyntaxViolation>()
+        .ok()
+        .flatten()
+        .map(|syntax| token_range(text, &syntax.span()))
+        .unwrap_or_else(|| eof_range(text));
+    let message = err
+        .condition::<SchemeMessage>()
+        .ok()
+        .flatten()
+        .map(|message| message.message.clone())
+        .unwrap_or_else(|| err.to_string());
+
+    let message = match (message.as_str(), token_at(text, &range)) {
+        ("undefined variable", Some(token)) => format!("undefined variable `{token}`"),
+        _ => message,
+    };
+    diagnostic(message, range)
+}
+
+fn diagnostic(message: String, range: Range) -> Diagnostic {
+    Diagnostic {
+        range,
+        message,
+        severity: Some(DiagnosticSeverity::ERROR),
+        source: Some("scheme-rs".into()),
+        ..Default::default()
+    }
+}
+
+fn token_range(text: &str, span: &Span) -> Range {
+    let mut range = range_from_span(span);
+    if let Some(token) = token_at(text, &range) {
+        range.end.character = range.start.character + token.chars().count() as u32;
+    }
+    range
+}
+
+fn token_at<'a>(text: &'a str, range: &Range) -> Option<&'a str> {
+    let line = text.lines().nth(range.start.line as usize)?;
+    let start = line
+        .char_indices()
+        .nth(range.start.character as usize)
+        .map(|(idx, _)| idx)
+        .unwrap_or(line.len());
+    line[start..]
+        .split(|chr: char| chr.is_whitespace() || matches!(chr, '(' | ')' | '[' | ']' | '"' | ';'))
+        .next()
+        .filter(|token| !token.is_empty())
+}
+
+fn parse_error_span(err: &ParseSyntaxError) -> Option<&Span> {
+    match err {
+        ParseSyntaxError::ExpectedClosingParen { span }
+        | ParseSyntaxError::UnexpectedClosingParen { span }
+        | ParseSyntaxError::InvalidPeriodLocation { span }
+        | ParseSyntaxError::NonByte { span }
+        | ParseSyntaxError::UnclosedParen { span } => Some(span),
+        ParseSyntaxError::Lex(err) => match err {
+            LexerError::InvalidCharacterInHexEscape { span, .. }
+            | LexerError::UnexpectedCharacter { span, .. }
+            | LexerError::BadEscapeCharacter { span, .. } => Some(span),
+            LexerError::UnexpectedEof | LexerError::ReadError(_) => None,
+        },
+        ParseSyntaxError::UnexpectedToken { token } => Some(&token.span),
+        ParseSyntaxError::UnexpectedEof
+        | ParseSyntaxError::CharTryFrom(_)
+        | ParseSyntaxError::ParseNumberError(_) => None,
+    }
+}
+
+fn range_from_span(span: &Span) -> Range {
+    let line = span.line.saturating_sub(1);
+    let character = span.column as u32;
+
+    Range::new(
+        Position { line, character },
+        Position {
+            line,
+            character: character.saturating_add(1),
+        },
+    )
+}
+
+fn eof_range(text: &str) -> Range {
+    let line = text.matches('\n').count() as u32;
+    let character = text.rsplit('\n').next().unwrap_or("").chars().count() as u32;
+    Range::new(Position { line, character }, Position { line, character })
+}
+
+fn cast_notification<N>(notification: Notification) -> Result<N::Params, LspError>
+where
+    N: lsp_types::notification::Notification,
+    N::Params: serde::de::DeserializeOwned,
+{
+    notification
+        .extract(N::METHOD)
+        .map_err(LspError::ExtractNotification)
+}

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -28,8 +28,13 @@ macro_rules! lsp_log {
     };
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+pub struct LspConfig {
+    pub allow_macro_expansion: bool,
+}
+
 #[maybe_async]
-pub fn start() -> Result<(), LspError> {
+pub fn start(config: LspConfig) -> Result<(), LspError> {
     lsp_log!("starting language server");
 
     let (connection, io_threads) = Connection::stdio();
@@ -56,7 +61,7 @@ pub fn start() -> Result<(), LspError> {
     };
 
     let runtime = Runtime::new();
-    maybe_await!(event_loop(connection, &runtime))?;
+    maybe_await!(event_loop(connection, &runtime, config))?;
 
     io_threads.join().map_err(|_| LspError::JoinIoThreads)?;
     lsp_log!("shutting down language server");
@@ -64,7 +69,11 @@ pub fn start() -> Result<(), LspError> {
 }
 
 #[maybe_async]
-fn event_loop(connection: Connection, runtime: &Runtime) -> Result<(), LspError> {
+fn event_loop(
+    connection: Connection,
+    runtime: &Runtime,
+    config: LspConfig,
+) -> Result<(), LspError> {
     for msg in &connection.receiver {
         match msg {
             Message::Request(req) => {
@@ -80,6 +89,7 @@ fn event_loop(connection: Connection, runtime: &Runtime) -> Result<(), LspError>
                     maybe_await!(publish_diagnostics(
                         &connection,
                         runtime,
+                        config,
                         params.text_document.uri,
                         &params.text_document.text,
                     ))?;
@@ -90,6 +100,7 @@ fn event_loop(connection: Connection, runtime: &Runtime) -> Result<(), LspError>
                         maybe_await!(publish_diagnostics(
                             &connection,
                             runtime,
+                            config,
                             params.text_document.uri,
                             &change.text
                         ))?;
@@ -107,10 +118,11 @@ fn event_loop(connection: Connection, runtime: &Runtime) -> Result<(), LspError>
 fn publish_diagnostics(
     connection: &Connection,
     runtime: &Runtime,
+    config: LspConfig,
     uri: Uri,
     text: &str,
 ) -> Result<(), LspError> {
-    let diagnostics = maybe_await!(diagnostics_for_document(runtime, &uri, text));
+    let diagnostics = maybe_await!(diagnostics_for_document(runtime, config, &uri, text));
     connection
         .sender
         .send(Message::Notification(Notification::new(
@@ -127,7 +139,12 @@ fn publish_diagnostics(
 }
 
 #[maybe_async]
-fn diagnostics_for_document(runtime: &Runtime, uri: &Uri, text: &str) -> Vec<Diagnostic> {
+fn diagnostics_for_document(
+    runtime: &Runtime,
+    config: LspConfig,
+    uri: &Uri,
+    text: &str,
+) -> Vec<Diagnostic> {
     let file_name = uri
         .as_str()
         .strip_prefix("file://")
@@ -138,6 +155,10 @@ fn diagnostics_for_document(runtime: &Runtime, uri: &Uri, text: &str) -> Vec<Dia
         Ok(form) => form,
         Err(err) => return vec![diagnostic_from_parse_error(err, text)],
     };
+
+    if !config.allow_macro_expansion {
+        return Vec::new();
+    }
 
     let program = TopLevelEnvironment::new_program(runtime, file_name.as_ref());
     let env = Environment::Top(program.clone());

--- a/src/lsp/procedure.rs
+++ b/src/lsp/procedure.rs
@@ -1,0 +1,81 @@
+use crate::proc::Procedure;
+
+pub(super) struct ProcedureInfo {
+    pub(super) signature: String,
+    pub(super) snippet: Option<String>,
+    pub(super) docs: Option<String>,
+}
+
+pub(super) fn procedure_info(fallback_name: String, procedure: &Procedure) -> ProcedureInfo {
+    let (required, variadic) = procedure.get_formals();
+    let (name, args, docs): (String, Vec<String>, Option<String>) =
+        procedure.get_debug_info().map_or_else(
+            || {
+                (
+                    fallback_name,
+                    (0..required + usize::from(variadic))
+                        .map(|idx| format!("${idx}"))
+                        .collect(),
+                    None,
+                )
+            },
+            |debug_info| {
+                (
+                    debug_info.name.to_string(),
+                    debug_info.args.iter().map(ToString::to_string).collect(),
+                    debug_info.docs.clone(),
+                )
+            },
+        );
+
+    let signature = format_signature(&name, &args, required, variadic);
+    let snippet = procedure_snippet(&name, &args);
+
+    ProcedureInfo {
+        signature,
+        snippet,
+        docs,
+    }
+}
+
+fn format_signature(name: &str, args: &[String], required: usize, variadic: bool) -> String {
+    if args.is_empty() {
+        return format!("({name})");
+    }
+
+    let mut output = format!("({name}");
+    for (idx, arg) in args.iter().enumerate() {
+        if variadic && idx == required {
+            output.push_str(" .");
+        }
+        output.push(' ');
+        output.push_str(arg);
+    }
+    output.push(')');
+    output
+}
+
+fn procedure_snippet(name: &str, args: &[String]) -> Option<String> {
+    if args.is_empty() {
+        return None;
+    }
+
+    let mut snippet = escape_snippet_text(name);
+    for (idx, arg) in args.iter().enumerate() {
+        let placeholder = idx + 1;
+        snippet.push(' ');
+        snippet.push_str(&format!(
+            "${{{placeholder}:{}}}",
+            escape_snippet_placeholder(arg)
+        ));
+    }
+    Some(snippet)
+}
+
+fn escape_snippet_text(text: &str) -> String {
+    text.replace('\\', "\\\\").replace('$', "\\$")
+}
+
+fn escape_snippet_placeholder(text: &str) -> String {
+    escape_snippet_text(text).replace('}', "\\}")
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,9 @@ struct Args {
     /// Start scheme-rs language server
     #[arg(long)]
     lsp: bool,
+    /// Allow the LSP to run macro expansion while producing diagnostics
+    #[arg(long)]
+    dangerously_allow_macro_expansion_in_lsp: bool,
 }
 
 #[cfg(not(feature = "async"))]
@@ -101,8 +104,10 @@ fn entry(runtime: &Runtime) -> Result<(), Exception> {
     #[cfg(feature = "lsp")]
     {
         if args.lsp {
-            maybe_await!(scheme_rs::lsp::start())
-                .map_err(|err| Exception::error(err.to_string()))?;
+            maybe_await!(scheme_rs::lsp::start(scheme_rs::lsp::LspConfig {
+                allow_macro_expansion: args.dangerously_allow_macro_expansion_in_lsp,
+            }))
+            .map_err(|err| Exception::error(err.to_string()))?;
             return Ok(());
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,9 +98,22 @@ impl IntoPort for TextStoringPrompt {
 fn entry(runtime: &Runtime) -> Result<(), Exception> {
     let args = Args::parse();
 
-    if args.lsp {
-        maybe_await!(scheme_rs::lsp::start()).map_err(|err| Exception::error(err.to_string()))?;
-        return Ok(());
+    #[cfg(feature = "lsp")]
+    {
+        if args.lsp {
+            maybe_await!(scheme_rs::lsp::start())
+                .map_err(|err| Exception::error(err.to_string()))?;
+            return Ok(());
+        }
+    }
+
+    #[cfg(not(feature = "lsp"))]
+    {
+        if args.lsp {
+            return Err(Exception::error(
+                "`--lsp` requires building scheme-rs with the `lsp` feature enabled",
+            ));
+        }
     }
 
     // Run any programs

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,9 @@ struct Args {
     /// Force interactive mode (REPL)
     #[arg(short, long)]
     interactive: bool,
+    /// Start scheme-rs language server
+    #[arg(long)]
+    lsp: bool,
 }
 
 #[cfg(not(feature = "async"))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,6 +98,11 @@ impl IntoPort for TextStoringPrompt {
 fn entry(runtime: &Runtime) -> Result<(), Exception> {
     let args = Args::parse();
 
+    if args.lsp {
+        maybe_await!(scheme_rs::lsp::start()).map_err(|err| Exception::error(err.to_string()))?;
+        return Ok(());
+    }
+
     // Run any programs
     for file in &args.files {
         let path = Path::new(file);

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -703,6 +703,8 @@ pub struct ProcDebugInfo {
     pub args: Vec<Local>,
     /// Location of the function definition
     pub location: Span,
+    /// Documentation captured from the function definition.
+    pub docs: Option<String>,
 }
 
 impl ProcDebugInfo {
@@ -711,6 +713,7 @@ impl ProcDebugInfo {
             name: name.unwrap_or_else(|| Symbol::intern("<lambda>")),
             args,
             location,
+            docs: None,
         }
     }
 
@@ -728,6 +731,7 @@ impl ProcDebugInfo {
                 offset: debug_info.offset,
                 file: std::sync::Arc::from(debug_info.file.to_string()),
             },
+            docs: (!debug_info.docs.is_empty()).then(|| debug_info.docs.to_string()),
         }
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -105,6 +105,7 @@ pub struct BridgeFnDebugInfo {
     pub(crate) column: u32,
     pub(crate) offset: usize,
     pub(crate) args: &'static [&'static str],
+    pub(crate) docs: &'static str,
 }
 
 impl BridgeFnDebugInfo {
@@ -114,6 +115,7 @@ impl BridgeFnDebugInfo {
         column: u32,
         offset: usize,
         args: &'static [&'static str],
+        docs: &'static str,
     ) -> Self {
         Self {
             file,
@@ -121,6 +123,7 @@ impl BridgeFnDebugInfo {
             column,
             offset,
             args,
+            docs,
         }
     }
 }

--- a/src/syntax/lex.rs
+++ b/src/syntax/lex.rs
@@ -1,6 +1,6 @@
 //! Lexical analysis of symbolic expressions
 
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 use super::Span;
 use malachite::{Integer, base::num::conversion::traits::*, rational::Rational};
@@ -609,6 +609,24 @@ pub enum LexerError {
     ReadError(Exception),
 }
 
+impl fmt::Display for LexerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnexpectedEof => write!(f, "unexpected end of file"),
+            Self::InvalidCharacterInHexEscape { chr, span } => {
+                write!(f, "invalid character `{chr}` in hex escape at `{span}`")
+            }
+            Self::UnexpectedCharacter { chr, span } => {
+                write!(f, "unexpected character `{chr}` at `{span}`")
+            }
+            Self::BadEscapeCharacter { chr, span } => {
+                write!(f, "bad escape character `{chr}` at `{span}`")
+            }
+            Self::ReadError(err) => write!(f, "read error: {err}"),
+        }
+    }
+}
+
 impl From<Exception> for LexerError {
     fn from(error: Exception) -> Self {
         Self::ReadError(error)
@@ -757,6 +775,14 @@ impl TryFrom<Number> for num::Number {
 #[derive(Debug)]
 pub enum ParseNumberError {
     NoValidRepresentation,
+}
+
+impl fmt::Display for ParseNumberError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoValidRepresentation => write!(f, "number has no valid representation"),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/syntax/parse.rs
+++ b/src/syntax/parse.rs
@@ -350,8 +350,8 @@ impl fmt::Display for ParseSyntaxError {
                 write!(f, "unclosed parenthesis at location `{span}`")
             }
             Self::CharTryFrom(e) => write!(f, "{e}"),
-            Self::Lex(e) => write!(f, "{e:?}"),
-            Self::ParseNumberError(e) => write!(f, "{e:?}"),
+            Self::Lex(e) => write!(f, "{e}"),
+            Self::ParseNumberError(e) => write!(f, "{e}"),
             Self::UnexpectedToken { token } => {
                 write!(
                     f,


### PR DESCRIPTION
Implements #256 

## Current progress

Testinput:

```scm
(import (rnrs))

(define (actorial n a) 
  (cond
    ; undefined binding y
    ((= n 0) (/ y 0))
    ; undefined function here
    (else (factrial (- n 1) (* n a)))))

(factorial 20 1)
```

- [x] show diagnostics

```text
# (in neovim quickfix list)
fact.scm|6 col 17-18 error| undefined variable `y`
# after fixing the above, the below appeared (correctly)
fact.scm|8 col 12-20 error| undefined variable `factrial`
```

- [x] builtin keywords, types of variables, etc on hover

## Issues

- Diagnostics stop at the first issue per document update.
- This is because the current impl reuses Syntax::from_str and DefinitionBody::parse_lib_body, both return early on the first error.
- There is no syntax recovery and I honestly dont know how to implement that
- Possible remote code execution in the language server, mitigated with `--dangerously-allow-macro-expansion-in-lsp`


## Manual testing

I tested the impl in neovim with first defining a scheme filetype:

```lua
vim.filetype.add({
    extension = {
        scm = "scheme",
        sls = "scheme",
    },
})
```

And then attaching the vim lsp client targetting scheme-rs i moved into my path:

```lua
vim.lsp.config("scheme-rs", 
  { 
    cmd = { 
        "/home/teo/programming/scheme-rs/target/debug/scheme-rs",
        "--lsp",
        "--dangerously-allow-macro-expansion-in-lsp" 
    },
    filetypes = { "scheme" },
  })
vim.lsp.enable("scheme-rs")
```