### PR TITLE
feat: port readiness — raw fd access and poll_read/write_ready

### DIFF
--- a/src/ports.rs
+++ b/src/ports.rs
@@ -782,11 +782,21 @@ mod __impl {
         fn seek_fns() -> Option<(GetPosFn, SetPosFn)> {
             Some((get_pos_fn::<Self>(), set_pos_fn::<Self>()))
         }
+
+        #[cfg(unix)]
+        fn raw_fd_fn() -> Option<RawFdFn> {
+            Some(raw_fd_fn_for::<Self>())
+        }
     }
 
     impl IntoPort for std::io::Stdin {
         fn read_fn() -> Option<ReadFn> {
             Some(read_fn::<Self>())
+        }
+
+        #[cfg(unix)]
+        fn raw_fd_fn() -> Option<RawFdFn> {
+            Some(raw_fd_fn_for::<Self>())
         }
     }
 
@@ -794,11 +804,21 @@ mod __impl {
         fn write_fn() -> Option<WriteFn> {
             Some(write_fn::<Self>())
         }
+
+        #[cfg(unix)]
+        fn raw_fd_fn() -> Option<RawFdFn> {
+            Some(raw_fd_fn_for::<Self>())
+        }
     }
 
     impl IntoPort for std::io::Stderr {
         fn write_fn() -> Option<WriteFn> {
             Some(write_fn::<Self>())
+        }
+
+        #[cfg(unix)]
+        fn raw_fd_fn() -> Option<RawFdFn> {
+            Some(raw_fd_fn_for::<Self>())
         }
     }
 }
@@ -1037,12 +1057,22 @@ mod __impl {
         fn seek_fns() -> Option<(GetPosFn, SetPosFn)> {
             Some((get_pos_fn::<Self>(), set_pos_fn::<Self>()))
         }
+
+        #[cfg(unix)]
+        fn raw_fd_fn() -> Option<RawFdFn> {
+            Some(raw_fd_fn_for::<Self>())
+        }
     }
 
     #[cfg(feature = "tokio")]
     impl IntoPort for tokio::io::Stdin {
         fn read_fn() -> Option<ReadFn> {
             Some(read_fn::<Self>())
+        }
+
+        #[cfg(unix)]
+        fn raw_fd_fn() -> Option<RawFdFn> {
+            Some(raw_fd_fn_for::<Self>())
         }
     }
 
@@ -1051,12 +1081,22 @@ mod __impl {
         fn write_fn() -> Option<WriteFn> {
             Some(write_fn::<Self>())
         }
+
+        #[cfg(unix)]
+        fn raw_fd_fn() -> Option<RawFdFn> {
+            Some(raw_fd_fn_for::<Self>())
+        }
     }
 
     #[cfg(feature = "tokio")]
     impl IntoPort for tokio::io::Stderr {
         fn write_fn() -> Option<WriteFn> {
             Some(write_fn::<Self>())
+        }
+
+        #[cfg(unix)]
+        fn raw_fd_fn() -> Option<RawFdFn> {
+            Some(raw_fd_fn_for::<Self>())
         }
     }
 
@@ -1068,6 +1108,11 @@ mod __impl {
 
         fn write_fn() -> Option<WriteFn> {
             Some(write_fn::<Self>())
+        }
+
+        #[cfg(unix)]
+        fn raw_fd_fn() -> Option<RawFdFn> {
+            Some(raw_fd_fn_for::<Self>())
         }
     }
 
@@ -1100,6 +1145,17 @@ mod __impl {
 }
 
 pub use __impl::*;
+
+#[cfg(unix)]
+pub type RawFdFn = Box<dyn Fn(&dyn Any) -> std::os::fd::RawFd + Send + Sync>;
+
+#[cfg(unix)]
+pub fn raw_fd_fn_for<T>() -> RawFdFn
+where
+    T: std::os::fd::AsRawFd + Any + Send + 'static,
+{
+    Box::new(|any| any.downcast_ref::<T>().unwrap().as_raw_fd())
+}
 
 #[derive(Trace)]
 pub(crate) struct PortInner {
@@ -1155,6 +1211,8 @@ impl PortInner {
                 get_pos,
                 set_pos,
                 close,
+                #[cfg(unix)]
+                raw_fd: P::raw_fd_fn(),
             })),
         }
     }
