### PR TITLE
Bug: make append variadic per R6RS

### DIFF
--- a/src/lists.rs
+++ b/src/lists.rs
@@ -379,14 +379,22 @@ pub fn list_to_string(List { items, .. }: List) -> Result<Vec<Value>, Exception>
 }
 
 #[bridge(name = "append", lib = "(rnrs base builtins (6))")]
-pub fn append(list: &Value, to_append: &Value) -> Result<Vec<Value>, Exception> {
-    let mut vec = Vec::new();
-    list_to_vec(list, &mut vec);
-    let mut list = to_append.clone();
-    for item in vec.into_iter().rev() {
-        list = Value::from(Pair::mutable(item, list));
+pub fn append(lists: &[Value]) -> Result<Vec<Value>, Exception> {
+    if lists.is_empty() {
+        return Ok(vec![Value::null()]);
     }
-    Ok(vec![list])
+    if lists.len() == 1 {
+        return Ok(vec![lists[0].clone()]);
+    }
+    let mut result = lists.last().unwrap().clone();
+    for list in lists[..lists.len() - 1].iter().rev() {
+        let mut vec = Vec::new();
+        list_to_vec(list, &mut vec);
+        for item in vec.into_iter().rev() {
+            result = Value::from(Pair::mutable(item, result));
+        }
+    }
+    Ok(vec![result])
 }
 
 #[cps_bridge(def = "map proc list1 . listn", lib = "(rnrs base builtins (6))")]

--- a/tests/r6rs.scm
+++ b/tests/r6rs.scm
@@ -112,6 +112,11 @@
 (assert-equal? (assoc 'b alist) '(b . 2))
 (assert-equal? (assoc 'c alist) #f)
 
+(assert-equal? (append) '())
+(assert-equal? (append (list 1 2)) (list 1 2))
+(assert-equal? (append (list 1 2 3) (list 4 5 6)) (list 1 2 3 4 5 6))
+(assert-equal? (apply append '()) '())
+
 ;; 11.2.2. Syntax definitions
 
 (assert-equal? (let ()


### PR DESCRIPTION
append previously required exactly 2 arguments. R6RS specifies it as variadic: https://man.scheme.org/append.3scm

(append) returns '(), (append lst) returns lst, (append lst1 lst2 ...) concatenates. This also fixes (apply append '()).