### PR TITLE
Add SRFI-88 keyword objects (#:foo syntax)

### DIFF
--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -1,0 +1,54 @@
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, Mutex};
+
+use scheme_rs_macros::{Trace, bridge};
+
+use crate::{
+    exceptions::Exception,
+    records::{RecordTypeDescriptor, SchemeCompatible, rtd},
+    strings::WideString,
+    symbols::Symbol,
+    value::Value,
+};
+
+#[derive(Debug, Clone, Trace)]
+pub struct Keyword(Symbol);
+
+static INTERNED: LazyLock<Mutex<HashMap<Symbol, Value>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+impl Keyword {
+    pub fn intern(name: &str) -> Value {
+        let sym = Symbol::intern(name);
+        let mut cache = INTERNED.lock().unwrap();
+        cache
+            .entry(sym)
+            .or_insert_with(|| Value::from_rust_type(Keyword(sym)))
+            .clone()
+    }
+}
+
+impl SchemeCompatible for Keyword {
+    fn rtd() -> Arc<RecordTypeDescriptor> {
+        rtd!(name: "keyword", sealed: true, opaque: true)
+    }
+}
+
+#[bridge(name = "keyword?", lib = "(srfi :88)")]
+pub fn keyword_pred(obj: &Value) -> Result<Vec<Value>, Exception> {
+    Ok(vec![Value::from(
+        obj.cast_to_rust_type::<Keyword>().is_some(),
+    )])
+}
+
+#[bridge(name = "keyword->string", lib = "(srfi :88)")]
+pub fn keyword_to_string(obj: &Value) -> Result<Vec<Value>, Exception> {
+    let kw = obj.try_to_rust_type::<Keyword>()?;
+    Ok(vec![Value::from(kw.0.to_str().to_string())])
+}
+
+#[bridge(name = "string->keyword", lib = "(srfi :88)")]
+pub fn string_to_keyword(s: &Value) -> Result<Vec<Value>, Exception> {
+    let s: WideString = s.clone().try_into()?;
+    Ok(vec![Keyword::intern(&s.to_string())])
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod exceptions;
 pub(crate) mod expand;
 pub mod gc;
 pub mod hashtables;
+pub mod keywords;
 pub mod lists;
 #[cfg(feature = "lsp")]
 pub mod lsp;

--- a/src/syntax/lex.rs
+++ b/src/syntax/lex.rs
@@ -176,6 +176,17 @@ impl<'a> Lexer<'a> {
                 '#' if maybe_await!(self.match_tag("`"))? => Lexeme::HashBackquote,
                 '#' if maybe_await!(self.match_tag(",@"))? => Lexeme::HashCommaAt,
                 '#' if maybe_await!(self.match_tag(","))? => Lexeme::HashComma,
+                '#' if maybe_await!(self.match_tag(":"))? => {
+                    match maybe_await!(self.identifier())? {
+                        Some(name) => Lexeme::Keyword(name),
+                        None => {
+                            return Err(LexerError::UnexpectedCharacter {
+                                chr: ':',
+                                span: self.curr_span(),
+                            });
+                        }
+                    }
+                }
                 '#' => {
                     let next_chr = maybe_await!(self.take())?;
                     if let Some(chr) = next_chr {
@@ -700,6 +711,7 @@ pub enum Lexeme {
     Number(Number),
     Character(Character),
     String(String),
+    Keyword(String),
     LParen,
     RParen,
     LBracket,

--- a/src/syntax/parse.rs
+++ b/src/syntax/parse.rs
@@ -1,4 +1,5 @@
 use crate::{
+    keywords::Keyword,
     num::Number,
     ports::{PortData, PortInfo},
     syntax::lex::ParseNumberError,
@@ -93,6 +94,9 @@ impl Parser<'_> {
                 )))
             }
             token!(Lexeme::String(s), span) => Ok(Some(Syntax::new_wrapped(Value::from(s), span))),
+            token!(Lexeme::Keyword(name), span) => {
+                Ok(Some(Syntax::new_wrapped(Keyword::intern(&name), span)))
+            }
             token!(Lexeme::Number(n), span) => Ok(Some(Syntax::new_wrapped(
                 Value::from(Number::try_from(n)?),
                 span,

--- a/tests/keywords.rs
+++ b/tests/keywords.rs
@@ -1,0 +1,3 @@
+mod common;
+
+common::run_test!(keywords);

--- a/tests/keywords.scm
+++ b/tests/keywords.scm
@@ -1,0 +1,29 @@
+(import (rnrs) (srfi :88) (test))
+
+;; keyword? predicate
+(assert-equal? (keyword? #:foo) #t)
+(assert-equal? (keyword? 'foo) #f)
+(assert-equal? (keyword? "foo") #f)
+(assert-equal? (keyword? 42) #f)
+
+;; keyword->string
+(assert-equal? (keyword->string #:hello) "hello")
+(assert-equal? (keyword->string #:foo-bar) "foo-bar")
+
+;; string->keyword
+(assert-equal? (keyword? (string->keyword "test")) #t)
+(assert-equal? (keyword->string (string->keyword "test")) "test")
+
+;; Round-trip
+(assert-equal? (string->keyword (keyword->string #:abc)) #:abc)
+
+;; Keywords are self-evaluating (no quote needed)
+(assert-equal? (let ((x #:key)) x) #:key)
+
+;; Keywords with the same name are eqv?
+(assert-equal? (eqv? #:foo #:foo) #t)
+(assert-equal? (eqv? #:foo (string->keyword "foo")) #t)
+(assert-equal? (eqv? #:foo #:bar) #f)
+
+;; Keywords are disjoint from symbols
+(assert-equal? (symbol? #:foo) #f)


### PR DESCRIPTION
Adds keyword objects as a new disjoint type to scheme-rs:
- Keyword type backed by Symbol, exposed via SchemeCompatible
- #:foo reader syntax in lexer and parser (self-evaluating)
- keyword?, keyword->string, string->keyword bridge functions
- Keywords are interned for correct eqv?/equal? semantics

Noooot super sure about how the GC works here. Is it all for "free" from `Trace`?