@@ -1201,6 +1259,8 @@ impl PortInner {
                 get_pos,
                 set_pos,
                 close,
+                #[cfg(unix)]
+                raw_fd: None,
             })),
         }
     }
@@ -1286,6 +1346,8 @@ pub(crate) struct BinaryPortData {
     get_pos: Option<GetPosFn>,
     set_pos: Option<SetPosFn>,
     close: Option<CloseFn>,
+    #[cfg(unix)]
+    raw_fd: Option<RawFdFn>,
 }
 
 pub const BUFFER_SIZE: usize = 8192;
@@ -2265,6 +2327,11 @@ pub trait IntoPort: IntoPortReqs {
     fn close_fn() -> Option<CloseFn> {
         None
     }
+
+    #[cfg(unix)]
+    fn raw_fd_fn() -> Option<RawFdFn> {
+        None
+    }
 }
 
 impl IntoPort for Cursor<Vec<u8>> {
@@ -2391,6 +2458,24 @@ impl Port {
             close,
             buffer_mode,
         )))
+    }
+
+    #[cfg(unix)]
+    pub fn raw_fd(&self) -> Option<std::os::fd::RawFd> {
+        #[cfg(not(feature = "async"))]
+        let data = self.0.data.lock().unwrap();
+
+        // tokio::sync::Mutex::blocking_lock for use outside async context
+        #[cfg(feature = "async")]
+        let data = self.0.data.blocking_lock();
+
+        match &*data {
+            PortData::BinaryPort(bp) => bp
+                .raw_fd
+                .as_ref()
+                .and_then(|f| bp.inner_port.as_deref().map(|port| f(port))),
+            PortData::CustomTextualPort(_) => None,
+        }
     }
 
     /// Return the Id of the port.
@@ -3432,6 +3517,8 @@ pub fn transcoded_port(
         get_pos: port_data.get_pos.take(),
         set_pos: port_data.set_pos.take(),
         close: port_data.close.take(),
+        #[cfg(unix)]
+        raw_fd: port_data.raw_fd.take(),
     };
 
     let new_info = BinaryPortInfo {

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -1114,6 +1114,27 @@ mod __impl {
         fn raw_fd_fn() -> Option<RawFdFn> {
             Some(raw_fd_fn_for::<Self>())
         }
+
+        fn poll_read_ready_fn() -> Option<PollReadyFn> {
+            Some(Box::new(|any| {
+                let stream = any.downcast_ref::<tokio::net::TcpStream>().unwrap();
+                let mut buf = [0u8; 0];
+                match stream.try_read(&mut buf) {
+                    Ok(_) => true,
+                    Err(e) => e.kind() != std::io::ErrorKind::WouldBlock,
+                }
+            }))
+        }
+
+        fn poll_write_ready_fn() -> Option<PollReadyFn> {
+            Some(Box::new(|any| {
+                let stream = any.downcast_ref::<tokio::net::TcpStream>().unwrap();
+                match stream.try_write(&[]) {
+                    Ok(_) => true,
+                    Err(e) => e.kind() != std::io::ErrorKind::WouldBlock,
+                }
+            }))
+        }
     }
 
     pub(super) trait StreamExtExt {
@@ -1156,6 +1177,8 @@ where
 {
     Box::new(|any| any.downcast_ref::<T>().unwrap().as_raw_fd())
 }
+
+pub type PollReadyFn = Box<dyn Fn(&dyn Any) -> bool + Send + Sync>;
 
 #[derive(Trace)]
 pub(crate) struct PortInner {
@@ -1213,6 +1236,8 @@ impl PortInner {
                 close,
                 #[cfg(unix)]
                 raw_fd: P::raw_fd_fn(),
+                poll_read_ready: P::poll_read_ready_fn(),
+                poll_write_ready: P::poll_write_ready_fn(),
             })),
         }
     }
@@ -1261,6 +1286,8 @@ impl PortInner {
                 close,
                 #[cfg(unix)]
                 raw_fd: None,
+                poll_read_ready: None,
+                poll_write_ready: None,
             })),
         }
     }
