### PR TITLE
Ignore dynamic-wind after-thunk results during exception unwind

### DIFF
--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -1043,8 +1043,7 @@ unsafe extern "C" fn unwind_to_exception_handler(
                 }
                 Some(DynStackElem::Winder(winder)) => {
                     // If this is a winder, we should call the out winder while unwinding.
-                    // The continuation is variadic so that any values returned by the
-                    // out winder are ignored and the raised value keeps unwinding.
+                    // Variadic: the out thunk's return arity is not under our control.
                     Application::new(
                         winder.out_thunk,
                         Some(Procedure::new_cont(

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -1042,7 +1042,9 @@ unsafe extern "C" fn unwind_to_exception_handler(
                     Application::halt_err(raised)
                 }
                 Some(DynStackElem::Winder(winder)) => {
-                    // If this is a winder, we should call the out winder while unwinding
+                    // If this is a winder, we should call the out winder while unwinding.
+                    // The continuation is variadic so that any values returned by the
+                    // out winder are ignored and the raised value keeps unwinding.
                     Application::new(
                         winder.out_thunk,
                         Some(Procedure::new_cont(
@@ -1050,7 +1052,7 @@ unsafe extern "C" fn unwind_to_exception_handler(
                             vec![raised],
                             unwind_to_exception_handler,
                             0,
-                            false,
+                            true,
                             barrier,
                         )),
                         Vec::new(),

--- a/tests/dynamic_wind_unwind.rs
+++ b/tests/dynamic_wind_unwind.rs
@@ -1,0 +1,3 @@
+mod common;
+
+common::run_test!(dynamic_wind_unwind);

--- a/tests/dynamic_wind_unwind.scm
+++ b/tests/dynamic_wind_unwind.scm
@@ -1,0 +1,16 @@
+(import (rnrs) (test))
+
+;; An exception unwinding through a dynamic-wind must reach the handler
+;; unchanged even when the after thunk returns a value (R6RS 11.15:
+;; after-thunk results are ignored).
+;; Regression: the unwind path gave the after thunk a strict 0-arity
+;; continuation, so returning a value raised wrong-number-of-args and
+;; replaced the original condition.
+
+(assert-equal?
+ (guard (e (#t (condition-message e)))
+   (dynamic-wind
+       (lambda () #f)
+       (lambda () (error 'inner "the real error"))
+       (lambda () #f)))
+ "the real error")

--- a/tests/dynamic_wind_unwind.scm
+++ b/tests/dynamic_wind_unwind.scm
@@ -1,11 +1,6 @@
 (import (rnrs) (test))
 
-;; An exception unwinding through a dynamic-wind must reach the handler
-;; unchanged even when the after thunk returns a value (R6RS 11.15:
-;; after-thunk results are ignored).
-;; Regression: the unwind path gave the after thunk a strict 0-arity
-;; continuation, so returning a value raised wrong-number-of-args and
-;; replaced the original condition.
+;; after-thunk return values must not disturb the exception unwinding through it.
 
 (assert-equal?
  (guard (e (#t (condition-message e)))


### PR DESCRIPTION
During exception unwinds, winder out-thunks get a strict 0-arity continuation
(`exceptions.rs` Winder arm). An after-thunk that returns a value trips the
arity check, which raises and drops the in-flight exception:

```scheme
(guard (e [#t (condition-message e)])
  (dynamic-wind
    (lambda () #f)
    (lambda () (error 'inner "the real error"))
    (lambda () #f)))
;; => "expected 0 arguments, provided 1", expected "the real error"
```

Fix: build that continuation variadic with results ignored, matching
`call_out_thunks` and the `ExceptionHandler` arm. Includes a regression test.
