### PR TITLE
Include form content in syntax error messages

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -45,11 +45,16 @@ mod error {
     }
 
     pub(super) fn bad_form(form: &Syntax, subform: Option<&Syntax>) -> Exception {
-        syntax_error(form, subform, "bad form")
+        syntax_error(form, subform, format!("bad form: {}", form.short_display()))
     }
 
     pub(super) fn undefined_variable(form: &Syntax, subform: Option<&Syntax>) -> Exception {
-        syntax_error(form, subform, "undefined variable")
+        let detail = subform.unwrap_or(form);
+        syntax_error(
+            form,
+            subform,
+            format!("undefined variable: {}", detail.short_display()),
+        )
     }
 
     pub(super) fn immutable_variable(form: &Syntax, subform: &Syntax) -> Exception {

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -380,6 +380,15 @@ impl Syntax {
         matches!(self.as_list(), Some([Self::Identifier { ident, .. }, .. ]) if ident == car)
     }
 
+    pub fn short_display(&self) -> String {
+        let s = format!("{self:?}");
+        if s.len() > 80 {
+            format!("{}...", &s[..77])
+        } else {
+            s
+        }
+    }
+
     pub fn span(&self) -> &Span {
         match self {
             Self::Wrapped { span, .. } => span,


### PR DESCRIPTION
## Summary

- `bad_form` errors now include a truncated representation of the offending syntax form
- `undefined_variable` errors now include the identifier name
- Added `Syntax::short_display()` — Debug format truncated to 80 chars

Before:
```
bad form
undefined variable
```

After:
```
bad form: (label "hello")
undefined variable: my-var
```

Makes diagnosing macro expansion and hygiene issues much easier.