@@ -1348,6 +1375,8 @@ pub(crate) struct BinaryPortData {
     close: Option<CloseFn>,
     #[cfg(unix)]
     raw_fd: Option<RawFdFn>,
+    poll_read_ready: Option<PollReadyFn>,
+    poll_write_ready: Option<PollReadyFn>,
 }
 
 pub const BUFFER_SIZE: usize = 8192;
@@ -2332,6 +2361,14 @@ pub trait IntoPort: IntoPortReqs {
     fn raw_fd_fn() -> Option<RawFdFn> {
         None
     }
+
+    fn poll_read_ready_fn() -> Option<PollReadyFn> {
+        None
+    }
+
+    fn poll_write_ready_fn() -> Option<PollReadyFn> {
+        None
+    }
 }
 
 impl IntoPort for Cursor<Vec<u8>> {
@@ -2461,13 +2498,12 @@ impl Port {
     }
 
     #[cfg(unix)]
+    #[maybe_async]
     pub fn raw_fd(&self) -> Option<std::os::fd::RawFd> {
         #[cfg(not(feature = "async"))]
         let data = self.0.data.lock().unwrap();
-
-        // tokio::sync::Mutex::blocking_lock for use outside async context
         #[cfg(feature = "async")]
-        let data = self.0.data.blocking_lock();
+        let data = self.0.data.lock().await;
 
         match &*data {
             PortData::BinaryPort(bp) => bp
@@ -2475,6 +2511,40 @@ impl Port {
                 .as_ref()
                 .and_then(|f| bp.inner_port.as_deref().map(|port| f(port))),
             PortData::CustomTextualPort(_) => None,
+        }
+    }
+
+    #[maybe_async]
+    pub fn poll_read_ready(&self) -> bool {
+        #[cfg(not(feature = "async"))]
+        let data = self.0.data.lock().unwrap();
+        #[cfg(feature = "async")]
+        let data = self.0.data.lock().await;
+
+        match &*data {
+            PortData::BinaryPort(bp) => bp
+                .poll_read_ready
+                .as_ref()
+                .and_then(|f| bp.inner_port.as_deref().map(|port| f(port)))
+                .unwrap_or(false),
+            PortData::CustomTextualPort(_) => false,
+        }
+    }
+
+    #[maybe_async]
+    pub fn poll_write_ready(&self) -> bool {
+        #[cfg(not(feature = "async"))]
+        let data = self.0.data.lock().unwrap();
+        #[cfg(feature = "async")]
+        let data = self.0.data.lock().await;
+
+        match &*data {
+            PortData::BinaryPort(bp) => bp
+                .poll_write_ready
+                .as_ref()
+                .and_then(|f| bp.inner_port.as_deref().map(|port| f(port)))
+                .unwrap_or(false),
+            PortData::CustomTextualPort(_) => false,
         }
     }
 
@@ -3519,6 +3589,8 @@ pub fn transcoded_port(
         close: port_data.close.take(),
         #[cfg(unix)]
         raw_fd: port_data.raw_fd.take(),
+        poll_read_ready: port_data.poll_read_ready.take(),
+        poll_write_ready: port_data.poll_write_ready.take(),
     };
 
     let new_info = BinaryPortInfo {


### PR DESCRIPTION
## Summary

- Expose `raw_fd()` on `Port` for fd-backed types (unix only, behind `#[cfg(unix)]`)
- Add `poll_read_ready()` / `poll_write_ready()` to `Port` for non-blocking readiness checks
- Implement `PollReadyFn` for `TcpStream` (via `try_read`/`try_write`)
- Wire `RawFdFn` through `IntoPort` for `File`, `Stdin`, `Stdout`, `Stderr`, and tokio stream types

These are needed for CML-style IO event operations (e.g. `accept-evt`) in downstream libraries that build on scheme-rs's port system.

## Test plan

- Builds cleanly on current main
- Used by the [parlor](https://gitlab.com/lshoravi/parlor) CML library (IO tests exercise `TcpStream` readiness polling and raw fd access)