### PR TITLE
Fix re-entrant library expansion producing undefined

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -386,13 +386,15 @@ impl TopLevelEnvironment {
         let body = {
             let mut this = self.0.write();
             if let LibraryState::Unexpanded(body) = &mut this.state {
-                std::mem::replace(
+                let body = std::mem::replace(
                     body,
                     Syntax::Wrapped {
                         value: Value::undefined(),
                         span: Span::default(),
                     },
-                )
+                );
+                this.state = LibraryState::Expanding;
+                body
             } else {
                 return Ok(());
             }
@@ -557,6 +559,7 @@ pub(crate) enum LibraryState {
     Invalid,
     BridgesDefined,
     Unexpanded(Syntax),
+    Expanding,
     Expanded {
         expanded: Definitions,
         mutable_vars: HashSet<Local>,

--- a/tests/lib-c.sls
+++ b/tests/lib-c.sls
@@ -1,0 +1,12 @@
+(library (tests lib-c)
+  (export make-wrapped wrap-value)
+  (import (rnrs))
+
+  (define (wrap-value v) (list 'wrapped v))
+
+  (define-syntax make-wrapped
+    (lambda (x)
+      (syntax-case x ()
+        ((_ (name . formals) body ...)
+         #'(define (name . formals)
+             (wrap-value (begin body ...))))))))

--- a/tests/lib-d.sls
+++ b/tests/lib-d.sls
@@ -1,0 +1,5 @@
+(library (tests lib-d)
+  (export my-fn)
+  (import (rnrs) (tests lib-c))
+
+  (make-wrapped (my-fn x) (+ x 1)))

--- a/tests/reentrant_expand.rs
+++ b/tests/reentrant_expand.rs
@@ -1,0 +1,3 @@
+mod common;
+
+common::run_test!(reentrant_expand);

--- a/tests/reentrant_expand.scm
+++ b/tests/reentrant_expand.scm
@@ -1,0 +1,3 @@
+(import (rnrs) (test) (tests lib-d))
+
+(assert-equal? '(wrapped 11) (my-fn 10))


### PR DESCRIPTION
## Summary

`maybe_expand()` replaces the library body with `Value::undefined()` before releasing the write lock and starting macro expansion. If a nested expansion during that window triggers a lookup that finds the same library's `Unexpanded` entry in `TOP_LEVEL_BINDINGS`, it calls `maybe_expand()` again, which processes the `undefined` sentinel as if it were the real body.

Fix: add an `Expanding` variant to `LibraryState`. The first `maybe_expand()` call sets the state to `Expanding` before releasing the lock. Re-entrant calls see `Expanding` (not `Unexpanded`), hit the `else` branch, and return `Ok(())` immediately.

## Reproduction

Found this from using define*, the bug triggers when a library uses a macro that generates `define*` calls (itself a macro from `(lang)`), and the macro template references bindings from the same library. During expansion of the generated `define*`, the `lambda*` macro looks up `%keyword-ref` from `(lang)`, which can trigger re-expansion of the originating library via `lookup_var_inner`'s `Unexpanded` handler.

## Test plan
- Added `reentrant_expand` test exercising the macro-generates-`define*` pattern across libraries
- All existing tests pass