### PR TITLE
[4/4] Add SRFI-39/R6RS parameters with per-task storage

### DIFF
--- a/scheme/rnrs/parameters.sls
+++ b/scheme/rnrs/parameters.sls
@@ -1,0 +1,29 @@
+(library (rnrs parameters)
+  (export make-parameter parameter? parameterize)
+  (import (rnrs) (rnrs parameters bridge))
+
+  (define (make-parameter init . args)
+    (let* ((converter (if (null? args) #f (car args)))
+           (converted-init (if converter (converter init) init))
+           (param (%make-parameter converted-init (or converter #f))))
+      (case-lambda
+        (() (%parameter-ref param))
+        ((val)
+         (let ((prev (%parameter-ref param)))
+           (%parameter-set! param (if converter (converter val) val))
+           prev)))))
+
+  (define-syntax parameterize
+    (syntax-rules ()
+      ((_ () body ...)
+       (begin body ...))
+      ((_ ((param val) ...) body ...)
+       (let ((procs (list param ...))
+             (vs (list val ...)))
+         (let* ((new-vals vs)
+                (swap!
+                 (lambda ()
+                   (let ((old-vals (map (lambda (p) (p)) procs)))
+                     (for-each (lambda (p v) (p v)) procs new-vals)
+                     (set! new-vals old-vals)))))
+           (dynamic-wind swap! (lambda () body ...) swap!)))))))

--- a/src/futures.rs
+++ b/src/futures.rs
@@ -15,8 +15,10 @@ use tokio::{
 use crate::{
     exceptions::Exception,
     ports::{BufferMode, Port},
-    proc::{ContBarrier, Procedure},
+    proc::{Application, ContBarrier, Procedure},
     records::{Record, RecordTypeDescriptor, SchemeCompatible, rtd},
+    registry::cps_bridge,
+    runtime::Runtime,
     strings::WideString,
     value::Value,
 };
@@ -33,22 +35,41 @@ impl SchemeCompatible for Future {
     }
 }
 
-#[bridge(name = "future", lib = "(async)")]
-pub async fn make_future(proc: Procedure) -> Result<Vec<Value>, Exception> {
-    let future: Future = async move { proc.call(&[], &mut ContBarrier::new()).await }
+#[cps_bridge(def = "future proc", lib = "(async)")]
+pub fn make_future(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier,
+) -> Result<Application, Exception> {
+    let proc: Procedure = args[0].clone().try_into()?;
+    // The task inherits a snapshot of the parameter bindings as of future
+    // creation, not as of first await.
+    let mut child = barrier.child();
+    let future: Future = async move { proc.call(&[], &mut child).await }
         .boxed()
         .shared();
     let future = Value::from_rust_type(future);
-    Ok(vec![future])
+    Ok(Application::new(k, None, vec![future]))
 }
 
-#[bridge(name = "spawn", lib = "(async)")]
-pub async fn spawn(task: &Value) -> Result<Vec<Value>, Exception> {
-    let task: Procedure = task.clone().try_into()?;
-    let task = tokio::task::spawn(async move { task.call(&[], &mut ContBarrier::new()).await });
+#[cps_bridge(def = "spawn task", lib = "(async)")]
+pub fn spawn(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier,
+) -> Result<Application, Exception> {
+    let task: Procedure = args[0].clone().try_into()?;
+    let mut child = barrier.child();
+    let task = tokio::task::spawn(async move { task.call(&[], &mut child).await });
     let future: Future = async move { task.await.unwrap() }.boxed().shared();
     let future = Value::from(Record::from_rust_type(future));
-    Ok(vec![future])
+    Ok(Application::new(k, None, vec![future]))
 }
 
 #[bridge(name = "await", lib = "(async)")]

--- a/src/futures.rs
+++ b/src/futures.rs
@@ -45,9 +45,8 @@ pub fn make_future(
     barrier: &mut ContBarrier,
 ) -> Result<Application, Exception> {
     let proc: Procedure = args[0].clone().try_into()?;
-    // The task inherits a snapshot of the parameter bindings as of future
-    // creation, not as of first await.
-    let mut child = barrier.child();
+    // Parameter bindings are inherited as of future creation, not first await.
+    let mut child = ContBarrier::from(barrier.child_state());
     let future: Future = async move { proc.call(&[], &mut child).await }
         .boxed()
         .shared();
@@ -65,7 +64,7 @@ pub fn spawn(
     barrier: &mut ContBarrier,
 ) -> Result<Application, Exception> {
     let task: Procedure = args[0].clone().try_into()?;
-    let mut child = barrier.child();
+    let mut child = ContBarrier::from(barrier.child_state());
     let task = tokio::task::spawn(async move { task.call(&[], &mut child).await });
     let future: Future = async move { task.await.unwrap() }.boxed().shared();
     let future = Value::from(Record::from_rust_type(future));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod env;
 pub mod eval;
 pub mod exceptions;
 pub(crate) mod expand;
+pub mod parameters;
 pub mod gc;
 pub mod hashtables;
 pub mod keywords;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@ pub mod env;
 pub mod eval;
 pub mod exceptions;
 pub(crate) mod expand;
-pub mod parameters;
 pub mod gc;
 pub mod hashtables;
 pub mod keywords;
@@ -19,6 +18,7 @@ pub mod lists;
 #[cfg(feature = "lsp")]
 pub mod lsp;
 pub mod num;
+pub mod parameters;
 pub mod ports;
 pub mod proc;
 pub mod records;

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,0 +1,125 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use scheme_rs_macros::bridge;
+
+use crate::{
+    exceptions::Exception,
+    gc::{Gc, Trace},
+    proc::{Application, ContBarrier, Procedure},
+    records::{RecordTypeDescriptor, SchemeCompatible, rtd},
+    registry::cps_bridge,
+    runtime::Runtime,
+    value::Value,
+};
+
+#[derive(Clone, Trace)]
+pub struct Parameter {
+    id: usize,
+    default: Value,
+    converter: Value,
+}
+
+impl std::fmt::Debug for Parameter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "#<parameter>")
+    }
+}
+
+impl Parameter {
+    pub fn new(default: Value, converter: Value) -> Self {
+        static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+        Self {
+            id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
+            default,
+            converter,
+        }
+    }
+
+    pub fn id(&self) -> usize {
+        self.id
+    }
+
+    pub fn default_value(&self) -> Value {
+        self.default.clone()
+    }
+
+    pub fn converter(&self) -> Value {
+        self.converter.clone()
+    }
+}
+
+impl SchemeCompatible for Parameter {
+    fn rtd() -> Arc<RecordTypeDescriptor> {
+        rtd!(name: "parameter", sealed: true, opaque: true)
+    }
+}
+
+#[bridge(name = "%make-parameter", lib = "(rnrs parameters bridge)")]
+pub fn make_parameter_bridge(init: &Value, converter: &Value) -> Result<Vec<Value>, Exception> {
+    Ok(vec![Value::from_rust_type(Parameter::new(
+        init.clone(),
+        converter.clone(),
+    ))])
+}
+
+#[cps_bridge(def = "%parameter-ref param", lib = "(rnrs parameters bridge)")]
+pub fn parameter_ref_bridge(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier,
+) -> Result<Application, Exception> {
+    let [param_val] = args else {
+        return Err(Exception::wrong_num_of_args(1, args.len()));
+    };
+    let param: Gc<Parameter> = param_val.try_to_rust_type::<Parameter>()?;
+    let val = barrier.parameter_ref(&param);
+    Ok(Application::new(k, None, vec![val]))
+}
+
+#[cps_bridge(def = "%parameter-set! param val", lib = "(rnrs parameters bridge)")]
+pub fn parameter_set_bridge(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier,
+) -> Result<Application, Exception> {
+    let [param_val, new_val] = args else {
+        return Err(Exception::wrong_num_of_args(2, args.len()));
+    };
+    let param: Gc<Parameter> = param_val.try_to_rust_type::<Parameter>()?;
+    barrier.parameter_set(param.id(), new_val.clone());
+    Ok(Application::new(k, None, vec![]))
+}
+
+#[bridge(name = "%parameter-converter", lib = "(rnrs parameters bridge)")]
+pub fn parameter_converter_bridge(param_val: &Value) -> Result<Vec<Value>, Exception> {
+    let param: Gc<Parameter> = param_val.try_to_rust_type::<Parameter>()?;
+    Ok(vec![param.converter()])
+}
+
+fn find_parameter_in_env(val: &Value) -> Option<Value> {
+    let proc: Procedure = val.clone().try_into().ok()?;
+    proc.0
+        .env
+        .iter()
+        .find(|v| v.try_to_rust_type::<Parameter>().is_ok())
+        .cloned()
+}
+
+#[bridge(name = "%parameter-extract", lib = "(rnrs parameters bridge)")]
+pub fn parameter_extract(val: &Value) -> Result<Vec<Value>, Exception> {
+    find_parameter_in_env(val)
+        .ok_or_else(|| Exception::error("not a parameter"))
+        .map(|v| vec![v])
+}
+
+#[bridge(name = "parameter?", lib = "(rnrs parameters bridge)")]
+pub fn is_parameter(val: &Value) -> Result<Vec<Value>, Exception> {
+    Ok(vec![Value::from(find_parameter_in_env(val).is_some())])
+}

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -945,16 +945,16 @@ impl<'a> ContBarrier<'a> {
         }
     }
 
-    pub fn child(&self) -> ContBarrier<'static> {
-        ContBarrier {
-            id: Self::next_id(),
+    /// The dynamic state a child task starts with: fresh everything except
+    /// the parameter bindings, which are inherited by value.
+    pub fn child_state(&self) -> SavedDynamicState {
+        SavedDynamicState {
+            id: self.id,
             dyn_stack: Vec::new(),
             cont_marks: vec![HashMap::new()],
-            params: HashMap::new(),
-            // Snapshot the parameter values rather than cloning the map:
-            // cells are shared Gc pointers that parameter_set writes
-            // through, so a plain clone would let a child's set or
-            // parameterize mutate the parent's bindings.
+            // Snapshot values, not the cell map: cells are shared Gc pointers,
+            // so a plain clone would let child writes mutate the parent's
+            // bindings.
             parameter_cells: self
                 .parameter_cells
                 .iter()

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -97,13 +97,14 @@ use crate::{
     exceptions::{Exception, raise},
     gc::{Gc, GcInner, Trace},
     lists::{self, Pair, list_to_vec},
+    parameters::Parameter,
     ports::{BufferMode, Port, Transcoder},
     records::{Record, RecordTypeDescriptor, SchemeCompatible, rtd},
     registry::BridgeFnDebugInfo,
     runtime::{Runtime, RuntimeInner},
     symbols::Symbol,
     syntax::Span,
-    value::Value,
+    value::{Cell, Value},
     vectors::Vector,
 };
 use parking_lot::RwLock;
@@ -920,14 +921,19 @@ pub struct ContBarrier<'a> {
     cont_marks: Vec<HashMap<Symbol, Value>>,
     /// The active installed mutable parameters
     params: HashMap<Symbol, Param<'a>>,
+    /// Per-task parameter bindings, keyed by Parameter id
+    parameter_cells: HashMap<usize, Cell>,
 }
 
 impl<'a> ContBarrier<'a> {
-    pub fn new() -> Self {
+    fn next_id() -> usize {
         static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+        NEXT_ID.fetch_add(1, Ordering::Relaxed)
+    }
 
+    pub fn new() -> Self {
         Self {
-            id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
+            id: Self::next_id(),
             dyn_stack: Vec::new(),
             // Procedures returned by the JIT compiler are delimited
             // continuations (of sorts), and therefore we need to preallocate
@@ -935,6 +941,17 @@ impl<'a> ContBarrier<'a> {
             // for them when they're run.
             cont_marks: vec![HashMap::new()],
             params: HashMap::new(),
+            parameter_cells: HashMap::new(),
+        }
+    }
+
+    pub fn child(&self) -> ContBarrier<'static> {
+        ContBarrier {
+            id: Self::next_id(),
+            dyn_stack: Vec::new(),
+            cont_marks: vec![HashMap::new()],
+            params: HashMap::new(),
+            parameter_cells: self.parameter_cells.clone(),
         }
     }
 
@@ -943,6 +960,7 @@ impl<'a> ContBarrier<'a> {
             id: self.id,
             dyn_stack: self.dyn_stack.clone(),
             cont_marks: self.cont_marks.clone(),
+            parameter_cells: self.parameter_cells.clone(),
         }
     }
 
@@ -1093,6 +1111,22 @@ impl<'a> ContBarrier<'a> {
     pub(crate) fn dyn_stack_is_empty(&self) -> bool {
         self.dyn_stack.is_empty()
     }
+
+    pub(crate) fn parameter_ref(&self, param: &Gc<Parameter>) -> Value {
+        match self.parameter_cells.get(&param.id()) {
+            Some(cell) => cell.get(),
+            None => param.default_value(),
+        }
+    }
+
+    pub(crate) fn parameter_set(&mut self, param_id: usize, val: Value) {
+        match self.parameter_cells.get(&param_id) {
+            Some(cell) => cell.set(val),
+            None => {
+                self.parameter_cells.insert(param_id, Cell::new(val));
+            }
+        }
+    }
 }
 
 impl Default for ContBarrier<'_> {
@@ -1120,6 +1154,7 @@ pub struct SavedDynamicState {
     id: usize,
     dyn_stack: Vec<DynStackElem>,
     cont_marks: Vec<HashMap<Symbol, Value>>,
+    parameter_cells: HashMap<usize, Cell>,
 }
 
 impl SavedDynamicState {
@@ -1145,6 +1180,7 @@ impl From<SavedDynamicState> for ContBarrier<'_> {
         ContBarrier {
             dyn_stack: value.dyn_stack,
             cont_marks: value.cont_marks,
+            parameter_cells: value.parameter_cells,
             ..Default::default()
         }
     }
@@ -1803,6 +1839,7 @@ unsafe extern "C" fn unwind_to_prompt(
                         dyn_stack: saved_barrier.as_ref().dyn_stack[barrier.dyn_stack_len() + 1..]
                             .to_vec(),
                         cont_marks: saved_barrier.cont_marks.clone(),
+                        parameter_cells: saved_barrier.parameter_cells.clone(),
                     };
                     let (req_args, var) = {
                         let k_proc: Procedure = k.clone().try_into().unwrap();

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -951,7 +951,15 @@ impl<'a> ContBarrier<'a> {
             dyn_stack: Vec::new(),
             cont_marks: vec![HashMap::new()],
             params: HashMap::new(),
-            parameter_cells: self.parameter_cells.clone(),
+            // Snapshot the parameter values rather than cloning the map:
+            // cells are shared Gc pointers that parameter_set writes
+            // through, so a plain clone would let a child's set or
+            // parameterize mutate the parent's bindings.
+            parameter_cells: self
+                .parameter_cells
+                .iter()
+                .map(|(id, cell)| (*id, Cell::new(cell.get())))
+                .collect(),
         }
     }
 

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -119,6 +119,37 @@ use std::{
     },
 };
 
+#[cfg(feature = "async")]
+struct ThreadWaker(std::thread::Thread);
+
+#[cfg(feature = "async")]
+impl std::task::Wake for ThreadWaker {
+    fn wake(self: Arc<Self>) {
+        self.0.unpark();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.0.unpark();
+    }
+}
+
+/// Minimal park-based `block_on`. Hand-rolled because the alternatives panic
+/// exactly where `call_sync` runs: `futures::executor::block_on`'s enter
+/// guard forbids nesting, and tokio's `Handle::block_on` refuses to run
+/// inside a runtime context.
+#[cfg(feature = "async")]
+fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+    let waker = std::task::Waker::from(Arc::new(ThreadWaker(std::thread::current())));
+    let mut cx = std::task::Context::from_waker(&waker);
+    let mut fut = std::pin::pin!(fut);
+    loop {
+        match fut.as_mut().poll(&mut cx) {
+            std::task::Poll::Ready(val) => return val,
+            std::task::Poll::Pending => std::thread::park(),
+        }
+    }
+}
+
 /// A function pointer to a generated continuation.
 pub(crate) type ContinuationPtr = unsafe extern "C" fn(
     runtime: *mut GcInner<RwLock<RuntimeInner>>,
@@ -200,20 +231,6 @@ impl KnownFunc {
     ) -> Application {
         match self.call(args) {
             Ok(result) => maybe_await!(k.0.apply(None, result, barrier)),
-            Err(err) => raise(runtime.clone(), err.into(), barrier),
-        }
-    }
-
-    #[cfg(feature = "async")]
-    fn apply_sync(
-        self,
-        runtime: &Runtime,
-        k: Procedure,
-        args: &[Value],
-        barrier: &mut ContBarrier<'_>,
-    ) -> Application {
-        match self.call(args) {
-            Ok(result) => k.0.apply_sync(None, result, barrier),
             Err(err) => raise(runtime.clone(), err.into(), barrier),
         }
     }
@@ -503,57 +520,6 @@ impl ProcedureInner {
             }
         }
     }
-
-    #[cfg(feature = "async")]
-    /// Attempt to call the function, and throw an error if is async
-    pub fn apply_sync(
-        &self,
-        k: Option<Procedure>,
-        args: Vec<Value>,
-        barrier: &mut ContBarrier,
-    ) -> Application {
-        if let FuncPtr::PromptBarrier { barrier_id: id, .. } = self.func {
-            barrier.pop_marks();
-            match barrier.pop_dyn_stack() {
-                Some(DynStackElem::PromptBarrier(PromptBarrier {
-                    barrier_id,
-                    replaced_k,
-                })) if barrier_id == id => {
-                    return if let Err(raised) =
-                        replaced_k.0.check_args(&k, args.as_slice(), barrier)
-                    {
-                        raised
-                    } else {
-                        Application::new(replaced_k, None, args)
-                    };
-                }
-                Some(other) => barrier.push_dyn_stack(other),
-                _ => (),
-            }
-        }
-
-        if let Err(raised) = self.check_args(&k, &args, barrier) {
-            return raised;
-        }
-
-        match self.func {
-            FuncPtr::Bridge(sbridge) => self.apply_sync_bridge(sbridge, k.unwrap(), &args, barrier),
-            FuncPtr::AsyncBridge(_) => raise(
-                self.runtime.clone(),
-                Exception::error("attempt to apply async function in a sync-only context").into(),
-                barrier,
-            ),
-            FuncPtr::User(user) => self.apply_jit(JitFuncPtr::User(user), k, args, barrier),
-            FuncPtr::Continuation(k) => {
-                barrier.pop_marks();
-                self.apply_jit(JitFuncPtr::Continuation(k), None, args, barrier)
-            }
-            FuncPtr::PromptBarrier { k, .. } => {
-                self.apply_jit(JitFuncPtr::Continuation(k), None, args, barrier)
-            }
-            FuncPtr::Known(known) => known.apply_sync(&self.runtime, k.unwrap(), &args, barrier),
-        }
-    }
 }
 
 impl fmt::Debug for ProcedureInner {
@@ -706,6 +672,8 @@ impl Procedure {
         maybe_await!(Application::new(self.clone(), k, args.to_vec()).eval(barrier))
     }
 
+    /// Like [`call`](Self::call), but blocks the current OS thread until
+    /// evaluation completes.
     #[cfg(feature = "async")]
     pub fn call_sync(
         &self,
@@ -713,7 +681,7 @@ impl Procedure {
         barrier: &mut ContBarrier<'_>,
     ) -> Result<Vec<Value>, Exception> {
         let k = (!self.is_continuation()).then(|| halt_continuation(self.get_runtime()));
-        Application::new(self.clone(), k, args.to_vec()).eval_sync(barrier)
+        block_on(Application::new(self.clone(), k, args.to_vec()).eval(barrier))
     }
 
     pub(crate) fn to_primop(&self) -> Option<PrimOp> {
@@ -861,21 +829,6 @@ impl Application {
                 }
             };
             self = maybe_await!(op.0.apply(self.k, self.args, barrier));
-        }
-    }
-
-    #[cfg(feature = "async")]
-    /// Just like [eval] but throws an error if we encounter an async function.
-    pub fn eval_sync(mut self, barrier: &mut ContBarrier) -> Result<Vec<Value>, Exception> {
-        loop {
-            let op = match self.op {
-                OpType::Proc(proc) => proc,
-                OpType::HaltOk => return Ok(self.args),
-                OpType::HaltErr => {
-                    return Err(Exception(self.args.pop().unwrap()));
-                }
-            };
-            self = op.0.apply_sync(self.k, self.args, barrier);
         }
     }
 }

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -53,10 +53,9 @@ pub fn spawn(
     let thunk: Procedure = args[0].clone().try_into()?;
     let cell = Gc::new(Mutex::new(Ok(Vec::new())));
     let cell_cloned = cell.clone();
-    // The child inherits a snapshot of the parent's parameter bindings.
-    // Moved as SavedDynamicState because ContBarrier itself is not Send
-    // in non-async builds.
-    let child = barrier.child().save();
+    // Built into a ContBarrier inside the closure; ContBarrier itself is
+    // not Send in non-async builds.
+    let child = barrier.child_state();
     // Capture the runtime handle so the child thread can enter the reactor
     // context (timers/IO in async bridges work). Remaining ceiling:
     // reactor-backed bridges reached from hashtable hash/eq callbacks park a

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -22,6 +22,8 @@ use crate::{
 pub struct JoinHandle {
     #[trace(skip)]
     id: ThreadId,
+    #[trace(skip)]
+    thread: Mutex<Option<thread::JoinHandle<()>>>,
     result: Gc<Mutex<Result<Vec<Value>, Exception>>>,
 }
 
@@ -55,20 +57,40 @@ pub fn spawn(thunk: Procedure) -> Result<Vec<Value>, Exception> {
         }
     });
     let id = join_handle.thread().id();
-    Ok(vec![Value::from_rust_type(JoinHandle { id, result: cell })])
+    Ok(vec![Value::from_rust_type(JoinHandle {
+        id,
+        thread: Mutex::new(Some(join_handle)),
+        result: cell,
+    })])
 }
 
 #[bridge(name = "join", lib = "(threads (1))")]
 pub fn join(handle: &Value) -> Result<Vec<Value>, Exception> {
     let handle = handle.try_to_rust_type::<JoinHandle>()?;
+    join_inner(&handle)
+}
+
+fn join_inner(handle: &JoinHandle) -> Result<Vec<Value>, Exception> {
     let curr_id = thread::current().id();
     if curr_id == handle.id {
-        Err(Exception::error(format!(
+        return Err(Exception::error(format!(
             "thread {curr_id:?} attempted to join itself"
-        )))
-    } else {
-        handle.result.lock().clone()
+        )));
     }
+    // The scrutinee's MutexGuard is held across join() (if-let temporary
+    // scope), which is what blocks concurrent joiners until the thread has
+    // finished; don't hoist the lock() into its own binding.
+    if let Some(thread) = handle.thread.lock().take()
+        && let Err(payload) = thread.join()
+    {
+        let msg = payload
+            .downcast_ref::<&str>()
+            .map(ToString::to_string)
+            .or_else(|| payload.downcast_ref::<String>().cloned())
+            .unwrap_or_else(|| "unknown panic".to_string());
+        *handle.result.lock() = Err(Exception::error(format!("thread panicked: {msg}")));
+    }
+    handle.result.lock().clone()
 }
 
 #[bridge(name = "sleep", lib = "(threads (1))")]
@@ -82,4 +104,24 @@ pub fn join_handle_pred(obj: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
         obj.cast_to_rust_type::<JoinHandle>().is_some(),
     )])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn join_surfaces_panics() {
+        let thread = thread::spawn(|| panic!("boom"));
+        let handle = JoinHandle {
+            id: thread.thread().id(),
+            thread: Mutex::new(Some(thread)),
+            result: Gc::new(Mutex::new(Ok(Vec::new()))),
+        };
+        let err = join_inner(&handle).unwrap_err();
+        assert!(format!("{err:?}").contains("boom"));
+        // Subsequent joins see the persisted error, not the default cell.
+        let err = join_inner(&handle).unwrap_err();
+        assert!(format!("{err:?}").contains("boom"));
+    }
 }

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -13,8 +13,10 @@ use scheme_rs_macros::bridge;
 use crate::{
     exceptions::Exception,
     gc::{Gc, Trace},
-    proc::{ContBarrier, Procedure},
+    proc::{Application, ContBarrier, Procedure},
     records::{RecordTypeDescriptor, SchemeCompatible, rtd},
+    registry::cps_bridge,
+    runtime::Runtime,
     value::Value,
 };
 
