### PR TITLE
Add SRFI-202 and-let*

### DIFF
--- a/scheme/srfi/:2.sls
+++ b/scheme/srfi/:2.sls
@@ -1,0 +1,67 @@
+;;; SRFI-2/202: and-let*
+;;; Implementation based on SRFI-202 (Pattern-matching variant of and-let*)
+;;; which is a strict superset of SRFI-2.
+;;;
+;;; SPDX-License-Identifier: MIT
+
+(library (srfi :2)
+  (export and-let*)
+  (import (rnrs)
+          (match))
+
+(define-syntax and-let*
+  (lambda (stx)
+    (syntax-case stx (values)
+      ((_)
+       #'#t)
+      ((_ ())
+       #'#t)
+      ((_ () body ...)
+       #'(let () body ...))
+      ((_ ((name binding) rest ...) body ...)
+       (identifier? #'name)
+       #'(let ((name binding))
+           (and name
+                (and-let* (rest ...)
+                  body ...))))
+      ((_ (((values . structure) expression) rest ...)
+          body ...)
+       #'(call-with-values (lambda () expression)
+           (lambda args
+             (match args
+               (structure
+                (and-let* (rest ...)
+                  body ...))
+               (_ #f)))))
+      ((_ ((value expression) rest ...) body ...)
+       #'(match expression
+           (value
+            (and-let* (rest ...)
+              body ...))
+           (_ #f)))
+      ((_ ((condition) rest ...)
+          body ...)
+       #'(and condition
+              (and-let* (rest ...)
+                body ...)))
+      ((_ ((value * ... expression) rest ...) body ...)
+       (identifier? #'value)
+       #'(call-with-values (lambda () expression)
+           (lambda args
+             (match args
+               ((value * ... . _)
+                (and value
+                     (and-let* (rest ...)
+                       body ...)))
+               (_ #f)))))
+      ((_ ((value ... expression) rest ...) body ...)
+       #'(call-with-values (lambda () expression)
+           (lambda args
+             (match args
+               ((value ... . _)
+                (and-let* (rest ...)
+                  body ...))
+               (_ #f)))))
+      )))
+
+)

--- a/tests/r6rs.scm
+++ b/tests/r6rs.scm
@@ -588,3 +588,17 @@
     ((_ (a ...) ...) '(#(a ...) ...))))
 
 (assert-equal? (vector-ellipsis-test (1 2) () (3)) '(#(1 2) #() #(3)))
+
+;; SRFI-2/202: and-let*
+(import (srfi :2))
+
+;; Basic SRFI-2 behavior
+(assert-equal? (and-let* ((x 1) (y 2)) (+ x y)) 3)
+(assert-equal? (and-let* ((x #f) (y 2)) (+ x y)) #f)
+(assert-equal? (and-let* ((x (memv 3 '(1 2 3 4)))) (car x)) 3)
+(assert-equal? (and-let* () 5) 5)
+(assert-equal? (and-let* ()) #t)
+
+;; SRFI-202 guard clause (bare expression, no binding)
+(assert-equal? (and-let* (((> 3 2))) 'yes) 'yes)
+(assert-equal? (and-let* (((> 2 3))) 'yes) #f)


### PR DESCRIPTION
## Summary
- Adds `(srfi :2)` exporting `and-let*`
- Uses the SRFI-202 `syntax-case` implementation (strict superset of SRFI-2) with pattern matching and multiple-values support via `(match)`
- Needed by SRFI-197's `chain-and` macro

Note: the SRFI-202 pattern matching extensions (destructuring clauses, `values` clauses) are available but require further `match` integration work. The core SRFI-2 functionality works fully.

## Test plan
- Binding and body: `(and-let* ((x 1) (y 2)) (+ x y))` → `3`
- Short-circuit on `#f`: `(and-let* ((x #f) (y 2)) (+ x y))` → `#f`
- Single clause with body: `(and-let* ((x (memv 3 '(1 2 3 4)))) (car x))` → `3`
- Empty clauses with body: `(and-let* () 5)` → `5`
- Empty clauses no body: `(and-let* ())` → `#t`
- Guard clause (bare expression): `(and-let* (((> 3 2))) 'yes)` → `yes`
- Guard clause fails: `(and-let* (((> 2 3))) 'yes)` → `#f`
- `cargo test` passes