### PR TITLE
[AI coded] cross-library macro expansion fails for transitive imports

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -54,6 +54,16 @@ pub(crate) enum TopLevelBinding {
 pub(crate) static TOP_LEVEL_BINDINGS: LazyLock<Mutex<HashMap<Binding, TopLevelBinding>>> =
     LazyLock::new(|| Mutex::new(HashMap::default()));
 
+/// Maps each binding to the library that defines it. Used to trigger lazy
+/// expansion of libraries when a macro transformer produces identifiers
+/// from libraries not directly imported by the use site.
+static BINDING_ORIGINS: LazyLock<Mutex<HashMap<Binding, TopLevelEnvironment>>> =
+    LazyLock::new(|| Mutex::new(HashMap::default()));
+
+pub(crate) fn record_binding_origin(binding: Binding, origin: TopLevelEnvironment) {
+    BINDING_ORIGINS.lock().entry(binding).or_insert(origin);
+}
+
 #[derive(Trace)]
 pub(crate) struct TopLevelEnvironmentInner {
     pub(crate) rt: Runtime,
@@ -216,6 +226,7 @@ impl TopLevelEnvironment {
                     return Err(error::name_bound_multiple_times(name));
                 }
                 bound_names.insert(name, import.binding);
+                record_binding_origin(import.binding, import.origin.clone());
                 imports.insert(import.binding, import.origin);
                 // Bind the new identifier in the global symbol table:
                 add_binding(Identifier::from_symbol(name, library_scope), import.binding);
@@ -242,6 +253,7 @@ impl TopLevelEnvironment {
                                 return Err(error::name_bound_multiple_times(name));
                             }
                             bound_names.insert(name, import.binding);
+                            record_binding_origin(import.binding, import.origin.clone());
                             imports.insert(import.binding, import.origin);
                             // Bind the new identifier in the global symbol table:
                             add_binding(
@@ -344,6 +356,7 @@ impl TopLevelEnvironment {
                 }
                 Entry::Vacant(slot) => {
                     add_binding(Identifier::from_symbol(sym, scope), import.binding);
+                    record_binding_origin(import.binding, import.origin.clone());
                     slot.insert(import.origin);
                 }
                 _ => (),
@@ -356,9 +369,10 @@ impl TopLevelEnvironment {
     pub(crate) fn maybe_expand(&self) -> Result<(), Exception> {
         let body = {
             let mut this = self.0.write();
-            if let LibraryState::Unexpanded(body) = &mut this.state {
-                // std::mem::take(body)
-                body.clone()
+            if let LibraryState::Unexpanded(body) = &this.state {
+                let body = body.clone();
+                this.state = LibraryState::Expanding;
+                body
             } else {
                 return Ok(());
             }
@@ -474,6 +488,18 @@ impl TopLevelEnvironment {
             maybe_await!(origin.lookup_keyword(binding))
         } else if let Some(TopLevelBinding::Keyword(kw)) = TOP_LEVEL_BINDINGS.lock().get(&binding) {
             Ok(Some(kw.clone()))
+        } else if let Some(origin) = { BINDING_ORIGINS.lock().get(&binding).cloned() } {
+            // The binding was not directly imported by this environment and hasn't
+            // been registered in TOP_LEVEL_BINDINGS yet. This happens when a macro
+            // transformer produces output containing identifiers from libraries that
+            // were imported by the macro's defining library but not by the use site.
+            // Use the global binding origin table to find and expand the right library.
+            maybe_await!(origin.maybe_expand())?;
+            if let Some(TopLevelBinding::Keyword(kw)) = TOP_LEVEL_BINDINGS.lock().get(&binding) {
+                Ok(Some(kw.clone()))
+            } else {
+                Ok(None)
+            }
         } else {
             Ok(None)
         }
@@ -502,6 +528,7 @@ pub(crate) enum LibraryState {
     Invalid,
     BridgesDefined,
     Unexpanded(Syntax),
+    Expanding,
     Expanded(DefinitionBody),
     Invoked,
 }
@@ -603,6 +630,7 @@ impl LexicalContour {
                 }
                 Entry::Vacant(slot) => {
                     add_binding(Identifier::from_symbol(sym, self.scope), import.binding);
+                    record_binding_origin(import.binding, import.origin);
                     slot.insert(binding_type);
                 }
                 _ => (),

--- a/tests/cross_lib_macros.rs
+++ b/tests/cross_lib_macros.rs
@@ -1,0 +1,414 @@
+mod common;
+
+use scheme_rs::env::{ImportPolicy, TopLevelEnvironment};
+use scheme_rs::runtime::Runtime;
+
+#[scheme_rs_macros::maybe_async]
+#[cfg_attr(feature = "async", ::tokio::test)]
+#[cfg_attr(not(feature = "async"), test)]
+fn cross_library_syntax_rules_basic() {
+    let rt = Runtime::new();
+
+    // Define a library that exports a macro
+    scheme_rs_macros::maybe_await!(rt.def_lib(
+        "(library (test-macro-lib)
+           (export my-macro)
+           (import (rnrs))
+           (define-syntax my-macro
+             (syntax-rules ()
+               ((_ body ...) (begin body ...)))))"
+    ))
+    .expect("Failed to define macro library");
+
+    // Use the macro in a different library
+    let env = TopLevelEnvironment::new_repl(&rt);
+    let result = scheme_rs_macros::maybe_await!(env.eval(
+        ImportPolicy::Allow,
+        "(import (rnrs) (test-macro-lib))
+         (my-macro 42)"
+    ));
+    match &result {
+        Ok(vals) => {
+            assert_eq!(vals.len(), 1, "Expected one value, got {:?}", vals);
+        }
+        Err(e) => {
+            panic!("Cross-library syntax-rules macro failed: {e:?}");
+        }
+    }
+}
+
+#[scheme_rs_macros::maybe_async]
+#[cfg_attr(feature = "async", ::tokio::test)]
+#[cfg_attr(not(feature = "async"), test)]
+fn cross_library_syntax_rules_with_expressions() {
+    let rt = Runtime::new();
+
+    scheme_rs_macros::maybe_await!(rt.def_lib(
+        "(library (test-macro-lib2)
+           (export my-when)
+           (import (rnrs))
+           (define-syntax my-when
+             (syntax-rules ()
+               ((_ test body ...)
+                (if test (begin body ...))))))"
+    ))
+    .expect("Failed to define macro library");
+
+    let env = TopLevelEnvironment::new_repl(&rt);
+    let result = scheme_rs_macros::maybe_await!(env.eval(
+        ImportPolicy::Allow,
+        "(import (rnrs) (test-macro-lib2))
+         (my-when #t 42)"
+    ));
+    match &result {
+        Ok(vals) => {
+            assert_eq!(vals.len(), 1, "Expected one value, got {:?}", vals);
+        }
+        Err(e) => {
+            panic!("Cross-library my-when macro failed: {e:?}");
+        }
+    }
+}
+
+#[scheme_rs_macros::maybe_async]
+#[cfg_attr(feature = "async", ::tokio::test)]
+#[cfg_attr(not(feature = "async"), test)]
+fn cross_library_macro_introducing_bindings() {
+    let rt = Runtime::new();
+
+    scheme_rs_macros::maybe_await!(rt.def_lib(
+        "(library (test-macro-lib3)
+           (export my-let1)
+           (import (rnrs))
+           (define-syntax my-let1
+             (syntax-rules ()
+               ((_ var val body ...)
+                (let ((var val)) body ...)))))"
+    ))
+    .expect("Failed to define macro library");
+
+    let env = TopLevelEnvironment::new_repl(&rt);
+    let result = scheme_rs_macros::maybe_await!(env.eval(
+        ImportPolicy::Allow,
+        "(import (rnrs) (test-macro-lib3))
+         (my-let1 x 10 (+ x 1))"
+    ));
+    match &result {
+        Ok(vals) => {
+            assert_eq!(vals.len(), 1, "Expected one value, got {:?}", vals);
+        }
+        Err(e) => {
+            panic!("Cross-library my-let1 macro failed: {e:?}");
+        }
+    }
+}
+
+#[scheme_rs_macros::maybe_async]
+#[cfg_attr(feature = "async", ::tokio::test)]
+#[cfg_attr(not(feature = "async"), test)]
+fn cross_library_macro_referencing_definition_env() {
+    let rt = Runtime::new();
+
+    // This macro references `list` from its own definition environment (rnrs).
+    // In a cross-library expansion, `list` must resolve through the macro's
+    // definition scope, not the use site scope.
+    scheme_rs_macros::maybe_await!(rt.def_lib(
+        "(library (test-macro-lib4)
+           (export wrap-in-list)
+           (import (rnrs))
+           (define-syntax wrap-in-list
+             (syntax-rules ()
+               ((_ x) (list x)))))"
+    ))
+    .expect("Failed to define macro library");
+
+    let env = TopLevelEnvironment::new_repl(&rt);
+    let result = scheme_rs_macros::maybe_await!(env.eval(
+        ImportPolicy::Allow,
+        "(import (rnrs) (test-macro-lib4))
+         (wrap-in-list 42)"
+    ));
+    match &result {
+        Ok(vals) => {
+            assert_eq!(vals.len(), 1, "Expected one value, got {:?}", vals);
+        }
+        Err(e) => {
+            panic!("Cross-library wrap-in-list macro failed: {e:?}");
+        }
+    }
+}
+
+#[scheme_rs_macros::maybe_async]
+#[cfg_attr(feature = "async", ::tokio::test)]
+#[cfg_attr(not(feature = "async"), test)]
+fn cross_library_macro_hygiene_no_capture() {
+    let rt = Runtime::new();
+
+    // The macro uses `list` from its definition env. The use site
+    // shadows `list` with something else. The macro should still use
+    // the original `list` from (rnrs).
+    scheme_rs_macros::maybe_await!(rt.def_lib(
+        "(library (test-macro-lib5)
+           (export wrap-in-list)
+           (import (rnrs))
+           (define-syntax wrap-in-list
+             (syntax-rules ()
+               ((_ x) (list x)))))"
+    ))
+    .expect("Failed to define macro library");
+
+    let env = TopLevelEnvironment::new_repl(&rt);
+    let result = scheme_rs_macros::maybe_await!(env.eval(
+        ImportPolicy::Allow,
+        "(import (rnrs) (test-macro-lib5))
+         (let ((list (lambda (x) 'shadowed)))
+           (wrap-in-list 42))"
+    ));
+    match &result {
+        Ok(vals) => {
+            assert_eq!(vals.len(), 1, "Expected one value, got {:?}", vals);
+            // If hygiene works, this should be (42), not 'shadowed
+        }
+        Err(e) => {
+            panic!("Cross-library hygiene test failed: {e:?}");
+        }
+    }
+}
+
+#[scheme_rs_macros::maybe_async]
+#[cfg_attr(feature = "async", ::tokio::test)]
+#[cfg_attr(not(feature = "async"), test)]
+fn cross_library_macro_using_helper_from_definition_lib() {
+    let rt = Runtime::new();
+
+    // Macro references a helper function defined in the same library.
+    // When expanded at use site, the helper must still be accessible.
+    scheme_rs_macros::maybe_await!(rt.def_lib(
+        "(library (test-macro-lib6)
+           (export my-double)
+           (import (rnrs))
+           (define (helper x) (* x 2))
+           (define-syntax my-double
+             (syntax-rules ()
+               ((_ x) (helper x)))))"
+    ))
+    .expect("Failed to define macro library");
+
+    let env = TopLevelEnvironment::new_repl(&rt);
+    let result = scheme_rs_macros::maybe_await!(env.eval(
+        ImportPolicy::Allow,
+        "(import (rnrs) (test-macro-lib6))
+         (my-double 21)"
+    ));
+    match &result {
+        Ok(vals) => {
+            assert_eq!(vals.len(), 1, "Expected one value, got {:?}", vals);
+        }
+        Err(e) => {
+            panic!("Cross-library macro with helper function failed: {e:?}");
+        }
+    }
+}
+
+#[scheme_rs_macros::maybe_async]
+#[cfg_attr(feature = "async", ::tokio::test)]
+#[cfg_attr(not(feature = "async"), test)]
+fn cross_library_nested_macro_expansion() {
+    let rt = Runtime::new();
+
+    // Library A exports macro-a, Library B imports A and exports macro-b
+    // that uses macro-a. Then a program uses macro-b.
+    scheme_rs_macros::maybe_await!(rt.def_lib(
+        "(library (test-nested-a)
+           (export macro-a)
+           (import (rnrs))
+           (define-syntax macro-a
+             (syntax-rules ()
+               ((_ x) (+ x 1)))))"
+    ))
+    .expect("Failed to define library A");
+
+    scheme_rs_macros::maybe_await!(rt.def_lib(
+        "(library (test-nested-b)
+           (export macro-b)
+           (import (rnrs) (test-nested-a))
+           (define-syntax macro-b
+             (syntax-rules ()
+               ((_ x) (macro-a (* x 2))))))"
+    ))
+    .expect("Failed to define library B");
+
+    let env = TopLevelEnvironment::new_repl(&rt);
+    let result = scheme_rs_macros::maybe_await!(env.eval(
+        ImportPolicy::Allow,
+        "(import (rnrs) (test-nested-b))
+         (macro-b 5)"
+    ));
+    match &result {
+        Ok(vals) => {
+            assert_eq!(vals.len(), 1, "Expected one value, got {:?}", vals);
+            // macro-b expands to (macro-a (* 5 2)) -> (+ (* 5 2) 1) -> 11
+        }
+        Err(e) => {
+            panic!("Nested cross-library macro expansion failed: {e:?}");
+        }
+    }
+}
+
+#[scheme_rs_macros::maybe_async]
+#[cfg_attr(feature = "async", ::tokio::test)]
+#[cfg_attr(not(feature = "async"), test)]
+fn cross_library_nested_macro_via_syntax_case() {
+    let rt = Runtime::new();
+
+    // Same as above but using syntax-case directly, to isolate whether
+    // the problem is in syntax-rules or in the core expansion mechanism.
+    scheme_rs_macros::maybe_await!(rt.def_lib(
+        "(library (test-nested-sc-a)
+           (export macro-a)
+           (import (rnrs))
+           (define-syntax macro-a
+             (lambda (x)
+               (syntax-case x ()
+                 ((_ y) #'(+ y 1))))))"
+    ))
+    .expect("Failed to define library A");
+
+    scheme_rs_macros::maybe_await!(rt.def_lib(
+        "(library (test-nested-sc-b)
+           (export macro-b)
+           (import (rnrs) (test-nested-sc-a))
+           (define-syntax macro-b
+             (lambda (x)
+               (syntax-case x ()
+                 ((_ y) #'(macro-a (* y 2)))))))"
+    ))
+    .expect("Failed to define library B");
+
+    let env = TopLevelEnvironment::new_repl(&rt);
+    let result = scheme_rs_macros::maybe_await!(env.eval(
+        ImportPolicy::Allow,
+        "(import (rnrs) (test-nested-sc-b))
+         (macro-b 5)"
+    ));
+    match &result {
+        Ok(vals) => {
+            assert_eq!(vals.len(), 1, "Expected one value, got {:?}", vals);
+        }
+        Err(e) => {
+            panic!("Nested cross-library syntax-case macro expansion failed: {e:?}");
+        }
+    }
+}
+
+#[scheme_rs_macros::maybe_async]
+#[cfg_attr(feature = "async", ::tokio::test)]
+#[cfg_attr(not(feature = "async"), test)]
+fn cross_library_macro_b_uses_a_directly() {
+    let rt = Runtime::new();
+
+    // Verify that macro-a works when directly invoked cross-library (not nested)
+    scheme_rs_macros::maybe_await!(rt.def_lib(
+        "(library (test-direct-a)
+           (export macro-a)
+           (import (rnrs))
+           (define-syntax macro-a
+             (syntax-rules ()
+               ((_ x) (+ x 1)))))"
+    ))
+    .expect("Failed to define library A");
+
+    let env = TopLevelEnvironment::new_repl(&rt);
+    let result = scheme_rs_macros::maybe_await!(env.eval(
+        ImportPolicy::Allow,
+        "(import (rnrs) (test-direct-a))
+         (macro-a 5)"
+    ));
+    match &result {
+        Ok(vals) => {
+            assert_eq!(vals.len(), 1, "Expected one value, got {:?}", vals);
+        }
+        Err(e) => {
+            panic!("Direct cross-library macro-a failed: {e:?}");
+        }
+    }
+}
+
+#[scheme_rs_macros::maybe_async]
+#[cfg_attr(feature = "async", ::tokio::test)]
+#[cfg_attr(not(feature = "async"), test)]
+fn cross_library_re_export_macro() {
+    let rt = Runtime::new();
+
+    // Library A defines and exports a macro, Library B re-exports it.
+    // Using the macro from library B should work.
+    scheme_rs_macros::maybe_await!(rt.def_lib(
+        "(library (test-reexport-a)
+           (export my-add1)
+           (import (rnrs))
+           (define-syntax my-add1
+             (syntax-rules ()
+               ((_ x) (+ x 1)))))"
+    ))
+    .expect("Failed to define library A");
+
+    scheme_rs_macros::maybe_await!(rt.def_lib(
+        "(library (test-reexport-b)
+           (export (import (test-reexport-a)))
+           (import (rnrs) (test-reexport-a)))"
+    ))
+    .expect("Failed to define library B");
+
+    let env = TopLevelEnvironment::new_repl(&rt);
+    let result = scheme_rs_macros::maybe_await!(env.eval(
+        ImportPolicy::Allow,
+        "(import (rnrs) (test-reexport-b))
+         (my-add1 5)"
+    ));
+    match &result {
+        Ok(vals) => {
+            assert_eq!(vals.len(), 1, "Expected one value, got {:?}", vals);
+        }
+        Err(e) => {
+            panic!("Re-exported cross-library macro failed: {e:?}");
+        }
+    }
+}
+
+#[scheme_rs_macros::maybe_async]
+#[cfg_attr(feature = "async", ::tokio::test)]
+#[cfg_attr(not(feature = "async"), test)]
+fn cross_library_syntax_case_macro() {
+    let rt = Runtime::new();
+
+    scheme_rs_macros::maybe_await!(rt.def_lib(
+        "(library (test-sc-lib)
+           (export my-swap!)
+           (import (rnrs))
+           (define-syntax my-swap!
+             (lambda (x)
+               (syntax-case x ()
+                 ((_ a b)
+                  #'(let ((tmp a))
+                      (set! a b)
+                      (set! b tmp)))))))"
+    ))
+    .expect("Failed to define syntax-case macro library");
+
+    let env = TopLevelEnvironment::new_repl(&rt);
+    let result = scheme_rs_macros::maybe_await!(env.eval(
+        ImportPolicy::Allow,
+        "(import (rnrs) (test-sc-lib))
+         (let ((x 1) (y 2))
+           (my-swap! x y)
+           (list x y))"
+    ));
+    match &result {
+        Ok(vals) => {
+            assert_eq!(vals.len(), 1, "Expected one value, got {:?}", vals);
+        }
+        Err(e) => {
+            panic!("Cross-library syntax-case macro failed: {e:?}");
+        }
+    }
+}


### PR DESCRIPTION
From Claude:

When macro B (library B) expands to code using macro A (library A), and the use site only imports B, the expander couldn't find A's bindings because A was never directly imported or expanded.

Fix: add a global BINDING_ORIGINS table that records which library each binding originates from. When lookup_keyword_inner can't find a binding in direct imports or TOP_LEVEL_BINDINGS, it checks BINDING_ORIGINS to find and lazily expand the originating library.

Added LibraryState::Expanding reentrancy guard to prevent infinite recursion during lazy expansion.

I can't actually explain this code yet, so I don't know if this is the right approach, but feel free to have a look if it makes sense. It _did_ seem to fix the issue,