@@ -39,10 +41,22 @@ impl SchemeCompatible for JoinHandle {
     }
 }
 
-#[bridge(name = "spawn", lib = "(threads (1))")]
-pub fn spawn(thunk: Procedure) -> Result<Vec<Value>, Exception> {
+#[cps_bridge(def = "spawn thunk", lib = "(threads (1))")]
+pub fn spawn(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier,
+) -> Result<Application, Exception> {
+    let thunk: Procedure = args[0].clone().try_into()?;
     let cell = Gc::new(Mutex::new(Ok(Vec::new())));
     let cell_cloned = cell.clone();
+    // The child inherits a snapshot of the parent's parameter bindings.
+    // Moved as SavedDynamicState because ContBarrier itself is not Send
+    // in non-async builds.
+    let child = barrier.child().save();
     // Capture the runtime handle so the child thread can enter the reactor
     // context (timers/IO in async bridges work). Remaining ceiling:
     // reactor-backed bridges reached from hashtable hash/eq callbacks park a
@@ -53,26 +67,28 @@ pub fn spawn(thunk: Procedure) -> Result<Vec<Value>, Exception> {
     let handle = tokio::runtime::Handle::try_current().ok();
     let join_handle = thread::spawn(move || {
         let mut cell_write = cell_cloned.lock();
+        let mut barrier = ContBarrier::from(child);
 
         #[cfg(not(feature = "async"))]
         {
-            *cell_write = thunk.call(&[], &mut ContBarrier::new());
+            *cell_write = thunk.call(&[], &mut barrier);
         }
 
         #[cfg(feature = "async")]
         {
             *cell_write = match handle {
-                Some(handle) => handle.block_on(thunk.call(&[], &mut ContBarrier::new())),
-                None => thunk.call_sync(&[], &mut ContBarrier::new()),
+                Some(handle) => handle.block_on(thunk.call(&[], &mut barrier)),
+                None => thunk.call_sync(&[], &mut barrier),
             };
         }
     });
     let id = join_handle.thread().id();
-    Ok(vec![Value::from_rust_type(JoinHandle {
+    let handle = Value::from_rust_type(JoinHandle {
         id,
         thread: Mutex::new(Some(join_handle)),
         result: cell,
-    })])
+    });
+    Ok(Application::new(k, None, vec![handle]))
 }
 
 #[bridge(name = "join", lib = "(threads (1))")]

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -43,6 +43,14 @@ impl SchemeCompatible for JoinHandle {
 pub fn spawn(thunk: Procedure) -> Result<Vec<Value>, Exception> {
     let cell = Gc::new(Mutex::new(Ok(Vec::new())));
     let cell_cloned = cell.clone();
+    // Capture the runtime handle so the child thread can enter the reactor
+    // context (timers/IO in async bridges work). Remaining ceiling:
+    // reactor-backed bridges reached from hashtable hash/eq callbacks park a
+    // runtime worker inside call_sync — deadlock on current_thread runtimes,
+    // pool starvation on multi_thread. Goes away once the hashtable path is
+    // asyncified (follow-up); call_sync then only parks non-worker threads.
+    #[cfg(feature = "async")]
+    let handle = tokio::runtime::Handle::try_current().ok();
     let join_handle = thread::spawn(move || {
         let mut cell_write = cell_cloned.lock();
 
@@ -53,7 +61,10 @@ pub fn spawn(thunk: Procedure) -> Result<Vec<Value>, Exception> {
 
         #[cfg(feature = "async")]
         {
-            *cell_write = thunk.call_sync(&[], &mut ContBarrier::new());
+            *cell_write = match handle {
+                Some(handle) => handle.block_on(thunk.call(&[], &mut ContBarrier::new())),
+                None => thunk.call_sync(&[], &mut ContBarrier::new()),
+            };
         }
     });
     let id = join_handle.thread().id();

--- a/src/value.rs
+++ b/src/value.rs
@@ -574,6 +574,12 @@ unsafe impl Trace for Value {
 #[derive(Clone, Trace)]
 pub struct Cell(pub(crate) Gc<RwLock<Value>>);
 
+impl std::fmt::Debug for Cell {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "#<cell>")
+    }
+}
+
 impl Cell {
     pub fn new(val: Value) -> Self {
         Self(Gc::new(RwLock::new(val)))

--- a/tests/blockon_pending.rs
+++ b/tests/blockon_pending.rs
@@ -1,0 +1,18 @@
+#![cfg(all(feature = "async", feature = "tokio"))]
+
+#[allow(unused)]
+mod common;
+
+// multi_thread is required: the park-based block_on parks this worker while
+// another drives the timer. On current_thread this would deadlock, which is
+// the ceiling documented in threads.rs.
+#[tokio::test(flavor = "multi_thread")]
+async fn blockon_pending() {
+    use scheme_rs::runtime::Runtime;
+    use std::path::Path;
+
+    let rt = Runtime::new();
+    rt.run_program(Path::new("tests/blockon_pending.scm"))
+        .await
+        .expect("Test blockon_pending failed");
+}

--- a/tests/blockon_pending.scm
+++ b/tests/blockon_pending.scm
@@ -1,0 +1,19 @@
+(import (rnrs) (test) (only (threads) spawn join) (only (async) sleep))
+
+;; sleep from (async) suspends on a tokio timer, so these force real
+;; Poll::Pending round-trips instead of first-poll completion.
+
+;; Through Handle::block_on in a spawned OS thread.
+(let ((h (spawn (lambda () (sleep 5) 'woke))))
+  (assert-equal? (join h) 'woke))
+
+;; Through the park-based block_on: hashtable ops run the hash function via
+;; call_sync on a runtime worker, which parks until another worker fires the
+;; timer. Requires a multi_thread runtime (see blockon_pending.rs).
+(define (sleepy-hash x)
+  (sleep 5)
+  x)
+
+(define ht (make-hashtable sleepy-hash =))
+(hashtable-set! ht 1 'one)
+(assert-equal? (hashtable-ref ht 1 'nope) 'one)

--- a/tests/hashtable_nested_block_on.rs
+++ b/tests/hashtable_nested_block_on.rs
@@ -1,0 +1,3 @@
+mod common;
+
+common::run_test!(hashtable_nested_block_on);

--- a/tests/hashtable_nested_block_on.scm
+++ b/tests/hashtable_nested_block_on.scm
@@ -1,0 +1,19 @@
+(import (rnrs) (test))
+
+;; A Scheme-defined hash function that hits an async bridge (display).
+;; Hashtable operations invoke it from sync Rust that is itself running
+;; inside the async evaluator on a Tokio worker thread, so this exercises
+;; block_on nested within the async evaluator. This used to raise "attempt
+;; to apply async function in a sync-only context".
+(define (loud-hash x)
+  (display "")
+  x)
+
+(define ht (make-hashtable loud-hash =))
+(hashtable-set! ht 1 'one)
+(hashtable-set! ht 2 'two)
+(assert-equal? (hashtable-ref ht 1 'nope) 'one)
+(assert-equal? (hashtable-ref ht 2 'nope) 'two)
+(assert-equal? (hashtable-ref ht 3 'nope) 'nope)
+(hashtable-update! ht 1 (lambda (v) (display "") 'uno) 'default)
+(assert-equal? (hashtable-ref ht 1 'nope) 'uno)

--- a/tests/parameters.rs
+++ b/tests/parameters.rs
@@ -1,0 +1,3 @@
+mod common;
+
+common::run_test!(parameters);

--- a/tests/parameters.scm
+++ b/tests/parameters.scm
@@ -1,0 +1,120 @@
+(import (rnrs) (rnrs parameters) (prompts) (test))
+
+;; Basic parameter creation and access
+(define p (make-parameter 42))
+(assert-equal? (p) 42)
+(assert-equal? (parameter? p) #t)
+(assert-equal? (parameter? 42) #f)
+(assert-equal? (parameter? car) #f)
+
+;; Direct set returns previous value
+(assert-equal? (p 99) 42)
+(assert-equal? (p) 99)
+(p 42) ;; reset
+
+;; Converter applied to initial value
+(define q (make-parameter 5 (lambda (x) (* x 2))))
+(assert-equal? (q) 10)
+
+;; Converter applied on direct set
+(q 3)
+(assert-equal? (q) 6)
+
+;; parameterize scoping (no converter on p)
+(assert-equal? (parameterize ((p 100)) (p)) 100)
+(assert-equal? (p) 42)
+
+;; parameterize applies converter
+(assert-equal? (parameterize ((q 7)) (q)) 14)
+;; restore applies converter to saved value: (* 6 2) = 12
+(assert-equal? (q) 12)
+
+;; Nested parameterize (no converter)
+(assert-equal?
+ (parameterize ((p 100))
+   (parameterize ((p 200))
+     (p)))
+ 200)
+(assert-equal? (p) 42)
+
+;; Multiple parameters in one parameterize
+(assert-equal?
+ (parameterize ((p 1) (q 2))
+   (cons (p) (q)))
+ '(1 . 4))
+;; q restore: converter applied to 12 -> 24
+(assert-equal? (q) 24)
+
+;; Mutation inside parameterize doesn't leak (no converter)
+(parameterize ((p 50))
+  (p 60))
+(assert-equal? (p) 42)
+
+;; parameterize + call/cc: mutations preserved via swap
+(define cc-param (make-parameter 'outside))
+(define saved-k #f)
+(define call-count 0)
+
+(parameterize ((cc-param 'inside))
+  (call-with-current-continuation
+    (lambda (k) (set! saved-k k)))
+  (assert-equal? (cc-param) 'inside)
+  (set! call-count (+ call-count 1)))
+
+(assert-equal? (cc-param) 'outside)
+
+(if (< call-count 2)
+    (saved-k))
+(assert-equal? (cc-param) 'outside)
+
+;; Mutation + re-entry: mutation preserved via swap
+(define mut-param (make-parameter 'default))
+(define mut-k #f)
+(define mut-count 0)
+
+(parameterize ((mut-param 'bound))
+  (call-with-current-continuation
+    (lambda (k) (set! mut-k k)))
+  (if (= mut-count 0)
+      (mut-param 'mutated))
+  (assert-equal? (mut-param) 'mutated)
+  (set! mut-count (+ mut-count 1)))
+
+(if (< mut-count 2)
+    (begin
+      (assert-equal? (mut-param) 'default)
+      (mut-k)))
+(assert-equal? (mut-param) 'default)
+
+;; parameterize + dynamic-wind
+(define dw-param (make-parameter 'default))
+(define dw-log '())
+
+(parameterize ((dw-param 'bound))
+  (dynamic-wind
+    (lambda () (set! dw-log (cons (cons 'in (dw-param)) dw-log)))
+    (lambda () (set! dw-log (cons (cons 'body (dw-param)) dw-log)))
+    (lambda () (set! dw-log (cons (cons 'out (dw-param)) dw-log)))))
+
+(assert-equal? (reverse dw-log) '((in . bound) (body . bound) (out . bound)))
+
+;; parameterize + abort-to-prompt
+(define prompt-param (make-parameter 'outside))
+
+(assert-equal?
+ (call-with-prompt 'test-tag
+   (lambda ()
+     (parameterize ((prompt-param 'inside))
+       (abort-to-prompt 'test-tag 'result)))
+   (lambda (k val)
+     (cons val (prompt-param))))
+ '(result . outside))
+
+;; Empty parameterize
+(assert-equal? (parameterize () 42) 42)
+
+;; Non-idempotent converter: converter applied on restore (matching Chez)
+(define ni-param (make-parameter 1 (lambda (x) (+ x 1))))
+(assert-equal? (ni-param) 2)
+(assert-equal? (parameterize ((ni-param 4)) (ni-param)) 5)
+(assert-equal? (ni-param) 3)

--- a/tests/task_param_inherit.rs
+++ b/tests/task_param_inherit.rs
@@ -1,0 +1,5 @@
+#![cfg(feature = "tokio")]
+
+mod common;
+
+common::run_test!(task_param_inherit);

--- a/tests/task_param_inherit.scm
+++ b/tests/task_param_inherit.scm
@@ -1,0 +1,25 @@
+(import (rnrs) (rnrs parameters) (async) (test))
+
+(define p (make-parameter 42))
+
+(p 99)
+
+;; A spawned task sees the parent's parameter values as of spawn time.
+(let ((f (spawn (lambda () (p)))))
+  (assert-equal? (await f) 99))
+
+;; Values are snapshotted, not shared: a direct set in the child is
+;; visible to the child but never to the parent.
+(let ((f (spawn (lambda () (p 5) (p)))))
+  (assert-equal? (await f) 5)
+  (assert-equal? (p) 99))
+
+;; parameterize in the child is likewise invisible to the parent.
+(let ((f (spawn (lambda () (parameterize ((p 7)) (p))))))
+  (assert-equal? (await f) 7)
+  (assert-equal? (p) 99))
+
+;; future bodies run lazily but snapshot at creation time.
+(let ((f (future (lambda () (p)))))
+  (p 123)
+  (assert-equal? (await f) 99))

--- a/tests/thread_async_bridge.rs
+++ b/tests/thread_async_bridge.rs
@@ -1,0 +1,3 @@
+mod common;
+
+common::run_test!(thread_async_bridge);

--- a/tests/thread_async_bridge.scm
+++ b/tests/thread_async_bridge.scm
@@ -1,0 +1,11 @@
+(import (rnrs) (threads) (test))
+
+;; A spawned OS thread must be able to run async bridges: display compiles
+;; to an AsyncBridge under the async feature. This used to raise "attempt
+;; to apply async function in a sync-only context".
+(define h
+  (spawn (lambda ()
+           (display "")
+           'done)))
+
+(assert-equal? (join h) 'done)

--- a/tests/thread_join.rs
+++ b/tests/thread_join.rs
@@ -1,0 +1,3 @@
+mod common;
+
+common::run_test!(thread_join);

--- a/tests/thread_join.scm
+++ b/tests/thread_join.scm
@@ -1,0 +1,5 @@
+(import (rnrs) (threads) (test))
+
+;; join must wait for the thread to finish even when it wins the race to
+;; the result cell.
+(assert-equal? (join (spawn (lambda () 42))) 42)

--- a/tests/thread_param_inherit.rs
+++ b/tests/thread_param_inherit.rs
@@ -1,0 +1,3 @@
+mod common;
+
+common::run_test!(thread_param_inherit);

--- a/tests/thread_param_inherit.scm
+++ b/tests/thread_param_inherit.scm
@@ -1,0 +1,20 @@
+(import (rnrs) (rnrs parameters) (threads) (test))
+
+(define p (make-parameter 42))
+
+(p 99)
+
+;; A spawned thread sees the parent's parameter values as of spawn time.
+(let ((h (spawn (lambda () (p)))))
+  (assert-equal? (join h) 99))
+
+;; Values are snapshotted, not shared: a direct set in the child is
+;; visible to the child but never to the parent.
+(let ((h (spawn (lambda () (p 5) (p)))))
+  (assert-equal? (join h) 5)
+  (assert-equal? (p) 99))
+
+;; parameterize in the child is likewise invisible to the parent.
+(let ((h (spawn (lambda () (parameterize ((p 7)) (p))))))
+  (assert-equal? (join h) 7)
+  (assert-equal? (p) 99))


### PR DESCRIPTION
Stacked on #315; the diff includes its commits until it merges.

## What this adds

`make-parameter`, `parameter?`, and `parameterize` matching R6RS/R7RS/SRFI-39 semantics. All test expectations verified against Chez Scheme.

```scheme
(define p (make-parameter 42))
(p)          ; => 42
(p 10)       ; => 42 (returns previous)
(p)          ; => 10

(parameterize ((p 100))
  (p))       ; => 100
(p)          ; => 10 (restored)
```

Converter functions are applied to the initial value, on direct set, on `parameterize` entry, and on `parameterize` restore. This matches Chez, including non-idempotent converters:

```scheme
(define ni (make-parameter 1 (lambda (x) (+ x 1))))
(ni)                              ; => 2
(parameterize ((ni 4)) (ni))      ; => 5
(ni)                              ; => 3 (converter applied on restore)
```

## How it works

The Rust side is minimal:
- `Parameter` struct holding a unique id, default value, and converter
- `parameter_cells: HashMap<usize, Cell>` on `ContBarrier` for per-task storage
- Bridges for raw operations: `%make-parameter`, `%parameter-ref`, `%parameter-set!`, `%parameter-extract`, `%parameter-converter`, `parameter?`

All logic lives in Scheme (`scheme/rnrs/parameters.sls`):
- `make-parameter` returns a `case-lambda` that reads/writes through the bridges, applying the converter on write
- `parameterize` uses `dynamic-wind` to swap values through the parameter procedure, so the converter is applied on every swap (no custom dynstack entries needed)
- `%parameter-extract` finds the raw `Parameter` in a parameter procedure's closure env

## Thread inheritance

`spawn` ((threads) and (async)) and `future` are cps bridges so they see the caller's barrier, seeding the child with `ContBarrier::child()` instead of a fresh barrier. `child()` snapshots the parameter values rather than cloning the cell map: cells are shared Gc pointers that `parameter_set` writes through, so a plain clone would let a child's set or parameterize mutate the parent's bindings. Chez semantics: children copy, never share.

## Test plan

- [x] Basic parameter ops, predicates
- [x] Converter applied to init, on set, on parameterize, on restore
- [x] Non-idempotent converter (verified against Chez)
- [x] Parameterize scoping and nesting
- [x] Multiple parameters in one parameterize
- [x] call/cc re-entry (mutations preserved via swap)
- [x] dynamic-wind interaction
- [x] Prompt abort
- [x] Inheritance snapshots for OS threads and tokio tasks
- [x] R6RS + all existing tests pass
