### PR TITLE
Add dynamic plugin loading for bridge functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ futures = { version = "0.3", optional = true }
 hashbrown = "0.16.1"
 indexmap = "2"
 inventory = "0.3"
+libloading = { version = "0.8", optional = true }
 lsp-server = { version = "0.7.9", optional = true }
 lsp-types = { version = "0.97.0", optional = true }
 malachite = { version = "0.9", features = ["floats"] }
@@ -53,6 +54,7 @@ default = ["load-libraries-from-fs"]
 async = ["dep:futures", "dep:async-stream"]
 lsp = ["dep:lsp-server", "dep:lsp-types", "dep:serde", "dep:serde_json"]
 load-libraries-from-fs = []
+plugins = ["dep:libloading"]
 
 [profile.release]
 lto = true

--- a/scheme/scheme-rs/plugins.sls
+++ b/scheme/scheme-rs/plugins.sls
@@ -1,0 +1,11 @@
+(library (scheme-rs plugins)
+  (export load-plugin)
+  (import (rnrs) (scheme-rs plugins builtins))
+
+  (define-syntax load-plugin
+    (lambda (stx)
+      (syntax-case stx ()
+        ((_ path)
+         (begin
+           (%load-plugin (syntax->datum #'path))
+           #'(values)))))))

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -7,13 +7,16 @@ use crate::{
         TopLevelEnvironment, TopLevelEnvironmentInner, TopLevelKind, add_binding,
     },
     exceptions::{Exception, ImportError},
-    gc::{Gc, Trace},
+    gc::{Gc, OpaqueGcPtr, Trace},
     proc::{BridgePtr, FuncPtr, KnownFunc, ProcDebugInfo, Procedure},
     runtime::Runtime,
     symbols::Symbol,
     syntax::{Identifier, Syntax},
     value::{Cell, Value},
 };
+
+#[cfg(feature = "plugins")]
+use crate::proc::{Application, ContBarrier};
 
 use std::{
     path::{Path, PathBuf},
@@ -61,6 +64,7 @@ pub(crate) mod error {
 }
 
 #[doc(hidden)]
+#[derive(Copy, Clone)]
 pub enum Bridge {
     Known(KnownFunc),
     Sync(BridgePtr),
@@ -68,7 +72,11 @@ pub enum Bridge {
     Async(crate::proc::AsyncBridgePtr),
 }
 
+// BridgeFn is passed across the FFI boundary between host and plugin.
+// Both sides MUST be compiled with the same rustc version and scheme-rs
+// feature flags, since BridgeFn is not #[repr(C)].
 #[doc(hidden)]
+#[derive(Copy, Clone)]
 pub struct BridgeFn {
     name: &'static str,
     lib_name: &'static str,
@@ -131,43 +139,105 @@ impl BridgeFnDebugInfo {
 
 inventory::collect!(BridgeFn);
 
+#[cfg(feature = "plugins")]
+#[unsafe(no_mangle)]
+pub extern "C" fn scheme_rs_bridges() -> PluginBridges {
+    use std::sync::OnceLock;
+    static BRIDGES: OnceLock<Vec<BridgeFn>> = OnceLock::new();
+    let bridges = BRIDGES.get_or_init(|| inventory::iter::<BridgeFn>().copied().collect());
+    PluginBridges {
+        version: SCHEME_RS_VERSION.as_ptr(),
+        version_len: SCHEME_RS_VERSION.len(),
+        ptr: bridges.as_ptr(),
+        len: bridges.len(),
+    }
+}
+
+#[cfg(feature = "plugins")]
+pub static SCHEME_RS_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg(feature = "plugins")]
+#[repr(C)]
+pub struct PluginBridges {
+    pub version: *const u8,
+    pub version_len: usize,
+    pub ptr: *const BridgeFn,
+    pub len: usize,
+}
+
+#[cfg(feature = "plugins")]
+#[allow(dead_code)]
+struct PluginHandle(std::mem::ManuallyDrop<libloading::Library>);
+
+#[cfg(feature = "plugins")]
+impl PluginHandle {
+    fn new(library: libloading::Library) -> Self {
+        Self(std::mem::ManuallyDrop::new(library))
+    }
+}
+
+#[cfg(feature = "plugins")]
+unsafe impl Trace for PluginHandle {
+    unsafe fn visit_children(&self, _visitor: &mut dyn FnMut(OpaqueGcPtr)) {}
+    unsafe fn finalize(&mut self) {}
+}
+
 #[derive(rust_embed::Embed)]
 #[folder = "scheme"]
 struct Stdlib;
 
-#[derive(Trace, Default)]
+#[derive(Default)]
 pub(crate) struct RegistryInner {
     pub(crate) libs: HashMap<Vec<Symbol>, TopLevelEnvironment>,
     loading: HashSet<Vec<Symbol>>,
+    #[cfg(feature = "plugins")]
+    plugins: Vec<PluginHandle>,
+    #[cfg(feature = "plugins")]
+    loaded_plugin_paths: HashSet<PathBuf>,
+}
+
+unsafe impl Trace for RegistryInner {
+    unsafe fn visit_children(&self, visitor: &mut dyn FnMut(OpaqueGcPtr)) {
+        unsafe { self.libs.visit_children(visitor) }
+    }
+    unsafe fn finalize(&mut self) {
+        unsafe {
+            self.libs.finalize();
+            std::ptr::drop_in_place(&mut self.loading);
+            #[cfg(feature = "plugins")]
+            std::ptr::drop_in_place(&mut self.plugins);
+            #[cfg(feature = "plugins")]
+            std::ptr::drop_in_place(&mut self.loaded_plugin_paths);
+        }
+    }
 }
 
 impl RegistryInner {
-    /// Construct an empty registry
     pub fn empty() -> Self {
         Self::default()
     }
 
-    /// Construct a Registry with all of the available bridge functions and special keywords.
-    pub fn new(rt: &Runtime) -> Self {
+    fn register_bridges<'a>(
+        &mut self,
+        rt: &Runtime,
+        bridges: impl Iterator<Item = &'a BridgeFn>,
+    ) -> Result<(), Exception> {
         struct Lib {
             version: Version,
             syms: HashMap<Symbol, Procedure>,
         }
-        let mut libs = HashMap::<Vec<Symbol>, Lib>::default();
+        let mut new_libs = HashMap::<Vec<Symbol>, Lib>::default();
 
-        // Import the bridge functions:
-        for bridge_fn in inventory::iter::<BridgeFn>() {
+        for bridge_fn in bridges {
             let debug_info = Arc::new(ProcDebugInfo::from_bridge_fn(
                 bridge_fn.name,
                 bridge_fn.debug_info,
             ));
-            let lib_name = LibraryName::from_str(bridge_fn.lib_name, None).unwrap();
-            let lib = libs.entry(lib_name.name).or_insert_with(|| Lib {
+            let lib_name = LibraryName::from_str(bridge_fn.lib_name, None)?;
+            let lib = new_libs.entry(lib_name.name).or_insert_with(|| Lib {
                 version: lib_name.version,
                 syms: HashMap::default(),
             });
-
-            // TODO: If version does not match, error.
 
             lib.syms.insert(
                 Symbol::intern(bridge_fn.name),
@@ -186,6 +256,67 @@ impl RegistryInner {
                 ),
             );
         }
+
+        for (name, lib) in new_libs {
+            let scope = Scope::new();
+
+            let exports = lib
+                .syms
+                .into_iter()
+                .map(|(name, proc)| {
+                    let binding = Binding::new();
+                    add_binding(Identifier::from_symbol(name, scope), binding);
+                    (
+                        name,
+                        proc,
+                        Export {
+                            binding,
+                            origin: None,
+                        },
+                    )
+                })
+                .collect::<Vec<_>>();
+            let tle = TopLevelEnvironment(Gc::new(RwLock::new(TopLevelEnvironmentInner {
+                rt: rt.clone(),
+                kind: TopLevelKind::Libary {
+                    name: LibraryName {
+                        version: lib.version,
+                        name: name.clone(),
+                    },
+                    path: None,
+                },
+                imports: HashMap::default(),
+                exports: exports
+                    .iter()
+                    .map(|(name, _, export)| (*name, export.clone()))
+                    .collect(),
+                state: LibraryState::BridgesDefined,
+                scope,
+            })));
+
+            for (name, proc, export) in exports {
+                TOP_LEVEL_BINDINGS.lock().insert(
+                    export.binding,
+                    TopLevelBinding::Global(Global::new(
+                        name,
+                        Cell::new(Value::from(proc)),
+                        false,
+                        tle.clone(),
+                    )),
+                );
+            }
+
+            self.libs.insert(name, tle);
+        }
+        Ok(())
+    }
+
+    /// Construct a Registry with all of the available bridge functions and special keywords.
+    pub fn new(rt: &Runtime) -> Self {
+        let mut this = Self::default();
+
+        this.register_bridges(rt, inventory::iter::<BridgeFn>())
+            .expect("statically-linked bridge has invalid lib_name");
 
         // Define the special keyword libraries:
         let special_keyword_libs = [
@@ -260,65 +391,8 @@ impl RegistryInner {
             )
         });
 
-        let libs = libs
-            .into_iter()
-            .map(|(name, lib)| {
-                let scope = Scope::new();
-
-                let exports = lib
-                    .syms
-                    .into_iter()
-                    .map(|(name, proc)| {
-                        let binding = Binding::new();
-                        add_binding(Identifier::from_symbol(name, scope), binding);
-                        (
-                            name,
-                            proc,
-                            Export {
-                                binding,
-                                origin: None,
-                            },
-                        )
-                    })
-                    .collect::<Vec<_>>();
-                let lib = TopLevelEnvironment(Gc::new(RwLock::new(TopLevelEnvironmentInner {
-                    rt: rt.clone(),
-                    kind: TopLevelKind::Libary {
-                        name: LibraryName {
-                            version: lib.version,
-                            name: name.clone(),
-                        },
-                        path: None,
-                    },
-                    imports: HashMap::default(),
-                    exports: exports
-                        .iter()
-                        .map(|(name, _, export)| (*name, export.clone()))
-                        .collect(),
-                    state: LibraryState::BridgesDefined,
-                    scope,
-                })));
-
-                for (name, proc, export) in exports {
-                    TOP_LEVEL_BINDINGS.lock().insert(
-                        export.binding,
-                        TopLevelBinding::Global(Global::new(
-                            name,
-                            Cell::new(Value::from(proc)),
-                            false,
-                            lib.clone(),
-                        )),
-                    );
-                }
-                (name, lib)
-            })
-            .chain(special_keyword_libs)
-            .collect();
-
-        Self {
-            libs,
-            loading: HashSet::default(),
-        }
+        this.libs.extend(special_keyword_libs);
+        this
     }
 }
 
@@ -332,6 +406,72 @@ impl Registry {
 
     pub(crate) fn new(rt: &Runtime) -> Self {
         Self(Gc::new(RwLock::new(RegistryInner::new(rt))))
+    }
+
+    /// # Safety
+    ///
+    /// The plugin must be built with the same `rustc` and scheme-rs
+    /// feature flags as the host. Version is checked at load time but
+    /// ABI drift from different compilers is not detected.
+    #[cfg(feature = "plugins")]
+    pub unsafe fn load_plugin(
+        &self,
+        rt: &Runtime,
+        library: libloading::Library,
+    ) -> Result<(), Exception> {
+        let mut inner = self.0.write();
+        unsafe { Self::load_plugin_locked(&mut inner, rt, library) }
+    }
+
+    #[cfg(feature = "plugins")]
+    unsafe fn load_plugin_locked(
+        inner: &mut RegistryInner,
+        rt: &Runtime,
+        library: libloading::Library,
+    ) -> Result<(), Exception> {
+        let bridges: &[BridgeFn] = unsafe {
+            let func: libloading::Symbol<extern "C" fn() -> PluginBridges> =
+                library.get(b"scheme_rs_bridges").map_err(|e| {
+                    Exception::error(format!("plugin does not export scheme_rs_bridges: {e}"))
+                })?;
+            let result = func();
+
+            let plugin_version = std::str::from_utf8(std::slice::from_raw_parts(
+                result.version,
+                result.version_len,
+            ))
+            .unwrap_or("<invalid utf8>");
+            if plugin_version != SCHEME_RS_VERSION {
+                return Err(Exception::error(format!(
+                    "plugin version mismatch: plugin was built against \
+                     scheme-rs {plugin_version}, host is {SCHEME_RS_VERSION}"
+                )));
+            }
+
+            std::slice::from_raw_parts(result.ptr, result.len)
+        };
+
+        inner.plugins.push(PluginHandle::new(library));
+        inner.register_bridges(rt, bridges.iter())?;
+        Ok(())
+    }
+
+    #[cfg(feature = "plugins")]
+    fn load_plugin_from_path(&self, rt: &Runtime, path: &str) -> Result<(), Exception> {
+        let canonical = std::fs::canonicalize(path)
+            .map_err(|e| Exception::error(format!("failed to resolve plugin path {path}: {e}")))?;
+
+        let mut inner = self.0.write();
+
+        if inner.loaded_plugin_paths.contains(&canonical) {
+            return Ok(());
+        }
+
+        let library = unsafe { libloading::Library::new(&canonical) }
+            .map_err(|e| Exception::error(format!("failed to load plugin {path}: {e}")))?;
+        unsafe { Self::load_plugin_locked(&mut inner, rt, library)? };
+        inner.loaded_plugin_paths.insert(canonical);
+        Ok(())
     }
 
     fn mark_as_loading(&self, name: &[Symbol]) {
@@ -525,6 +665,24 @@ impl Registry {
             ) as DynIter<'b>),
         }
     }
+}
+
+#[cfg(feature = "plugins")]
+#[cps_bridge(def = "%load-plugin path", lib = "(scheme-rs plugins builtins)")]
+pub fn load_plugin(
+    runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    _barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let [path] = args else { unreachable!() };
+    let path: crate::strings::WideString = path.clone().try_into()?;
+    runtime
+        .get_registry()
+        .load_plugin_from_path(runtime, &path.to_string())?;
+    Ok(Application::new(k, None, vec![]))
 }
 
 type DynIter<'a> = Box<dyn Iterator<Item = (Symbol, Import)> + 'a>;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -7,7 +7,7 @@ use crate::{
         TopLevelEnvironment, TopLevelEnvironmentInner, TopLevelKind, add_binding,
     },
     exceptions::{Exception, ImportError},
-    gc::{Gc, OpaqueGcPtr, Trace},
+    gc::{Gc, Trace},
     proc::{BridgePtr, FuncPtr, KnownFunc, ProcDebugInfo, Procedure},
     runtime::Runtime,
     symbols::Symbol,
@@ -167,7 +167,8 @@ pub struct PluginBridges {
 
 #[cfg(feature = "plugins")]
 #[allow(dead_code)]
-struct PluginHandle(std::mem::ManuallyDrop<libloading::Library>);
+#[derive(Trace)]
+struct PluginHandle(#[trace(skip)] std::mem::ManuallyDrop<libloading::Library>);
 
 #[cfg(feature = "plugins")]
 impl PluginHandle {
@@ -176,40 +177,21 @@ impl PluginHandle {
     }
 }
 
-#[cfg(feature = "plugins")]
-unsafe impl Trace for PluginHandle {
-    unsafe fn visit_children(&self, _visitor: &mut dyn FnMut(OpaqueGcPtr)) {}
-    unsafe fn finalize(&mut self) {}
-}
-
 #[derive(rust_embed::Embed)]
 #[folder = "scheme"]
 struct Stdlib;
 
-#[derive(Default)]
+#[derive(Default, Trace)]
 pub(crate) struct RegistryInner {
     pub(crate) libs: HashMap<Vec<Symbol>, TopLevelEnvironment>,
+    #[trace(skip)]
     loading: HashSet<Vec<Symbol>>,
     #[cfg(feature = "plugins")]
+    #[trace(skip)]
     plugins: Vec<PluginHandle>,
     #[cfg(feature = "plugins")]
+    #[trace(skip)]
     loaded_plugin_paths: HashSet<PathBuf>,
-}
-
-unsafe impl Trace for RegistryInner {
-    unsafe fn visit_children(&self, visitor: &mut dyn FnMut(OpaqueGcPtr)) {
-        unsafe { self.libs.visit_children(visitor) }
-    }
-    unsafe fn finalize(&mut self) {
-        unsafe {
-            self.libs.finalize();
-            std::ptr::drop_in_place(&mut self.loading);
-            #[cfg(feature = "plugins")]
-            std::ptr::drop_in_place(&mut self.plugins);
-            #[cfg(feature = "plugins")]
-            std::ptr::drop_in_place(&mut self.loaded_plugin_paths);
-        }
-    }
 }
 
 impl RegistryInner {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -153,6 +153,14 @@ impl Runtime {
             .await
     }
 
+    /// # Safety
+    ///
+    /// See [`Registry::load_plugin`].
+    #[cfg(feature = "plugins")]
+    pub unsafe fn load_plugin(&self, library: libloading::Library) -> Result<(), Exception> {
+        unsafe { self.get_registry().load_plugin(self, library) }
+    }
+
     pub(crate) fn get_registry(&self) -> Registry {
         self.0.read().registry.clone()
     }

--- a/tests/plugins.rs
+++ b/tests/plugins.rs
@@ -1,0 +1,80 @@
+#[cfg(feature = "plugins")]
+#[allow(unused_macros, unused_imports)]
+mod common;
+
+#[cfg(feature = "plugins")]
+fn test_plugin_dylib_name() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "target/debug/libtest_plugin.dylib"
+    } else if cfg!(target_os = "windows") {
+        "target/debug/test_plugin.dll"
+    } else {
+        "target/debug/libtest_plugin.so"
+    }
+}
+
+#[cfg(feature = "plugins")]
+#[scheme_rs_macros::maybe_async]
+#[cfg_attr(feature = "async", ::tokio::test)]
+#[cfg_attr(not(feature = "async"), test)]
+fn load_plugin_and_call_bridges() {
+    use scheme_rs::runtime::Runtime;
+    use std::path::Path;
+    use std::process::Command;
+
+    let plugin_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/test-plugin");
+    let status = Command::new("cargo")
+        .args(["build", "--quiet"])
+        .current_dir(&plugin_dir)
+        .status()
+        .expect("failed to build test plugin");
+    assert!(status.success(), "test plugin build failed");
+
+    let dylib = plugin_dir.join(test_plugin_dylib_name());
+    assert!(dylib.exists(), "test plugin dylib not found at {dylib:?}");
+
+    let rt = Runtime::new();
+    let lib = unsafe { libloading::Library::new(&dylib) }.expect("failed to dlopen test plugin");
+    unsafe { rt.load_plugin(lib) }.expect("failed to load plugin bridges");
+
+    scheme_rs_macros::maybe_await!(rt.run_program(Path::new("tests/plugins.scm")))
+        .expect("scheme test failed");
+}
+
+#[cfg(feature = "plugins")]
+#[scheme_rs_macros::maybe_async]
+#[cfg_attr(feature = "async", ::tokio::test)]
+#[cfg_attr(not(feature = "async"), test)]
+fn load_same_plugin_twice_is_ok() {
+    use scheme_rs::runtime::Runtime;
+    use std::path::Path;
+    use std::process::Command;
+
+    let plugin_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/test-plugin");
+    Command::new("cargo")
+        .args(["build", "--quiet"])
+        .current_dir(&plugin_dir)
+        .status()
+        .expect("failed to build test plugin");
+
+    let dylib = plugin_dir.join(test_plugin_dylib_name());
+
+    let rt = Runtime::new();
+    let lib1 = unsafe { libloading::Library::new(&dylib) }.unwrap();
+    unsafe { rt.load_plugin(lib1) }.expect("first load failed");
+
+    let lib2 = unsafe { libloading::Library::new(&dylib) }.unwrap();
+    unsafe { rt.load_plugin(lib2) }.expect("second load should succeed");
+
+    scheme_rs_macros::maybe_await!(rt.run_program(Path::new("tests/plugins.scm")))
+        .expect("bridges should work after double load");
+}
+
+#[cfg(feature = "plugins")]
+#[test]
+fn version_constant_matches_crate() {
+    assert_eq!(
+        scheme_rs::registry::SCHEME_RS_VERSION,
+        env!("CARGO_PKG_VERSION"),
+    );
+}

--- a/tests/plugins.scm
+++ b/tests/plugins.scm
@@ -1,0 +1,5 @@
+(import (test) (test plugin))
+
+(assert-equal? (test-plugin-add 2 3) 5)
+(assert-equal? (test-plugin-add -1 1) 0)
+(assert-equal? (test-plugin-greeting) "hello from plugin")

--- a/tests/test-plugin/Cargo.toml
+++ b/tests/test-plugin/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "test-plugin"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+scheme-rs = { path = "../..", features = ["plugins", "async", "tokio"] }

--- a/tests/test-plugin/src/lib.rs
+++ b/tests/test-plugin/src/lib.rs
@@ -1,0 +1,13 @@
+use scheme_rs::exceptions::Exception;
+use scheme_rs::registry::bridge;
+use scheme_rs::value::Value;
+
+#[bridge(name = "test-plugin-add", lib = "(test plugin)")]
+fn test_plugin_add(a: i64, b: i64) -> Result<Vec<Value>, Exception> {
+    Ok(vec![Value::from(a + b)])
+}
+
+#[bridge(name = "test-plugin-greeting", lib = "(test plugin)")]
+fn test_plugin_greeting() -> Result<Vec<Value>, Exception> {
+    Ok(vec![Value::from("hello from plugin".to_string())])
+}


### PR DESCRIPTION
## Summary

Adds support for loading bridge functions from cdylib plugins at runtime via `libloading`, gated behind a `plugins` Cargo feature.

- **Dynamic loading**: `Registry::load_plugin()` loads a `.dylib`/`.so`, calls its `scheme_rs_bridges` export, and registers the bridge functions into the runtime
- **Zero boilerplate for plugin authors**: enabling `features = ["plugins"]` automatically exports `scheme_rs_bridges` via `OnceLock` — plugin crates just write `#[bridge]` functions and set `crate-type = ["cdylib"]`
- **Expand-time `load-plugin` macro**: `(scheme-rs plugins)` exposes `load-plugin` as a syntax transformer so `(import ...)` works after it in the same file
- **Safety hardening**: `load_plugin` is `unsafe fn`, plugin libraries are never unmapped (`ManuallyDrop`), duplicate loads are detected by canonical path, and the check-load-insert sequence holds a single write lock to prevent TOCTOU races

### Usage (Scheme)

```scheme
(import (rnrs) (scheme-rs plugins))
(load-plugin "/path/to/libmy_plugin.dylib")
(import (my plugin))
(my-bridge-fn "hello")
```

### Usage (Rust, host side)

```rust
let library = unsafe { libloading::Library::new("libmy_plugin.dylib") }?;
unsafe { runtime.load_plugin(library)? };
```

## Test plan

- [x] Built and tested with a throwaway cdylib plugin crate (single bridge function, verified return value)
- [x] Verified `load-plugin` → `import` works in a single Scheme program
- [x] Verified duplicate load is a no-op
- [x] `cargo test --features "async,tokio,plugins" --lib --tests` passes
- [x] Builds cleanly without `plugins` feature
- [ x Integration test with a cdylib fixture (not yet in-tree)