### PR TITLE
Support custom ellipsis in syntax-rules

### DIFF
--- a/scheme/rnrs/syntax-rules.sls
+++ b/scheme/rnrs/syntax-rules.sls
@@ -8,6 +8,12 @@
   (define-syntax syntax-rules
     (lambda (x)
       (syntax-case x ()
+        ((_ ellipsis (i ...) ((keyword . pattern) template) ...)
+         (identifier? (syntax ellipsis))
+         (syntax (lambda (x)
+                   (syntax-case x ellipsis (i ...)
+                     ((dummy . pattern) (syntax template))
+                     ...))))
         ((_ (i ...) ((keyword . pattern) template) ...)
          (syntax (lambda (x)
                    (syntax-case x (i ...)

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -985,6 +985,7 @@ impl From<bool> for ImportPolicy {
 pub struct ParseContext {
     runtime: Runtime,
     import_policy: ImportPolicy,
+    ellipsis: Symbol,
 }
 
 impl ParseContext {
@@ -992,6 +993,15 @@ impl ParseContext {
         Self {
             runtime: runtime.clone(),
             import_policy: import_policy.into(),
+            ellipsis: Symbol::intern("..."),
+        }
+    }
+
+    pub(crate) fn with_ellipsis(&self, ellipsis: Symbol) -> Self {
+        Self {
+            runtime: self.runtime.clone(),
+            import_policy: self.import_policy.clone(),
+            ellipsis,
         }
     }
 }
@@ -1257,9 +1267,8 @@ impl Expression {
                             Primitive::Or => maybe_await!(Or::parse(ctxt, tail, env, mutable_vars))
                                 .map(Expression::Or),
                             Primitive::Quote => Quote::parse(tail, &form).map(Expression::Quote),
-                            Primitive::Syntax => {
-                                SyntaxQuote::parse(tail, env, &form).map(Expression::SyntaxQuote)
-                            }
+                            Primitive::Syntax => SyntaxQuote::parse(ctxt, tail, env, &form)
+                                .map(Expression::SyntaxQuote),
                             Primitive::SyntaxCase => maybe_await!(SyntaxCase::parse(
                                 ctxt,
                                 tail,
@@ -1363,12 +1372,17 @@ pub struct SyntaxQuote {
 }
 
 impl SyntaxQuote {
-    fn parse(exprs: &[Syntax], env: &Environment, form: &Syntax) -> Result<Self, Exception> {
+    fn parse(
+        ctxt: &ParseContext,
+        exprs: &[Syntax],
+        env: &Environment,
+        form: &Syntax,
+    ) -> Result<Self, Exception> {
         match exprs {
             [] => Err(error::expected_more_arguments(form)),
             [expr] => {
                 let mut expansions = HashMap::default();
-                let template = Template::compile(expr, env, &mut expansions)?;
+                let template = Template::compile(expr, env, &mut expansions, ctxt.ellipsis)?;
                 Ok(SyntaxQuote {
                     template,
                     expansions,
@@ -1917,6 +1931,7 @@ impl Definitions {
         let ctxt = ParseContext {
             runtime: runtime.clone(),
             import_policy: ImportPolicy::Allow,
+            ellipsis: Symbol::intern("..."),
         };
         // No explanation needed
         match form.as_list() {
@@ -2527,7 +2542,35 @@ impl SyntaxCase {
         form: &Syntax,
         mutable_vars: &mut HashSet<Local>,
     ) -> Result<Self, Exception> {
-        let (arg, keywords, mut rules) = match exprs {
+        let (arg, keywords, mut rules, ellipsis) = match exprs {
+            [
+                arg,
+                Syntax::Identifier {
+                    ident: custom_ellipsis,
+                    ..
+                },
+                Syntax::List { list, .. },
+                rules @ ..,
+            ] => {
+                let mut keywords = HashSet::default();
+                for keyword in &list[..list.len() - 1] {
+                    if let Syntax::Identifier { ident, .. } = keyword {
+                        keywords.insert(ident);
+                    } else {
+                        return Err(error::expected_identifier(form, Some(keyword)));
+                    }
+                }
+                (arg, keywords, rules, custom_ellipsis.sym)
+            }
+            [
+                arg,
+                Syntax::Identifier {
+                    ident: custom_ellipsis,
+                    ..
+                },
+                empty,
+                rules @ ..,
+            ] if empty.is_null() => (arg, HashSet::default(), rules, custom_ellipsis.sym),
             [arg, Syntax::List { list, .. }, rules @ ..] => {
                 let mut keywords = HashSet::default();
                 // TODO: ensure keywords_list is proper
@@ -2538,9 +2581,11 @@ impl SyntaxCase {
                         return Err(error::expected_identifier(form, Some(keyword)));
                     }
                 }
-                (arg, keywords, rules)
+                (arg, keywords, rules, Symbol::intern("..."))
             }
-            [arg, empty, rules @ ..] if empty.is_null() => (arg, HashSet::default(), rules),
+            [arg, empty, rules @ ..] if empty.is_null() => {
+                (arg, HashSet::default(), rules, Symbol::intern("..."))
+            }
             _ => return Err(error::bad_form(form, None)),
         };
         let mut syntax_rules = Vec::new();
@@ -2556,7 +2601,8 @@ impl SyntaxCase {
                             None,
                             output_expression,
                             env,
-                            mutable_vars
+                            mutable_vars,
+                            ellipsis,
                         ))?);
                         rules = tail;
                     }
@@ -2569,6 +2615,7 @@ impl SyntaxCase {
                             output_expression,
                             env,
                             mutable_vars,
+                            ellipsis,
                         ))?);
                         rules = tail;
                     }

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -60,6 +60,7 @@ pub struct SyntaxRule {
 
 impl SyntaxRule {
     #[maybe_async]
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn compile<'a>(
         ctxt: &ParseContext,
         keywords: &HashSet<&'a Identifier>,
@@ -68,17 +69,26 @@ impl SyntaxRule {
         output_expression: &'a Syntax,
         env: &Environment,
         mutable_vars: &mut HashSet<Local>,
+        ellipsis: Symbol,
     ) -> Result<Self, Exception> {
         let mut variables = HashMap::default();
         let pattern_scope = Scope::new();
-        let pattern = Pattern::compile(pattern, keywords, 0, pattern_scope, &mut variables)?;
+        let pattern = Pattern::compile(
+            pattern,
+            keywords,
+            0,
+            pattern_scope,
+            &mut variables,
+            ellipsis,
+        )?;
         let binds = Local::gensym();
         let env = env.new_syntax_case_contour(pattern_scope, binds, variables);
+        let ctxt = ctxt.with_ellipsis(ellipsis);
         let fender = if let Some(fender) = fender {
             let mut fender = fender.clone();
             fender.add_scope(pattern_scope);
             Some(maybe_await!(Expression::parse(
-                ctxt,
+                &ctxt,
                 fender,
                 &env,
                 mutable_vars
@@ -89,7 +99,7 @@ impl SyntaxRule {
         let mut output_expression = output_expression.clone();
         output_expression.add_scope(pattern_scope);
         let output_expression = maybe_await!(Expression::parse(
-            ctxt,
+            &ctxt,
             output_expression,
             &env,
             mutable_vars
@@ -121,6 +131,7 @@ impl Pattern {
         curr_nesting_level: usize,
         scope: Scope,
         variables: &mut HashMap<Binding, usize>,
+        ellipsis: Symbol,
     ) -> Result<Self, Exception> {
         Ok(match expr {
             // Allow for underscores as keywords
@@ -142,6 +153,7 @@ impl Pattern {
                 curr_nesting_level,
                 scope,
                 variables,
+                ellipsis,
             )?),
             Syntax::Vector { vector, .. } => Self::Vector(Self::compile_slice(
                 vector,
@@ -149,6 +161,7 @@ impl Pattern {
                 curr_nesting_level,
                 scope,
                 variables,
+                ellipsis,
             )?),
             Syntax::Wrapped { value, .. } => Self::Literal(value.clone()),
         })
@@ -160,6 +173,7 @@ impl Pattern {
         curr_nesting_level: usize,
         scope: Scope,
         variables: &mut HashMap<Binding, usize>,
+        ellipsis: Symbol,
     ) -> Result<Vec<Self>, Exception> {
         let mut output = Vec::new();
         let mut seen_ellipsis = false;
@@ -169,10 +183,11 @@ impl Pattern {
                 [
                     pattern,
                     Syntax::Identifier {
-                        ident: ellipsis, ..
+                        ident: ellipsis_ident,
+                        ..
                     },
                     tail @ ..,
-                ] if ellipsis.sym == "..." => {
+                ] if ellipsis_ident.sym == ellipsis => {
                     if seen_ellipsis {
                         return Err(error::multiple_ellipsis_at_same_level(pattern));
                     }
@@ -183,6 +198,7 @@ impl Pattern {
                         curr_nesting_level + 1,
                         scope,
                         variables,
+                        ellipsis,
                     )?)));
                     expr = tail;
                 }
@@ -193,6 +209,7 @@ impl Pattern {
                         curr_nesting_level,
                         scope,
                         variables,
+                        ellipsis,
                     )?);
                     expr = tail;
                 }
@@ -427,9 +444,10 @@ impl Template {
         expr: &Syntax,
         env: &Environment,
         expansions: &mut HashMap<Binding, Local>,
+        ellipsis: Symbol,
     ) -> Result<Self, Exception> {
-        check_ellipsis(expr, env)?;
-        Self::compile_inner(expr, env, expansions)
+        check_ellipsis(expr, env, ellipsis)?;
+        Self::compile_inner(expr, env, expansions, ellipsis)
     }
 
     fn is_wrapped(&self) -> bool {
@@ -472,31 +490,33 @@ impl Template {
         expr: &Syntax,
         env: &Environment,
         expansions: &mut HashMap<Binding, Local>,
+        ellipsis: Symbol,
     ) -> Result<Self, Exception> {
         match expr {
             Syntax::List { list, span, .. } => {
                 if let [
                     Syntax::Identifier {
-                        ident: ellipsis, ..
+                        ident: ellipsis_ident,
+                        ..
                     },
                     template,
                     _,
                 ] = list.as_slice()
-                    && ellipsis.sym == "..."
+                    && ellipsis_ident.sym == ellipsis
                 {
                     Self::compile_escaped(template, env, expansions)
                 } else {
                     Ok(Self::new_list(
-                        Self::compile_slice(list, env, expansions)?,
+                        Self::compile_slice(list, env, expansions, ellipsis)?,
                         span.clone(),
                     ))
                 }
             }
             Syntax::Vector { vector, span, .. } => Ok(Self::new_vector(
-                Self::compile_slice(vector, env, expansions)?,
+                Self::compile_slice(vector, env, expansions, ellipsis)?,
                 span.clone(),
             )),
-            Syntax::Identifier { ident, .. } if ident.sym == "..." => {
+            Syntax::Identifier { ident, .. } if ident.sym == ellipsis => {
                 Err(Exception::syntax(expr.clone(), None))
             }
             Syntax::Identifier { ident, span, .. } => {
@@ -551,6 +571,7 @@ impl Template {
         mut expr: &[Syntax],
         env: &Environment,
         expansions: &mut HashMap<Binding, Local>,
+        ellipsis: Symbol,
     ) -> Result<Vec<Self>, Exception> {
         let mut output = Vec::new();
         loop {
@@ -559,14 +580,16 @@ impl Template {
                 [
                     template,
                     Syntax::Identifier {
-                        ident: ellipsis, ..
+                        ident: ellipsis_ident,
+                        ..
                     },
                     tail @ ..,
-                ] if ellipsis.sym == "..." => {
-                    let mut compiled =
-                        Self::Ellipsis(Box::new(Self::compile_inner(template, env, expansions)?));
+                ] if ellipsis_ident.sym == ellipsis => {
+                    let mut compiled = Self::Ellipsis(Box::new(Self::compile_inner(
+                        template, env, expansions, ellipsis,
+                    )?));
                     let mut tail = tail;
-                    while matches!(tail.first(), Some(Syntax::Identifier { ident, ..}) if ident.sym == "...")
+                    while matches!(tail.first(), Some(Syntax::Identifier { ident, ..}) if ident.sym == ellipsis)
                     {
                         compiled = Self::Ellipsis(Box::new(compiled));
                         tail = &tail[1..];
@@ -575,7 +598,7 @@ impl Template {
                     expr = tail;
                 }
                 [head, tail @ ..] => {
-                    output.push(Self::compile_inner(head, env, expansions)?);
+                    output.push(Self::compile_inner(head, env, expansions, ellipsis)?);
                     expr = tail;
                 }
             }
@@ -684,24 +707,25 @@ fn vec_to_improper_list(mut expanded: Vec<Value>) -> Value {
     output
 }
 
-fn check_ellipsis(expr: &Syntax, env: &Environment) -> Result<(), Exception> {
+fn check_ellipsis(expr: &Syntax, env: &Environment, ellipsis: Symbol) -> Result<(), Exception> {
     let binds = match expr {
         Syntax::List { list, .. } => {
             if let [
                 Syntax::Identifier {
-                    ident: ellipsis, ..
+                    ident: ellipsis_ident,
+                    ..
                 },
                 template,
                 _,
             ] = list.as_slice()
-                && ellipsis.sym == "..."
+                && ellipsis_ident.sym == ellipsis
             {
                 check_escaped_template(template, env)
             } else {
-                check_subtemplate(list, env)?
+                check_subtemplate(list, env, ellipsis)?
             }
         }
-        Syntax::Vector { vector, .. } => check_subtemplate(vector, env)?,
+        Syntax::Vector { vector, .. } => check_subtemplate(vector, env, ellipsis)?,
         Syntax::Identifier { ident, .. } => {
             if let Some(binding) = ident.resolve()
                 && let Some((_, depth)) = env.lookup_pattern_variable(binding)
@@ -726,24 +750,29 @@ fn check_ellipsis(expr: &Syntax, env: &Environment) -> Result<(), Exception> {
     Ok(())
 }
 
-fn check_template(expr: &Syntax, env: &Environment) -> Result<Vec<(Symbol, isize)>, Exception> {
+fn check_template(
+    expr: &Syntax,
+    env: &Environment,
+    ellipsis: Symbol,
+) -> Result<Vec<(Symbol, isize)>, Exception> {
     match expr {
         Syntax::List { list, .. } => {
             if let [
                 Syntax::Identifier {
-                    ident: ellipsis, ..
+                    ident: ellipsis_ident,
+                    ..
                 },
                 template,
                 _,
             ] = list.as_slice()
-                && ellipsis.sym == "..."
+                && ellipsis_ident.sym == ellipsis
             {
                 Ok(check_escaped_template(template, env))
             } else {
-                check_subtemplate(list, env)
+                check_subtemplate(list, env, ellipsis)
             }
         }
-        Syntax::Vector { vector, .. } => check_subtemplate(vector, env),
+        Syntax::Vector { vector, .. } => check_subtemplate(vector, env, ellipsis),
         Syntax::Identifier { ident, .. } => {
             // TODO: Probably should cache these resolves at some point...
             if let Some(binding) = ident.resolve()
@@ -761,25 +790,26 @@ fn check_template(expr: &Syntax, env: &Environment) -> Result<Vec<(Symbol, isize
 fn check_subtemplate(
     expr: &[Syntax],
     env: &Environment,
+    ellipsis: Symbol,
 ) -> Result<Vec<(Symbol, isize)>, Exception> {
     match expr {
         [] => Ok(Vec::new()),
         [template, tail @ ..] => {
             let mut num_ellipsis = 0;
             let mut tail = tail;
-            while matches!(tail.first(), Some(Syntax::Identifier { ident, ..}) if ident.sym == "...")
+            while matches!(tail.first(), Some(Syntax::Identifier { ident, ..}) if ident.sym == ellipsis)
             {
                 num_ellipsis += 1;
                 tail = &tail[1..];
             }
-            let mut patterns = check_template(template, env)?;
+            let mut patterns = check_template(template, env, ellipsis)?;
             if patterns.is_empty() && num_ellipsis > 0 {
                 return Err(error::no_pattern_variables_in_template(template));
             }
             for pattern in &mut patterns {
                 pattern.1 -= num_ellipsis;
             }
-            patterns.extend(check_subtemplate(tail, env)?);
+            patterns.extend(check_subtemplate(tail, env, ellipsis)?);
             Ok(patterns)
         }
     }

--- a/tests/r6rs.scm
+++ b/tests/r6rs.scm
@@ -533,3 +533,25 @@
   (assert-equal? (list x y) '(2 1)))
 
 (assert-equal? (let ((tmp 5)) (set! tmp (+ tmp 1)) tmp) 6)
+
+;; Custom ellipsis in syntax-rules
+(let ()
+  (define-syntax my-list
+    (syntax-rules ::: ()
+      ((_ x :::) (list x :::))))
+  (assert-equal? (my-list 1 2 3) '(1 2 3)))
+
+;; Custom ellipsis with recursive macro
+(let ()
+  (define-syntax my-or
+    (syntax-rules ::: ()
+      ((_ e) e)
+      ((_ e1 e2 :::) (let ((t e1)) (if t t (my-or e2 :::))))))
+  (assert-equal? (my-or #f #f 42) 42))
+
+;; Custom ellipsis with nested patterns
+(let ()
+  (define-syntax my-map
+    (syntax-rules ::: ()
+      ((_ f (x :::)) (list (f x) :::))))
+  (assert-equal? (my-map (lambda (x) (+ x 1)) (1 2 3)) '(2 3 4)))


### PR DESCRIPTION
Adds R6RS custom ellipsis support for `syntax-rules`:

```scheme
(syntax-rules ::: ()
  ((_ x :::) (list x :::)))
```

Threads an `ellipsis` symbol through pattern and template compilation instead of hardcoding `"..."`.

With this we can take in some ready-made portable SRFIs like chain/nest