### PR TITLE
fix: match wildcard `_` returns body as data instead of evaluating it

### DIFF
--- a/scheme/match.sls
+++ b/scheme/match.sls
@@ -471,7 +471,7 @@
          fk))
     ((match-two v #(p ...) g+s . x)
      (match-vector v 0 () (p ...) . x))
-    ((match-two v _ g+s (sk ...) fk i) '(sk ... i))
+    ((match-two v _ g+s (sk ...) fk i) (sk ... i))
     ;; Not a pair or vector or special literal, test to see if it's a
     ;; new symbol, in which case we just bind it, or if it's an
     ;; already bound symbol or some other literal, in which case we

--- a/tests/match_wildcard.rs
+++ b/tests/match_wildcard.rs
@@ -1,0 +1,3 @@
+mod common;
+
+common::run_test!(match_wildcard);

--- a/tests/match_wildcard.scm
+++ b/tests/match_wildcard.scm
@@ -1,0 +1,10 @@
+(import (rnrs) (test) (lang))
+
+;; The _ wildcard must evaluate the body, not return it as data.
+;; Regression: a spurious quote on the _ rule in match-two caused
+;; the success continuation to be returned as a quoted list.
+
+(define result #f)
+(match '(hello 1)
+  (('hello _) (set! result 'ok)))
+(assert-equal? result 'ok)


### PR DESCRIPTION
Line 474 of `scheme/match.sls` has `'(sk ... i)` — should be `(sk ... i)` (no quote). The original Alex Shinn matcher doesn't have the quote; it was introduced in the initial port.

**Repro:**

```scheme
(import (rnrs) (lang))

(define result #f)
(match '(hello 1)
  (('hello _) (set! result 'ok)))
result ;; => #f, should be ok
```

The `_` rule quotes the success continuation, so the body is returned as a list instead of being evaluated.

Includes a regression test.