### PR TITLE
Decode inline hex escapes as one Unicode scalar value

### DIFF
--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -323,6 +323,7 @@ fn parse_error_span(err: &ParseSyntaxError) -> Option<&Span> {
         | ParseSyntaxError::UnclosedParen { span } => Some(span),
         ParseSyntaxError::Lex(err) => match err {
             LexerError::InvalidCharacterInHexEscape { span, .. }
+            | LexerError::InvalidHexEscape { span }
             | LexerError::UnexpectedCharacter { span, .. }
             | LexerError::BadEscapeCharacter { span, .. } => Some(span),
             LexerError::UnexpectedEof | LexerError::ReadError(_) => None,

--- a/src/syntax/lex.rs
+++ b/src/syntax/lex.rs
@@ -510,11 +510,7 @@ impl<'a> Lexer<'a> {
         while let Some(chr) = maybe_await!(self.match_pred(|chr| chr != '"'))? {
             if chr == '\\' {
                 let escaped = match maybe_await!(self.take())?.ok_or(LexerError::UnexpectedEof)? {
-                    'x' => {
-                        let escaped = maybe_await!(self.inline_hex_escape())?;
-                        output.push_str(&escaped);
-                        continue;
-                    }
+                    'x' => maybe_await!(self.inline_hex_escape())?,
                     'a' => '\u{07}',
                     'b' => '\u{08}',
                     't' => '\t',
@@ -560,7 +556,7 @@ impl<'a> Lexer<'a> {
     #[maybe_async]
     fn identifier(&mut self) -> Result<Option<String>, LexerError> {
         let mut ident = if maybe_await!(self.match_tag("\\x"))? {
-            maybe_await!(self.inline_hex_escape())?
+            String::from(maybe_await!(self.inline_hex_escape())?)
         } else if maybe_await!(self.match_tag("..."))? {
             String::from("...")
         } else if maybe_await!(self.match_tag("->"))? {
@@ -575,7 +571,7 @@ impl<'a> Lexer<'a> {
 
         loop {
             if maybe_await!(self.match_tag("\\x"))? {
-                ident.push_str(&maybe_await!(self.inline_hex_escape())?);
+                ident.push(maybe_await!(self.inline_hex_escape())?);
             } else if let Some(next) = maybe_await!(self.match_pred(is_subsequent))? {
                 ident.push(next);
             } else {
@@ -587,9 +583,8 @@ impl<'a> Lexer<'a> {
     }
 
     #[maybe_async]
-    fn inline_hex_escape(&mut self) -> Result<String, LexerError> {
-        let mut escaped = String::new();
-        let mut buff = String::with_capacity(2);
+    fn inline_hex_escape(&mut self) -> Result<char, LexerError> {
+        let mut digits = String::new();
         while let Some(chr) = maybe_await!(self.match_pred(|chr| chr != ';'))? {
             if !chr.is_ascii_hexdigit() {
                 return Err(LexerError::InvalidCharacterInHexEscape {
@@ -597,17 +592,15 @@ impl<'a> Lexer<'a> {
                     span: self.curr_span(),
                 });
             }
-            buff.push(chr);
-            if buff.len() == 2 {
-                escaped.push(u8::from_str_radix(&buff, 16).unwrap() as char);
-                buff.clear();
-            }
-        }
-        if !buff.is_empty() {
-            escaped.push(u8::from_str_radix(&buff, 16).unwrap() as char);
+            digits.push(chr);
         }
         maybe_await!(self.take())?;
-        Ok(escaped)
+        u32::from_str_radix(&digits, 16)
+            .ok()
+            .and_then(char::from_u32)
+            .ok_or_else(|| LexerError::InvalidHexEscape {
+                span: self.curr_span(),
+            })
     }
 }
 
@@ -615,6 +608,7 @@ impl<'a> Lexer<'a> {
 pub enum LexerError {
     UnexpectedEof,
     InvalidCharacterInHexEscape { chr: char, span: Span },
+    InvalidHexEscape { span: Span },
     UnexpectedCharacter { chr: char, span: Span },
     BadEscapeCharacter { chr: char, span: Span },
     ReadError(Exception),
@@ -626,6 +620,12 @@ impl fmt::Display for LexerError {
             Self::UnexpectedEof => write!(f, "unexpected end of file"),
             Self::InvalidCharacterInHexEscape { chr, span } => {
                 write!(f, "invalid character `{chr}` in hex escape at `{span}`")
+            }
+            Self::InvalidHexEscape { span } => {
+                write!(
+                    f,
+                    "hex escape is not a valid Unicode scalar value at `{span}`"
+                )
             }
             Self::UnexpectedCharacter { chr, span } => {
                 write!(f, "unexpected character `{chr}` at `{span}`")

--- a/tests/hex_escape.rs
+++ b/tests/hex_escape.rs
@@ -1,0 +1,3 @@
+mod common;
+
+common::run_test!(hex_escape);

--- a/tests/hex_escape.scm
+++ b/tests/hex_escape.scm
@@ -1,0 +1,10 @@
+(import (rnrs) (test))
+
+;; R6RS 4.2.1: \x<hex>; denotes the single character whose Unicode scalar
+;; value is the whole hex digit run, not one character per digit pair.
+
+(assert-equal? (string-length "\x1F468;") 1)
+(assert-equal? (char->integer (string-ref "\x1F468;" 0)) 128104)
+(assert-equal? (string-length "\xe9;") 1)
+(assert-equal? (char->integer (string-ref "\xe9;" 0)) 233)
+(assert-equal? (symbol->string '\x3BB;) (string #\x3BB))


### PR DESCRIPTION
`"\x1F468;"` lexes to three garbage characters instead of one: `(string-length "\x1F468;")` returns 3 and `(char->integer (string-ref "\x1F468;" 0))` returns 31 (0x1F), where R6RS 4.2.1 requires a single character with scalar value #x1F468 (128104). The same applies to `\x<hex>;` escapes in identifiers.

Root cause: `inline_hex_escape` decoded the hex digit run pairwise as bytes (`u8` per two digits) rather than as one Unicode scalar value, so two-digit escapes like `"\xe9;"` only worked by coincidence.

Fix: accumulate the whole digit run and decode it once, mirroring the `#\x<hex>` character-literal path, with a new `LexerError::InvalidHexEscape` for empty/overflowing/surrogate values instead of unwrapping.