### PR TITLE
Fix various small bugs

### DIFF
--- a/src/cps/reduce.rs
+++ b/src/cps/reduce.rs
@@ -220,7 +220,7 @@ impl Cps {
                     );
                     *binding.body = body.eta_reduction(uses, modified);
                 }
-                Cps::Fix(bindings, Box::new(cexpr.beta_reduction(uses, modified)))
+                Cps::Fix(bindings, Box::new(cexpr.eta_reduction(uses, modified)))
             }
             cexpr => cexpr,
         }

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -855,7 +855,9 @@ where
 {
     unsafe fn visit_children(&self, visitor: &mut dyn FnMut(OpaqueGcPtr)) {
         unsafe {
-            self.read().visit_or_recurse(visitor);
+            if let Some(read_lock) = self.try_read() {
+                read_lock.visit_or_recurse(visitor);
+            }
         }
     }
 

--- a/src/num.rs
+++ b/src/num.rs
@@ -2198,21 +2198,17 @@ pub fn div(arg1: &Value, args: &[Value]) -> Result<Vec<Value>, Exception> {
 }
 
 pub(crate) fn div_prim(val1: &Value, vals: &[Value]) -> Result<Number, Exception> {
-    let mut is_exact = true;
     let val1: Number = val1.try_to_scheme_type()?;
-    is_exact &= val1.is_exact();
     if vals.is_empty() {
-        if val1.is_zero() && is_exact {
+        if val1.is_zero() && val1.is_exact() {
             return Err(Exception::error("division by zero"));
-        } else {
-            return Ok(Number::from(1) / val1);
         }
+        return Ok(Number::from(1) / val1);
     }
     let mut result = val1.clone();
     for val in vals {
         let num: Number = val.try_to_scheme_type()?;
-        is_exact &= num.is_exact();
-        if num.is_zero() && is_exact {
+        if num.is_zero() && num.is_exact() {
             return Err(Exception::error("division by zero"));
         }
         result = result / num;

--- a/src/value.rs
+++ b/src/value.rs
@@ -1578,7 +1578,7 @@ pub fn eqv(a: &Value, b: &Value) -> Result<Vec<Value>, Exception> {
 
 #[bridge(name = "eq?", lib = "(rnrs base builtins (6))")]
 pub fn eq(a: &Value, b: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(a.eqv(b))])
+    Ok(vec![Value::from(a.eq(b))])
 }
 
 #[bridge(name = "equal?", lib = "(rnrs base builtins (6))")]


### PR DESCRIPTION
- eta reduction not propagated over fix body
- garbage collector blocks on RwLocks
- `eq?` uses `.eqv` instead of `.eq`
- division uses wrong exactness test for erroring