### PR TITLE
Fix cells being transferred through to let bindings

### DIFF
--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -222,6 +222,11 @@ impl<'m, 'f, 'c, 'd> CompilationUnit<'m, 'f, 'c, 'd> {
             Cps::PrimOp(PrimOp::AllocCell, _, into, cexpr) => {
                 self.alloc_cell_codegen(into, *cexpr, deferred);
             }
+            Cps::PrimOp(PrimOp::Read, args, result, cexpr) => {
+                let value = self.value_codegen(&args[0]);
+                self.rebinds.rebind(result, IrValue::Value(value));
+                self.cps_codegen(*cexpr, deferred);
+            }
             Cps::PrimOp(PrimOp::Matches, args, bind_to, cexpr) => {
                 let [pattern, expr] = args.as_slice() else {
                     unreachable!()

--- a/src/cps/compile.rs
+++ b/src/cps/compile.rs
@@ -91,13 +91,19 @@ fn compile_let(
         let k1 = Local::gensym();
         let k2 = Local::gensym();
         let k3 = Local::gensym();
+        let raw_val = Local::gensym();
         Cps::Lambda {
             args: LambdaArgs::new(vec![k2], false, None),
             body: Box::new(Cps::Lambda {
-                args: LambdaArgs::new(vec![*curr_bind], false, None),
-                body: Box::new(compile_let(tail, body, &mut move |result| {
-                    Cps::App(result, vec![Value::from(k2)])
-                })),
+                args: LambdaArgs::new(vec![raw_val], false, None),
+                body: Box::new(Cps::PrimOp(
+                    PrimOp::Read,
+                    vec![Value::from(raw_val)],
+                    *curr_bind,
+                    Box::new(compile_let(tail, body, &mut move |result| {
+                        Cps::App(result, vec![Value::from(k2)])
+                    })),
+                )),
                 val: k3,
                 cexp: Box::new(
                     curr_expr.compile(&mut move |result| Cps::App(result, vec![Value::from(k3)])),
@@ -895,6 +901,10 @@ impl Cps {
                 local,
                 Box::new(cexpr.vals_to_cells(mutable_vars)),
             ),
+            Self::PrimOp(PrimOp::Read, vals, mut local, cexpr) if mutable_vars.contains(&local) => {
+                let body = val_to_cell(&mut local, Box::new(cexpr.vals_to_cells(mutable_vars)));
+                Self::PrimOp(PrimOp::Read, vals, local, body)
+            }
             Self::PrimOp(op, vals, local, cexpr) => {
                 let cexpr = Box::new(cexpr.vals_to_cells(mutable_vars));
                 Self::PrimOp(op, vals, local, cexpr)

--- a/src/cps/mod.rs
+++ b/src/cps/mod.rs
@@ -81,11 +81,12 @@ impl fmt::Debug for Value {
 
 #[derive(Copy, Clone, Debug, Trace)]
 pub enum PrimOp {
+    // Cell operations:
     /// Set cell value:
     Set,
-
-    // Cell operations:
-    /// Allocate a cell, returning a Gc<Value>:
+    /// Read a cell value (or return the value):
+    Read,
+    /// Allocate a cell:
     AllocCell,
 
     // List/pair operators:
@@ -130,6 +131,7 @@ impl PrimOp {
     pub(crate) fn info(&self) -> PrimOpInfo {
         match self {
             Self::Set => PrimOpInfo::new(2, false, false, false),
+            Self::Read => PrimOpInfo::new(1, false, false, false),
             Self::AllocCell => PrimOpInfo::new(0, false, false, true),
             Self::Car => PrimOpInfo::new(1, false, true, true),
             Self::Cdr => PrimOpInfo::new(1, false, true, true),

--- a/tests/r6rs.scm
+++ b/tests/r6rs.scm
@@ -522,3 +522,14 @@
      (list (list (list a ...) ...) (list b ...) c))))
 
 (assert-equal? (test-bug-286 (1 2) 99) '(() (1 2) 99))
+
+;; Test cell bug:
+
+(let ((x 1)
+      (y 2))
+  (let ((tmp x))
+    (set! x y)
+    (set! y tmp))
+  (assert-equal? (list x y) '(2 1)))
+
+(assert-equal? (let ((tmp 5)) (set! tmp (+ tmp 1)) tmp) 6)


### PR DESCRIPTION
Beta reduction would pass cells through to bindings. This change adds a read barrier that enforces binding the cells as values