### PR TITLE
[2/5] Fix the join race and give spawned OS threads an async context

### DIFF
--- a/benches/fib.rs
+++ b/benches/fib.rs
@@ -1,8 +1,4 @@
-use scheme_rs::{
-    env::TopLevelEnvironment,
-    proc::{ContBarrier, Procedure},
-    value::Expect1,
-};
+use scheme_rs::{env::TopLevelEnvironment, proc::Procedure, value::Expect1};
 
 use criterion::*;
 use scheme_rs_macros::{maybe_async, maybe_await};
@@ -26,9 +22,7 @@ fn fib_fn() -> Procedure {
 fn fib_benchmark(c: &mut Criterion) {
     let proc = fib_fn();
 
-    c.bench_function("fib 10000", |b| {
-        b.iter(|| proc.call(&[], &mut ContBarrier::new()))
-    });
+    c.bench_function("fib 10000", |b| b.iter(|| proc.call(&[])));
 }
 
 #[cfg(feature = "async")]
@@ -40,7 +34,7 @@ fn fib_benchmark(c: &mut Criterion) {
     c.bench_function("fib 10000", |b| {
         b.to_async(&runtime).iter(|| {
             let val = proc.clone();
-            async move { val.call(&[], &mut ContBarrier::new()).await }
+            async move { val.call(&[]).await }
         })
     });
 }

--- a/benches/integrate.rs
+++ b/benches/integrate.rs
@@ -1,8 +1,4 @@
-use scheme_rs::{
-    env::TopLevelEnvironment,
-    proc::{ContBarrier, Procedure},
-    value::Expect1,
-};
+use scheme_rs::{env::TopLevelEnvironment, proc::Procedure, value::Expect1};
 
 use criterion::*;
 use scheme_rs_macros::{maybe_async, maybe_await};
@@ -21,7 +17,7 @@ fn integrate_benchmark(c: &mut Criterion) {
     let proc = integrate_fn();
 
     c.bench_function("integrate", |b| {
-        b.iter(|| proc.call(&[], &mut ContBarrier::new()));
+        b.iter(|| proc.call(&[]));
     });
 }
 
@@ -34,7 +30,7 @@ fn integrate_benchmark(c: &mut Criterion) {
     c.bench_function("integrate", |b| {
         b.to_async(&runtime).iter(|| {
             let val = proc.clone();
-            async move { val.call(&[], &mut ContBarrier::new()).await }
+            async move { val.call(&[]).await }
         })
     });
 }

--- a/benches/yin_yang.rs
+++ b/benches/yin_yang.rs
@@ -1,8 +1,4 @@
-use scheme_rs::{
-    env::TopLevelEnvironment,
-    proc::{ContBarrier, Procedure},
-    value::Expect1,
-};
+use scheme_rs::{env::TopLevelEnvironment, proc::Procedure, value::Expect1};
 
 use criterion::*;
 use scheme_rs_macros::{maybe_async, maybe_await};
@@ -28,7 +24,7 @@ fn yin_yang_benchmark(c: &mut Criterion) {
     let proc = yin_yang_fn();
 
     c.bench_function("yin_yang", |b| {
-        b.iter(|| proc.call(&[], &mut ContBarrier::new()));
+        b.iter(|| proc.call(&[]));
     });
 }
 
@@ -41,7 +37,7 @@ fn yin_yang_benchmark(c: &mut Criterion) {
     c.bench_function("yin_yang", |b| {
         b.to_async(&runtime).iter(|| {
             let val = proc.clone();
-            async move { val.call(&[], &mut ContBarrier::new()).await }
+            async move { val.call(&[]).await }
         })
     });
 }

--- a/src/docs.md
+++ b/src/docs.md
@@ -75,7 +75,7 @@ anywhere.
 
 ```rust
 # use scheme_rs::{
-# env::TopLevelEnvironment, value::Value, proc::{ContBarrier, Procedure},
+# env::TopLevelEnvironment, value::Value, proc::Procedure,
 # };
 # let env = TopLevelEnvironment::new_repl();
 # env.import("(library (rnrs))".parse().unwrap());
@@ -93,14 +93,7 @@ anywhere.
 # .try_into()
 # .unwrap();
 # let factorial = factorial.cast::<Procedure>().unwrap();
-let [result] = factorial
-    .call(
-        &[Value::from(5)],
-        &mut ContBarrier::new(),
-    )
-    .unwrap()
-    .try_into()
-    .unwrap();
+let [result] = factorial.call(&[Value::from(5)]).unwrap().try_into().unwrap();
 let result: u64 = result.try_into().unwrap();
 assert_eq!(result, 120);
 ```
@@ -273,16 +266,14 @@ pub fn call_with_var(
     _rest_args: &[Value],
     barrier: &mut ContBarrier,
 ) -> Result<Application, Exception> {
-    // Set up the new dynamic state and add the param
-    let result = {
-        let mut var = 0u32;
-        let mut new_barrier = ContBarrier::from(barrier.save());
-        new_barrier.add_param("var", &mut var);
-    
-        // Call the thunk arg with the new dyn state:
-        let thunk: Procedure = args[0].clone().try_into()?;
-        thunk.call(&[], &mut new_barrier)?
-    };
+    // Set up a barrier with the new param
+    let mut var = 0u32;
+    let mut new_barrier = ContBarrier::new();
+    new_barrier.add_param("var", &mut var);
+
+    // Call the thunk arg with the new barrier:
+    let thunk: Procedure = args[0].clone().try_into()?;
+    let result = thunk.call_with_barrier(&[], &mut new_barrier)?;
 
     // Return to the continuation:
     Ok(barrier.call_cont(result))

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -54,7 +54,10 @@ use crate::{
     gc::Trace,
     lists::slice_to_list,
     ports::{IoDecodingError, IoEncodingError, IoError, IoReadError, IoWriteError},
-    proc::{Application, ContBarrier, ContPtr, DynStackElem, FuncPtr, Procedure, pop_dyn_stack},
+    proc::{
+        Application, ContBarrier, ContPtr, DynStackElem, FuncPtr, Procedure,
+        current_exception_handler, pop_dyn_stack, pop_dyn_stack_cont, push_dyn_stack,
+    },
     records::{Embeddable, Embedded, RecordTypeDescriptor, rtd},
     registry::{bridge, cps_bridge},
     runtime::Runtime,
@@ -936,13 +939,13 @@ pub fn with_exception_handler(
     let handler: Procedure = handler.clone().try_into()?;
     let thunk: Procedure = thunk.clone().try_into()?;
 
-    barrier.push_dyn_stack(DynStackElem::ExceptionHandler(handler));
+    push_dyn_stack(DynStackElem::ExceptionHandler(handler));
 
     let (req_args, var) = barrier.cont_formals();
 
     barrier.push_cont(
         Vec::new(),
-        ContPtr::Continuation(pop_dyn_stack),
+        ContPtr::Continuation(pop_dyn_stack_cont),
         req_args,
         var,
     );
@@ -1005,7 +1008,7 @@ unsafe extern "C" fn unwind_to_exception_handler(
         let barrier = barrier.as_mut().unwrap_unchecked();
 
         loop {
-            let app = match barrier.pop_dyn_stack() {
+            let app = match pop_dyn_stack() {
                 None => {
                     // If the stack is empty, we should return the error
                     Application::halt_err(raised)
@@ -1062,13 +1065,13 @@ pub fn raise_continuable(
     _env: &[Value],
     args: &[Value],
     _rest_args: &[Value],
-    barrier: &mut ContBarrier,
+    _barrier: &mut ContBarrier,
 ) -> Result<Application, Exception> {
     let [condition] = args else {
         unreachable!();
     };
 
-    let Some(handler) = barrier.current_exception_handler() else {
+    let Some(handler) = current_exception_handler() else {
         return Ok(Application::halt_err(condition.clone()));
     };
 

--- a/src/futures.rs
+++ b/src/futures.rs
@@ -15,7 +15,7 @@ use tokio::{
 use crate::{
     exceptions::Exception,
     ports::{BufferMode, Port},
-    proc::{ContBarrier, Procedure},
+    proc::{Procedure, dyn_state_snapshot, with_dyn_state},
     records::{Embeddable, Embedded, RecordTypeDescriptor, rtd},
     strings::WideString,
     value::Value,
@@ -36,7 +36,11 @@ unsafe impl Embeddable for Future {
 
 #[bridge(name = "future", lib = "(async)")]
 pub async fn make_future(proc: Procedure) -> Result<Vec<Value>, Exception> {
-    let future: Future = async move { proc.call(&[], &mut ContBarrier::new()).await }
+    // Snapshot the current dynamic state now, at creation time: the
+    // future's body runs later, whenever it's awaited, possibly from an
+    // unrelated dynamic extent.
+    let snapshot = dyn_state_snapshot();
+    let future: Future = with_dyn_state(snapshot, async move { proc.call(&[]).await })
         .boxed()
         .shared();
     let future = Value::from(future);
@@ -46,7 +50,11 @@ pub async fn make_future(proc: Procedure) -> Result<Vec<Value>, Exception> {
 #[bridge(name = "spawn", lib = "(async)")]
 pub async fn spawn(task: &Value) -> Result<Vec<Value>, Exception> {
     let task: Procedure = task.clone().try_into()?;
-    let task = tokio::task::spawn(async move { task.call(&[], &mut ContBarrier::new()).await });
+    let snapshot = dyn_state_snapshot();
+    let task = tokio::task::spawn(with_dyn_state(
+        snapshot,
+        async move { task.call(&[]).await },
+    ));
     let future: Future = async move { task.await.unwrap() }.boxed().shared();
     let future = Value::from(future);
     Ok(vec![future])

--- a/src/hashtables.rs
+++ b/src/hashtables.rs
@@ -13,7 +13,7 @@ use std::{
 use crate::{
     exceptions::Exception,
     gc::Trace,
-    proc::{ContBarrier, Procedure},
+    proc::Procedure,
     records::{Embeddable, Embedded, RecordTypeDescriptor},
     registry::bridge,
     strings::WideString,
@@ -67,28 +67,22 @@ impl HashTableInner {
 
     #[cfg(not(feature = "async"))]
     pub fn hash(&self, val: Value) -> Result<u64, Exception> {
-        self.hash.call(&[val], &mut ContBarrier::new())?.expect1()
+        self.hash.call(&[val])?.expect1()
     }
 
     #[cfg(feature = "async")]
     pub fn hash(&self, val: Value) -> Result<u64, Exception> {
-        self.hash
-            .call_sync(&[val], &mut ContBarrier::new())?
-            .expect1()
+        self.hash.call_sync(&[val])?.expect1()
     }
 
     #[cfg(not(feature = "async"))]
     pub fn eq(&self, lhs: Value, rhs: Value) -> Result<bool, Exception> {
-        self.eq
-            .call(&[lhs, rhs], &mut ContBarrier::new())?
-            .expect1()
+        self.eq.call(&[lhs, rhs])?.expect1()
     }
 
     #[cfg(feature = "async")]
     pub fn eq(&self, lhs: Value, rhs: Value) -> Result<bool, Exception> {
-        self.eq
-            .call_sync(&[lhs, rhs], &mut ContBarrier::new())?
-            .expect1()
+        self.eq.call_sync(&[lhs, rhs])?.expect1()
     }
 
     /// Equivalent to `hashtable-ref`
@@ -177,13 +171,10 @@ impl HashTableInner {
         for entry in table.iter_hash_mut(hash) {
             if entry.hash == hash && self.eq(key.clone(), entry.key.clone())? {
                 #[cfg(not(feature = "async"))]
-                let updated =
-                    proc.call(slice::from_ref(&entry.val), &mut ContBarrier::new())?[0].clone();
+                let updated = proc.call(slice::from_ref(&entry.val))?[0].clone();
 
                 #[cfg(feature = "async")]
-                let updated = proc
-                    .call_sync(slice::from_ref(&entry.val), &mut ContBarrier::new())?[0]
-                    .clone();
+                let updated = proc.call_sync(slice::from_ref(&entry.val))?[0].clone();
 
                 entry.val = updated;
                 return Ok(());
@@ -191,10 +182,10 @@ impl HashTableInner {
         }
 
         #[cfg(not(feature = "async"))]
-        let updated = proc.call(slice::from_ref(default), &mut ContBarrier::new())?[0].clone(); // 
+        let updated = proc.call(slice::from_ref(default))?[0].clone();
 
         #[cfg(feature = "async")]
-        let updated = proc.call_sync(slice::from_ref(default), &mut ContBarrier::new())?[0].clone();
+        let updated = proc.call_sync(slice::from_ref(default))?[0].clone();
 
         table.insert_unique(
             hash,

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -25,7 +25,11 @@ use crate::{
     enumerations::{EnumerationSet, EnumerationType},
     exceptions::{Assertion, Error, Exception, raise},
     gc::Trace,
-    proc::{Application, ContBarrier, ContPtr, DynStackElem, FuncPtr, Procedure, pop_dyn_stack},
+    proc::{
+        Application, ContBarrier, ContPtr, DynStackElem, FuncPtr, Procedure,
+        current_input_port as dyn_current_input_port,
+        current_output_port as dyn_current_output_port, pop_dyn_stack_cont, push_dyn_stack,
+    },
     records::{Embeddable, Embedded, RecordTypeDescriptor},
     strings::WideString,
     symbols::Symbol,
@@ -686,14 +690,11 @@ mod __impl {
     pub(super) fn proc_to_read_fn(read: Procedure) -> ReadFn {
         Box::new(move |_, buff, start, count| {
             let [read] = read
-                .call(
-                    &[
-                        Value::from(buff.clone()),
-                        Value::from(start),
-                        Value::from(count),
-                    ],
-                    &mut ContBarrier::new(),
-                )
+                .call(&[
+                    Value::from(buff.clone()),
+                    Value::from(start),
+                    Value::from(count),
+                ])
                 .map_err(|err| err.add_condition(IoReadError::new()))?
                 .try_into()
                 .map_err(|_| {
@@ -711,14 +712,11 @@ mod __impl {
     pub(super) fn proc_to_write_fn(write: Procedure) -> WriteFn {
         Box::new(move |_, buff, start, count| {
             let _ = write
-                .call(
-                    &[
-                        Value::from(buff.clone()),
-                        Value::from(start),
-                        Value::from(count),
-                    ],
-                    &mut ContBarrier::new(),
-                )
+                .call(&[
+                    Value::from(buff.clone()),
+                    Value::from(start),
+                    Value::from(count),
+                ])
                 .map_err(|err| err.add_condition(IoReadError::new()))?;
             Ok(())
         })
@@ -727,7 +725,7 @@ mod __impl {
     pub(super) fn proc_to_get_pos_fn(get_pos: Procedure) -> GetPosFn {
         Box::new(move |_| {
             let [pos] = get_pos
-                .call(&[], &mut ContBarrier::new())
+                .call(&[])
                 .map_err(|err| err.add_condition(IoError::new()))?
                 .try_into()
                 .map_err(|_| {
@@ -743,7 +741,7 @@ mod __impl {
     pub(super) fn proc_to_set_pos_fn(set_pos: Procedure) -> SetPosFn {
         Box::new(move |_, pos| {
             let _ = set_pos
-                .call(&[Value::from(pos)], &mut ContBarrier::new())
+                .call(&[Value::from(pos)])
                 .map_err(|err| err.add_condition(IoError::new()))?;
             Ok(())
         })
@@ -752,7 +750,7 @@ mod __impl {
     pub(super) fn proc_to_close_fn(close: Procedure) -> CloseFn {
         Box::new(move |_| {
             let _ = close
-                .call(&[], &mut ContBarrier::new())
+                .call(&[])
                 .map_err(|err| err.add_condition(IoError::new()))?;
             Ok(())
         })
@@ -949,14 +947,11 @@ mod __impl {
             let read = read.clone();
             Box::pin(async move {
                 let [read] = read
-                    .call(
-                        &[
-                            Value::from(buff.clone()),
-                            Value::from(start),
-                            Value::from(count),
-                        ],
-                        &mut ContBarrier::new(),
-                    )
+                    .call(&[
+                        Value::from(buff.clone()),
+                        Value::from(start),
+                        Value::from(count),
+                    ])
                     .await
                     .map_err(|err| err.add_condition(IoReadError::new()))?
                     .try_into()
@@ -980,14 +975,11 @@ mod __impl {
             let write = write.clone();
             Box::pin(async move {
                 let _ = write
-                    .call(
-                        &[
-                            Value::from(buff.clone()),
-                            Value::from(start),
-                            Value::from(count),
-                        ],
-                        &mut ContBarrier::new(),
-                    )
+                    .call(&[
+                        Value::from(buff.clone()),
+                        Value::from(start),
+                        Value::from(count),
+                    ])
                     .await
                     .map_err(|err| err.add_condition(IoReadError::new()))?;
                 Ok(())
@@ -1000,7 +992,7 @@ mod __impl {
             let get_pos = get_pos.clone();
             Box::pin(async move {
                 let [pos] = get_pos
-                    .call(&[], &mut ContBarrier::new())
+                    .call(&[])
                     .await
                     .map_err(|err| err.add_condition(IoError::new()))?
                     .try_into()
@@ -1022,7 +1014,7 @@ mod __impl {
             let set_pos = set_pos.clone();
             Box::pin(async move {
                 let _ = set_pos
-                    .call(&[Value::from(pos)], &mut ContBarrier::new())
+                    .call(&[Value::from(pos)])
                     .await
                     .map_err(|err| err.add_condition(IoError::new()))?;
                 Ok(())
@@ -1035,7 +1027,7 @@ mod __impl {
             let close = close.clone();
             Box::pin(async move {
                 let _ = close
-                    .call(&[], &mut ContBarrier::new())
+                    .call(&[])
                     .await
                     .map_err(|err| err.add_condition(IoError::new()))?;
                 Ok(())
@@ -1899,14 +1891,11 @@ impl CustomTextualPortData {
             && let len = self.output_buffer.len()
             && len != 0
         {
-            maybe_await!(write.call(
-                &[
-                    Value::from(self.output_buffer.clone()),
-                    Value::from(0usize),
-                    Value::from(len)
-                ],
-                &mut ContBarrier::new()
-            ))?;
+            maybe_await!(write.call(&[
+                Value::from(self.output_buffer.clone()),
+                Value::from(0usize),
+                Value::from(len)
+            ]))?;
             self.output_buffer.clear();
         }
 
@@ -1921,14 +1910,11 @@ impl CustomTextualPortData {
                     (self.chars_read, self.input_buffer.len() - self.chars_read)
                 }
             };
-            let read: usize = maybe_await!(read.call(
-                &[
-                    Value::from(self.input_buffer.clone()),
-                    Value::from(start),
-                    Value::from(count)
-                ],
-                &mut ContBarrier::new()
-            ))?
+            let read: usize = maybe_await!(read.call(&[
+                Value::from(self.input_buffer.clone()),
+                Value::from(start),
+                Value::from(count)
+            ]))?
             .expect1()?;
 
             if read == 0 {
@@ -1983,11 +1969,11 @@ impl CustomTextualPortData {
             && let Some(set_pos) = port_info.set_pos.as_ref()
             && self.chars_read > 0
         {
-            let curr_pos: u64 = maybe_await!(get_pos.call(&[], &mut ContBarrier::new()))?
+            let curr_pos: u64 = maybe_await!(get_pos.call(&[]))?
                 .expect1()
                 .map_err(|err: Exception| err.add_condition(IoWriteError::new()))?;
             let seek_to = curr_pos - (self.chars_read as u64 - self.input_pos as u64);
-            maybe_await!(set_pos.call(&[Value::from(seek_to)], &mut ContBarrier::new()))?;
+            maybe_await!(set_pos.call(&[Value::from(seek_to)]))?;
             self.chars_read = 0;
             self.input_pos = 0;
         }
@@ -1998,14 +1984,11 @@ impl CustomTextualPortData {
                     {
                         self.output_buffer.0.chars.write()[0] = chr;
                     }
-                    maybe_await!(write.call(
-                        &[
-                            Value::from(self.output_buffer.clone()),
-                            Value::from(0usize),
-                            Value::from(1usize)
-                        ],
-                        &mut ContBarrier::new()
-                    ))?;
+                    maybe_await!(write.call(&[
+                        Value::from(self.output_buffer.clone()),
+                        Value::from(0usize),
+                        Value::from(1usize)
+                    ]))?;
                 }
             }
             BufferMode::Line => {
@@ -2022,14 +2005,11 @@ impl CustomTextualPortData {
                         }
                     }
                     let len = self.output_buffer.len();
-                    maybe_await!(write.call(
-                        &[
-                            Value::from(self.output_buffer.clone()),
-                            Value::from(0usize),
-                            Value::from(len)
-                        ],
-                        &mut ContBarrier::new()
-                    ))?;
+                    maybe_await!(write.call(&[
+                        Value::from(self.output_buffer.clone()),
+                        Value::from(0usize),
+                        Value::from(len)
+                    ]))?;
                     self.output_buffer.clear();
                 }
             }
@@ -2037,14 +2017,11 @@ impl CustomTextualPortData {
                 for chr in s.chars() {
                     let len = self.output_buffer.len();
                     if len >= BUFFER_SIZE {
-                        maybe_await!(write.call(
-                            &[
-                                Value::from(self.output_buffer.clone()),
-                                Value::from(0usize),
-                                Value::from(len)
-                            ],
-                            &mut ContBarrier::new()
-                        ))?;
+                        maybe_await!(write.call(&[
+                            Value::from(self.output_buffer.clone()),
+                            Value::from(0usize),
+                            Value::from(len)
+                        ]))?;
                         self.output_buffer.clear();
                     }
                     self.output_buffer.0.chars.write().push(chr);
@@ -2065,14 +2042,11 @@ impl CustomTextualPortData {
             return Err(Exception::io_error("port is closed"));
         }
 
-        maybe_await!(write.call(
-            &[
-                Value::from(self.output_buffer.clone()),
-                Value::from(0usize),
-                Value::from(self.output_buffer.len()),
-            ],
-            &mut ContBarrier::new()
-        ))?;
+        maybe_await!(write.call(&[
+            Value::from(self.output_buffer.clone()),
+            Value::from(0usize),
+            Value::from(self.output_buffer.len()),
+        ]))?;
         self.output_buffer.clear();
 
         Ok(())
@@ -2088,7 +2062,7 @@ impl CustomTextualPortData {
             return Err(Exception::io_error("port is closed"));
         }
 
-        maybe_await!(get_pos.call(&[], &mut ContBarrier::new()))?.expect1()
+        maybe_await!(get_pos.call(&[]))?.expect1()
     }
 
     #[maybe_async]
@@ -2105,21 +2079,18 @@ impl CustomTextualPortData {
 
         // Reset the buffers
         if let Some(write) = port_info.write.as_ref() {
-            maybe_await!(write.call(
-                &[
-                    Value::from(self.output_buffer.clone()),
-                    Value::from(0usize),
-                    Value::from(self.output_buffer.len()),
-                ],
-                &mut ContBarrier::new()
-            ))?;
+            maybe_await!(write.call(&[
+                Value::from(self.output_buffer.clone()),
+                Value::from(0usize),
+                Value::from(self.output_buffer.len()),
+            ]))?;
             self.output_buffer.clear();
         }
 
         self.chars_read = 0;
         self.input_pos = 0;
 
-        maybe_await!(set_pos.call(&[Value::from(pos)], &mut ContBarrier::new()))?;
+        maybe_await!(set_pos.call(&[Value::from(pos)]))?;
 
         Ok(())
     }
@@ -2136,7 +2107,7 @@ impl CustomTextualPortData {
         maybe_await!(self.flush(port_info))?;
 
         if let Some(close) = port_info.close.as_ref() {
-            maybe_await!(close.call(&[], &mut ContBarrier::new()))?;
+            maybe_await!(close.call(&[]))?;
         }
 
         Ok(())
@@ -3802,7 +3773,7 @@ pub fn current_input_port(
     _rest_args: &[Value],
     barrier: &mut ContBarrier,
 ) -> Result<Application, Exception> {
-    let current_input_port = barrier.current_input_port();
+    let current_input_port = dyn_current_input_port();
     Ok(barrier.call_cont(vec![Value::from(current_input_port)]))
 }
 
@@ -3813,7 +3784,7 @@ pub fn current_output_port(
     _rest_args: &[Value],
     barrier: &mut ContBarrier,
 ) -> Result<Application, Exception> {
-    let current_input_port = barrier.current_output_port();
+    let current_input_port = dyn_current_output_port();
     Ok(barrier.call_cont(vec![Value::from(current_input_port)]))
 }
 
@@ -4580,14 +4551,14 @@ pub fn with_input_from_file(
         Some(Transcoder::native()),
     );
 
-    barrier.push_dyn_stack(DynStackElem::CurrentInputPort(port.clone()));
+    push_dyn_stack(DynStackElem::CurrentInputPort(port.clone()));
 
     let (req_args, var) = barrier.cont_formals();
 
     // Stack (bottom to top): the outer continuation, pop_dyn_stack (removes the
     // current-input-port entry), then close_port_and_call_k (closes the port).
     // The thunk returns to the top.
-    barrier.push_cont([], ContPtr::Continuation(pop_dyn_stack), req_args, var);
+    barrier.push_cont([], ContPtr::Continuation(pop_dyn_stack_cont), req_args, var);
 
     barrier.push_cont(
         [Value::from(port.clone())],
@@ -4643,11 +4614,11 @@ pub fn with_output_to_file(
         Some(Transcoder::native()),
     );
 
-    barrier.push_dyn_stack(DynStackElem::CurrentOutputPort(port.clone()));
+    push_dyn_stack(DynStackElem::CurrentOutputPort(port.clone()));
 
     let (req_args, var) = barrier.cont_formals();
 
-    barrier.push_cont([], ContPtr::Continuation(pop_dyn_stack), req_args, var);
+    barrier.push_cont([], ContPtr::Continuation(pop_dyn_stack_cont), req_args, var);
 
     barrier.push_cont(
         [Value::from(port.clone())],
@@ -4692,7 +4663,7 @@ pub fn read_char(
     barrier: &mut ContBarrier<'_>,
 ) -> Result<Application, Exception> {
     let input_port = match rest_args {
-        [] => barrier.current_input_port(),
+        [] => dyn_current_input_port(),
         [input_port] => input_port.clone().try_into()?,
         _ => {
             return Ok(raise(
@@ -4723,7 +4694,7 @@ pub fn peek_char(
     barrier: &mut ContBarrier<'_>,
 ) -> Result<Application, Exception> {
     let input_port = match rest_args {
-        [] => barrier.current_input_port(),
+        [] => dyn_current_input_port(),
         [input_port] => input_port.clone().try_into()?,
         _ => {
             return Ok(raise(
@@ -4754,7 +4725,7 @@ pub fn read(
     barrier: &mut ContBarrier<'_>,
 ) -> Result<Application, Exception> {
     let input_port = match rest_args {
-        [] => barrier.current_input_port(),
+        [] => dyn_current_input_port(),
         [input_port] => input_port.clone().try_into()?,
         _ => {
             return Ok(raise(
@@ -4787,7 +4758,7 @@ pub fn write_char(
     let [chr] = args else { unreachable!() };
     let chr: char = chr.clone().try_into()?;
     let output_port = match rest_args {
-        [] => barrier.current_output_port(),
+        [] => dyn_current_output_port(),
         [output_port] => output_port.clone().try_into()?,
         _ => {
             return Ok(raise(
@@ -4814,7 +4785,7 @@ pub fn newline(
     barrier: &mut ContBarrier<'_>,
 ) -> Result<Application, Exception> {
     let output_port = match rest_args {
-        [] => barrier.current_output_port(),
+        [] => dyn_current_output_port(),
         [output_port] => output_port.clone().try_into()?,
         _ => {
             return Ok(raise(
@@ -4843,7 +4814,7 @@ pub fn display(
     let [obj] = args else { unreachable!() };
     let obj = format!("{obj}");
     let output_port = match rest_args {
-        [] => barrier.current_output_port(),
+        [] => dyn_current_output_port(),
         [output_port] => output_port.clone().try_into()?,
         _ => {
             return Ok(raise(
@@ -4872,7 +4843,7 @@ pub fn write(
     let [obj] = args else { unreachable!() };
     let obj = format!("{obj:?}");
     let output_port = match rest_args {
-        [] => barrier.current_output_port(),
+        [] => dyn_current_output_port(),
         [output_port] => output_port.clone().try_into()?,
         _ => {
             return Ok(raise(

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -92,6 +92,7 @@ use crate::{
     ports::{BufferMode, Port, Transcoder},
     records::{Embeddable, Embedded, RecordTypeDescriptor, rtd},
     registry::BridgeFnDebugInfo,
+    runtime::Runtime,
     symbols::Symbol,
     syntax::Span,
     value::Value,
@@ -99,8 +100,11 @@ use crate::{
 };
 use scheme_rs_macros::{cps_bridge, maybe_async, maybe_await};
 use smallvec::SmallVec;
+#[cfg(feature = "async")]
+use std::future::Future;
 use std::{
     any::Any,
+    cell::RefCell,
     collections::HashMap,
     fmt,
     mem::MaybeUninit,
@@ -474,7 +478,17 @@ impl Procedure {
 
     /// Applies `args` to the procedure and returns the values it evaluates to.
     #[maybe_async]
-    pub fn call(
+    pub fn call(&self, args: &[Value]) -> Result<Vec<Value>, Exception> {
+        maybe_await!(self.call_with_barrier(args, &mut ContBarrier::new()))
+    }
+
+    #[cfg(feature = "async")]
+    pub fn call_sync(&self, args: &[Value]) -> Result<Vec<Value>, Exception> {
+        self.call_sync_with_barrier(args, &mut ContBarrier::new())
+    }
+
+    #[maybe_async]
+    pub fn call_with_barrier(
         &self,
         args: &[Value],
         barrier: &mut ContBarrier<'_>,
@@ -483,7 +497,7 @@ impl Procedure {
     }
 
     #[cfg(feature = "async")]
-    pub fn call_sync(
+    pub fn call_sync_with_barrier(
         &self,
         args: &[Value],
         barrier: &mut ContBarrier<'_>,
@@ -600,10 +614,9 @@ impl Application {
         }
     }
 
-    /// Evaluate the application - and all subsequent application - until all that
-    /// remains are values. This is the main trampoline of the evaluation engine.
+    /// The main trampoline loop.
     #[maybe_async]
-    pub fn eval(mut self, barrier: &mut ContBarrier<'_>) -> Result<Vec<Value>, Exception> {
+    fn eval_inner(mut self, barrier: &mut ContBarrier<'_>) -> Result<Vec<Value>, Exception> {
         loop {
             let Application { op, args } = self;
             self = match op {
@@ -617,9 +630,33 @@ impl Application {
         }
     }
 
+    /// Evaluate the application - and all subsequent application - until all that
+    /// remains are values. This is the main trampoline of the evaluation engine.
+    ///
+    /// Publishes the runtime's root dynamic state if none is already active;
+    /// reuses whatever's published otherwise.
     #[cfg(feature = "async")]
-    /// Just like [eval] but throws an error if we encounter an async function.
-    pub fn eval_sync(mut self, barrier: &mut ContBarrier) -> Result<Vec<Value>, Exception> {
+    pub async fn eval(self, barrier: &mut ContBarrier<'_>) -> Result<Vec<Value>, Exception> {
+        if !DYN_STATE.is_published() {
+            with_root_dyn_state(Runtime::handle(), self.eval_inner(barrier)).await
+        } else {
+            self.eval_inner(barrier).await
+        }
+    }
+
+    /// Evaluate the application - and all subsequent application - until all that
+    /// remains are values. This is the main trampoline of the evaluation engine.
+    #[cfg(not(feature = "async"))]
+    pub fn eval(self, barrier: &mut ContBarrier<'_>) -> Result<Vec<Value>, Exception> {
+        if !DYN_STATE.is_published() {
+            with_root_dyn_state_sync(Runtime::handle(), move || self.eval_inner(barrier))
+        } else {
+            self.eval_inner(barrier)
+        }
+    }
+
+    #[cfg(feature = "async")]
+    fn eval_sync_inner(mut self, barrier: &mut ContBarrier) -> Result<Vec<Value>, Exception> {
         loop {
             let Application { op, args } = self;
             self = match op {
@@ -630,6 +667,16 @@ impl Application {
                     return Err(Exception(args.pop().unwrap()));
                 }
             };
+        }
+    }
+
+    #[cfg(feature = "async")]
+    /// Just like [eval] but throws an error if we encounter an async function.
+    pub fn eval_sync(self, barrier: &mut ContBarrier) -> Result<Vec<Value>, Exception> {
+        if !DYN_STATE.is_published() {
+            with_root_dyn_state_sync(Runtime::handle(), move || self.eval_sync_inner(barrier))
+        } else {
+            self.eval_sync_inner(barrier)
         }
     }
 }
@@ -705,16 +752,268 @@ type Param<'a> = &'a mut (dyn Any + Send + Sync);
 #[cfg(not(feature = "async"))]
 type Param<'a> = &'a mut dyn Any;
 
+/// The dynamic state of a running program, owned by the trampoline as a
+/// local and published as the current dynamic state for an evaluation.
+#[derive(Trace)]
+pub struct DynState {
+    /// The active dynamic stack
+    dyn_stack: Vec<DynStackElem>,
+    /// Whether this is the state currently being evaluated. False for a
+    /// dormant/idle slot; [`DynStateSlot::is_published`] is just this flag.
+    published: bool,
+}
+
+impl DynState {
+    fn new() -> Self {
+        Self {
+            dyn_stack: Vec::new(),
+            published: false,
+        }
+    }
+
+    /// Current ports cross a spawn boundary; winders, handlers, and prompts
+    /// do not.
+    fn spawn_snapshot(&self) -> DynState {
+        DynState {
+            dyn_stack: self
+                .dyn_stack
+                .iter()
+                .filter(|elem| elem.crosses_spawn())
+                .cloned()
+                .collect(),
+            published: false,
+        }
+    }
+}
+
+impl Default for DynState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DynStackElem {
+    /// Only current ports survive a spawn.
+    fn crosses_spawn(&self) -> bool {
+        matches!(
+            self,
+            DynStackElem::CurrentInputPort(_) | DynStackElem::CurrentOutputPort(_)
+        )
+    }
+}
+
+std::thread_local! {
+    /// Sync-trampoline dynamic state. Always holds a `DynState`; dormant
+    /// (not currently evaluating) is `published == false`, not absence.
+    static CURRENT_DYN_STATE: RefCell<DynState> = RefCell::new(DynState::new());
+}
+
+#[cfg(feature = "async")]
+tokio::task_local! {
+    /// Async-trampoline dynamic state (survives work-stealing).
+    static TASK_DYN_STATE: RefCell<DynState>;
+}
+
+pub(crate) struct DynStateGuard(DynState);
+
+impl Drop for DynStateGuard {
+    fn drop(&mut self) {
+        CURRENT_DYN_STATE.with(|c| *c.borrow_mut() = std::mem::take(&mut self.0));
+    }
+}
+
+/// Unified access to the thread-local and task-local dynamic state.
+struct DynStateSlot;
+
+static DYN_STATE: DynStateSlot = DynStateSlot;
+
+impl DynStateSlot {
+    fn is_published(&self) -> bool {
+        #[cfg(feature = "async")]
+        if let Ok(published) = TASK_DYN_STATE.try_with(|c| c.borrow().published) {
+            return published;
+        }
+        CURRENT_DYN_STATE.with(|c| c.borrow().published)
+    }
+
+    /// Short borrow of the current dynamic state; never hold across
+    /// re-entry.
+    fn with<R>(&self, f: impl FnOnce(&mut DynState) -> R) -> R {
+        #[cfg(feature = "async")]
+        {
+            let task_active = TASK_DYN_STATE.try_with(|_| ()).is_ok();
+            if task_active {
+                return TASK_DYN_STATE.with(|c| f(&mut c.borrow_mut()));
+            }
+        }
+        CURRENT_DYN_STATE.with(|c| f(&mut c.borrow_mut()))
+    }
+
+    /// Publish state for a synchronous evaluation.
+    fn enter_sync(&self, mut state: DynState) -> DynStateGuard {
+        state.published = true;
+        let prev = CURRENT_DYN_STATE.with(|c| std::mem::replace(&mut *c.borrow_mut(), state));
+        DynStateGuard(prev)
+    }
+
+    /// Publish state for an async evaluation.
+    #[cfg(feature = "async")]
+    async fn enter_async<F: Future>(&self, mut state: DynState, fut: F) -> F::Output {
+        state.published = true;
+        TASK_DYN_STATE.scope(RefCell::new(state), fut).await
+    }
+}
+
+pub(crate) fn with_dyn_state_sync<R>(state: DynState, f: impl FnOnce() -> R) -> R {
+    let _guard = DYN_STATE.enter_sync(state);
+    f()
+}
+
+#[cfg(feature = "async")]
+pub(crate) async fn with_dyn_state<F: Future>(state: DynState, fut: F) -> F::Output {
+    DYN_STATE.enter_async(state, fut).await
+}
+
+/// On drop, takes whatever's published and checks it back into `runtime`,
+/// marked no longer published. Runs before the enclosing [`DynStateGuard`]
+/// (declared first, so dropped last) restores the previous (dormant) slot,
+/// so it still observes the finished state.
+struct RootDynStateCheckin(Runtime);
+
+impl Drop for RootDynStateCheckin {
+    fn drop(&mut self) {
+        let mut state = DYN_STATE.with(std::mem::take);
+        state.published = false;
+        self.0.restore_dyn_state(state);
+    }
+}
+
+/// Checks out `runtime`'s root dynamic state and publishes it for the
+/// duration of `f`, then checks the (possibly mutated) state back in so
+/// later top-level entries into `runtime` observe the same parameter
+/// roots, current ports, etc.
+pub(crate) fn with_root_dyn_state_sync<R>(runtime: Runtime, f: impl FnOnce() -> R) -> R {
+    let state = runtime.checkout_dyn_state();
+    let _guard = DYN_STATE.enter_sync(state);
+    let _checkin = RootDynStateCheckin(runtime);
+    f()
+}
+
+/// Async counterpart to [`with_root_dyn_state_sync`]. The checkin runs
+/// inside the scoped future so it can still read the task-local dynamic
+/// state once `fut` completes (or is dropped without completing).
+///
+/// Boxed so this call's stack frame stays a fixed, small size regardless of
+/// what `fut` contains: macro transformers re-enter `eval` (and thus this
+/// function) once per level of macro nesting in the source being expanded,
+/// so an unboxed frame here grows with source-level macro nesting depth and
+/// can overflow the stack on deeply macro-heavy code.
+#[cfg(feature = "async")]
+pub(crate) async fn with_root_dyn_state<F: Future + Send>(runtime: Runtime, fut: F) -> F::Output
+where
+    F::Output: Send,
+{
+    let state = runtime.checkout_dyn_state();
+    let boxed: std::pin::Pin<Box<dyn Future<Output = F::Output> + Send>> = Box::pin(async move {
+        let _checkin = RootDynStateCheckin(runtime);
+        fut.await
+    });
+    DYN_STATE.enter_async(state, boxed).await
+}
+
+// TODO: We should certainly try to optimize these functions. Linear
+// searching isn't _great_, although in practice I can't imagine this stack
+// will ever get very large.
+
+pub fn current_exception_handler() -> Option<Procedure> {
+    DYN_STATE.with(|s| {
+        s.dyn_stack.iter().rev().find_map(|elem| match elem {
+            DynStackElem::ExceptionHandler(proc) => Some(proc.clone()),
+            _ => None,
+        })
+    })
+}
+
+pub fn current_input_port() -> Port {
+    DYN_STATE.with(|s| {
+        s.dyn_stack
+            .iter()
+            .rev()
+            .find_map(|elem| match elem {
+                DynStackElem::CurrentInputPort(port) => Some(port.clone()),
+                _ => None,
+            })
+            .unwrap_or_else(|| {
+                Port::new(
+                    "<stdin>",
+                    #[cfg(not(feature = "async"))]
+                    std::io::stdin(),
+                    #[cfg(feature = "tokio")]
+                    tokio::io::stdin(),
+                    BufferMode::Line,
+                    Some(Transcoder::native()),
+                )
+            })
+    })
+}
+
+pub fn current_output_port() -> Port {
+    DYN_STATE.with(|s| {
+        s.dyn_stack
+            .iter()
+            .rev()
+            .find_map(|elem| match elem {
+                DynStackElem::CurrentOutputPort(port) => Some(port.clone()),
+                _ => None,
+            })
+            .unwrap_or_else(|| {
+                Port::new(
+                    "<stdout>",
+                    #[cfg(not(feature = "async"))]
+                    std::io::stdout(),
+                    #[cfg(feature = "tokio")]
+                    tokio::io::stdout(),
+                    // TODO: Probably should change this to line, but that
+                    // doesn't play nicely with rustyline
+                    BufferMode::None,
+                    Some(Transcoder::native()),
+                )
+            })
+    })
+}
+
+pub(crate) fn push_dyn_stack(elem: DynStackElem) {
+    DYN_STATE.with(|s| s.dyn_stack.push(elem));
+}
+
+pub(crate) fn pop_dyn_stack() -> Option<DynStackElem> {
+    DYN_STATE.with(|s| s.dyn_stack.pop())
+}
+
+pub(crate) fn dyn_stack_last() -> Option<DynStackElem> {
+    DYN_STATE.with(|s| s.dyn_stack.last().cloned())
+}
+
+pub(crate) fn dyn_stack_len() -> usize {
+    DYN_STATE.with(|s| s.dyn_stack.len())
+}
+
+pub(crate) fn dyn_stack_is_empty() -> bool {
+    DYN_STATE.with(|s| s.dyn_stack.is_empty())
+}
+
+pub(crate) fn dyn_state_snapshot() -> DynState {
+    if !DYN_STATE.is_published() {
+        return DynState::new();
+    }
+    DYN_STATE.with(|s| s.spawn_snapshot())
+}
+
 /// A continuation barrier. Escape procedures created within a continuation
 /// barrier cannot be called within another barrier.
-///
-/// This structure also contains the dynamic state of the running program
-/// including winders, exception handlers, continuation marks, and parameters.
 pub struct ContBarrier<'a> {
     /// The id of the barrier. Checked when calling an escape procedure
     id: usize,
-    /// The active dynamic stack
-    dyn_stack: Vec<DynStackElem>,
     /// The current live continuations for the program. Effectively the call
     /// stack. Includes active [continuation marks](https://srfi.schemers.org/srfi-157/srfi-157.html).
     cont_stack: ContStack,
@@ -728,7 +1027,6 @@ impl<'a> ContBarrier<'a> {
 
         let mut this = Self {
             id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
-            dyn_stack: Vec::new(),
             cont_stack: ContStack::default(),
             params: HashMap::new(),
         };
@@ -739,12 +1037,14 @@ impl<'a> ContBarrier<'a> {
         this
     }
 
+    /// Captures the barrier id and a copy of the current dyn_stack/cont_stack,
+    /// for restoring later (call/cc, prompts).
     pub fn save(&self) -> SavedDynamicState {
-        SavedDynamicState {
+        DYN_STATE.with(|s| SavedDynamicState {
             id: self.id,
-            dyn_stack: self.dyn_stack.clone(),
+            dyn_stack: s.dyn_stack.clone(),
             cont_stack: self.cont_stack.clone(),
-        }
+        })
     }
 
     pub fn add_param(
@@ -775,6 +1075,8 @@ impl<'a> ContBarrier<'a> {
 
     /// Constructs a child barrier from the current barrier, extracting an array
     /// of parameters that are not automatically passed onto the child.
+    /// dyn_stack isn't copied here (it's ambient, already shared); cont_stack
+    /// is, via `save`/`From<SavedDynamicState>`.
     pub fn child_barrier<'b, 'c, const N: usize>(
         &'b mut self,
         params: [impl Into<Symbol>; N],
@@ -819,81 +1121,6 @@ impl<'a> ContBarrier<'a> {
             .unwrap()
             .marks
             .insert(tag, val);
-    }
-
-    // TODO: We should certainly try to optimize these functions. Linear
-    // searching isn't _great_, although in practice I can't imagine this stack
-    // will ever get very large.
-
-    pub fn current_exception_handler(&self) -> Option<Procedure> {
-        self.dyn_stack.iter().rev().find_map(|elem| match elem {
-            DynStackElem::ExceptionHandler(proc) => Some(proc.clone()),
-            _ => None,
-        })
-    }
-
-    pub fn current_input_port(&self) -> Port {
-        self.dyn_stack
-            .iter()
-            .rev()
-            .find_map(|elem| match elem {
-                DynStackElem::CurrentInputPort(port) => Some(port.clone()),
-                _ => None,
-            })
-            .unwrap_or_else(|| {
-                Port::new(
-                    "<stdin>",
-                    #[cfg(not(feature = "async"))]
-                    std::io::stdin(),
-                    #[cfg(feature = "tokio")]
-                    tokio::io::stdin(),
-                    BufferMode::Line,
-                    Some(Transcoder::native()),
-                )
-            })
-    }
-
-    pub fn current_output_port(&self) -> Port {
-        self.dyn_stack
-            .iter()
-            .rev()
-            .find_map(|elem| match elem {
-                DynStackElem::CurrentOutputPort(port) => Some(port.clone()),
-                _ => None,
-            })
-            .unwrap_or_else(|| {
-                Port::new(
-                    "<stdout>",
-                    #[cfg(not(feature = "async"))]
-                    std::io::stdout(),
-                    #[cfg(feature = "tokio")]
-                    tokio::io::stdout(),
-                    // TODO: Probably should change this to line, but that
-                    // doesn't play nicely with rustyline
-                    BufferMode::None,
-                    Some(Transcoder::native()),
-                )
-            })
-    }
-
-    pub(crate) fn push_dyn_stack(&mut self, elem: DynStackElem) {
-        self.dyn_stack.push(elem);
-    }
-
-    pub(crate) fn pop_dyn_stack(&mut self) -> Option<DynStackElem> {
-        self.dyn_stack.pop()
-    }
-
-    pub(crate) fn dyn_stack_last(&self) -> Option<&DynStackElem> {
-        self.dyn_stack.last()
-    }
-
-    pub(crate) fn dyn_stack_len(&self) -> usize {
-        self.dyn_stack.len()
-    }
-
-    pub(crate) fn dyn_stack_is_empty(&self) -> bool {
-        self.dyn_stack.is_empty()
     }
 
     /// Push a continuation onto the current call stack.
@@ -944,7 +1171,7 @@ impl<'a> ContBarrier<'a> {
                 app.assume_init()
             },
             ContPtr::PromptBarrier { .. } => {
-                self.pop_dyn_stack();
+                pop_dyn_stack();
                 let mut values: Vec<Value> = args[..curr_frame.num_required_args].to_vec();
                 if curr_frame.variadic {
                     list_to_vec(&args[curr_frame.num_required_args], &mut values);
@@ -979,7 +1206,8 @@ where
     }
 }
 
-/// A copy of [`ContBarrier`] without mutable parameters
+/// Independent of the current dynamic state: a plain value, safe to embed
+/// and pass around Scheme code.
 #[derive(Clone, Trace)]
 pub struct SavedDynamicState {
     id: usize,
@@ -999,8 +1227,10 @@ impl SavedDynamicState {
 
 impl From<SavedDynamicState> for ContBarrier<'_> {
     fn from(value: SavedDynamicState) -> Self {
+        // dyn_stack isn't restored here: it's ambient (shared with whatever
+        // published it), not barrier-local, so a sibling/child barrier
+        // already observes it without copying.
         ContBarrier {
-            dyn_stack: value.dyn_stack,
             cont_stack: value.cont_stack,
             ..Default::default()
         }
@@ -1022,7 +1252,8 @@ pub(crate) enum DynStackElem {
     CurrentOutputPort(Port),
 }
 
-pub(crate) unsafe extern "C" fn pop_dyn_stack(
+/// Named distinctly from the free function `pop_dyn_stack` to avoid a clash.
+pub(crate) unsafe extern "C" fn pop_dyn_stack_cont(
     _env: *const Value,
     args: *const Value,
     barrier: *mut ContBarrier,
@@ -1030,7 +1261,7 @@ pub(crate) unsafe extern "C" fn pop_dyn_stack(
 ) {
     unsafe {
         let barrier = barrier.as_mut().unwrap_unchecked();
-        barrier.pop_dyn_stack();
+        pop_dyn_stack();
 
         let (num_required_args, variadic) = barrier.cont_formals();
         let mut collected_args: Vec<_> = (0..num_required_args)
@@ -1160,8 +1391,15 @@ fn escape_procedure(
         .cast::<Embedded<SavedDynamicState>>()
         .unwrap();
 
+    // Cross-barrier escape must halt this trampoline (halt_err) instead of
+    // raising through the exception-handler search. With shared dynamic state,
+    // raising would find a handler belonging to an ancestor evaluation (e.g.
+    // guard's), whose own escape continuation also crosses this barrier,
+    // causing a second rejection with no handler left to catch it.
     if saved_barrier.id != barrier.id {
-        return Err(Exception::error("attempt to cross continuation barrier"));
+        return Ok(Application::halt_err(Value::from(Exception::error(
+            "attempt to cross continuation barrier",
+        ))));
     }
 
     let args = args.iter().chain(rest_args).cloned().collect::<Vec<_>>();
@@ -1196,12 +1434,11 @@ unsafe extern "C" fn unwind(
 
         let barrier = barrier.as_mut().unwrap_unchecked();
 
-        while !barrier.dyn_stack_is_empty()
-            && (barrier.dyn_stack_len() > dest_stack_read.dyn_stack_len()
-                || barrier.dyn_stack_last()
-                    != dest_stack_read.dyn_stack_get(barrier.dyn_stack_len() - 1))
+        while !dyn_stack_is_empty()
+            && (dyn_stack_len() > dest_stack_read.dyn_stack_len()
+                || dyn_stack_last().as_ref() != dest_stack_read.dyn_stack_get(dyn_stack_len() - 1))
         {
-            match barrier.pop_dyn_stack() {
+            match pop_dyn_stack() {
                 None => {
                     break;
                 }
@@ -1255,14 +1492,11 @@ unsafe extern "C" fn wind(
         let winder = env.add(2).as_ref().unwrap().clone();
         if winder.is_true() {
             let winder = winder.try_to::<Embedded<Winder>>().unwrap();
-            barrier.push_dyn_stack(DynStackElem::Winder(winder.as_ref().clone()));
+            push_dyn_stack(DynStackElem::Winder(winder.as_ref().clone()));
         }
 
-        while barrier.dyn_stack_len() < dest_stack_read.dyn_stack_len() {
-            match dest_stack_read
-                .dyn_stack_get(barrier.dyn_stack_len())
-                .cloned()
-            {
+        while dyn_stack_len() < dest_stack_read.dyn_stack_len() {
+            match dest_stack_read.dyn_stack_get(dyn_stack_len()).cloned() {
                 None => {
                     break;
                 }
@@ -1279,7 +1513,7 @@ unsafe extern "C" fn wind(
                     (*out).write(app);
                     return;
                 }
-                Some(elem) => barrier.push_dyn_stack(elem),
+                Some(elem) => push_dyn_stack(elem),
             }
         }
 
@@ -1427,7 +1661,7 @@ pub(crate) unsafe extern "C" fn call_body_thunk(
 
         let barrier = barrier.as_mut().unwrap_unchecked();
 
-        barrier.push_dyn_stack(DynStackElem::Winder(Winder {
+        push_dyn_stack(DynStackElem::Winder(Winder {
             in_thunk: in_thunk.clone().try_into().unwrap(),
             out_thunk: out_thunk.clone().try_into().unwrap(),
         }));
@@ -1452,7 +1686,7 @@ pub(crate) unsafe extern "C" fn call_out_thunks(
         let body_thunk_res = args.as_ref().unwrap().clone();
 
         let barrier = barrier.as_mut().unwrap_unchecked();
-        barrier.pop_dyn_stack();
+        pop_dyn_stack();
 
         barrier.push_cont(
             vec![body_thunk_res],
@@ -1512,7 +1746,7 @@ pub fn call_with_prompt(
 
     let barrier_id = BARRIER_ID.fetch_add(1, Ordering::Relaxed);
 
-    barrier.push_dyn_stack(DynStackElem::Prompt(Prompt {
+    push_dyn_stack(DynStackElem::Prompt(Prompt {
         tag,
         handler: handler.clone().try_into().unwrap(),
         barrier_id,
@@ -1569,10 +1803,13 @@ unsafe extern "C" fn unwind_to_prompt(
         let barrier = barrier.as_mut().unwrap_unchecked();
 
         loop {
-            let app = match barrier.pop_dyn_stack() {
-                None => Application::halt_err(Value::from(Exception::error(format!(
-                    "no prompt tag {tag} found"
-                )))),
+            let app = match pop_dyn_stack() {
+                None => {
+                    // If the stack is empty, we should return the error
+                    Application::halt_err(Value::from(Exception::error(format!(
+                        "no prompt tag {tag} found"
+                    ))))
+                }
                 Some(DynStackElem::Prompt(Prompt {
                     tag: prompt_tag,
                     barrier_id,
@@ -1611,8 +1848,7 @@ unsafe extern "C" fn unwind_to_prompt(
                         .unwrap();
                     let prompt_delimited_barrier = SavedDynamicState {
                         id: saved_barrier.id,
-                        dyn_stack: saved_barrier.as_ref().dyn_stack[barrier.dyn_stack_len() + 1..]
-                            .to_vec(),
+                        dyn_stack: saved_barrier.as_ref().dyn_stack[dyn_stack_len() + 1..].to_vec(),
                         cont_stack: delimited_cont,
                     };
 
@@ -1706,7 +1942,7 @@ unsafe extern "C" fn wind_delim(
         let winder = env.add(3).as_ref().unwrap().clone();
         if winder.is_true() {
             let winder = winder.try_to::<Embedded<Winder>>().unwrap();
-            barrier.push_dyn_stack(DynStackElem::Winder(winder.as_ref().clone()));
+            push_dyn_stack(DynStackElem::Winder(winder.as_ref().clone()));
         }
 
         while let Some(elem) = dest_stack.as_ref().dyn_stack_get(idx) {
@@ -1727,7 +1963,7 @@ unsafe extern "C" fn wind_delim(
                 (*out).write(Application::new(winder.in_thunk.clone(), Vec::new()));
                 return;
             }
-            barrier.push_dyn_stack(elem.clone());
+            push_dyn_stack(elem.clone());
         }
 
         let args: Vector = args.try_into().unwrap();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -15,8 +15,8 @@ use crate::{
     num,
     ports::{BufferMode, Port, Transcoder},
     proc::{
-        Application, ContBarrier, ContPtr, ContinuationPtr, FuncPtr, ProcDebugInfo, Procedure,
-        ProcedureInner, UserPtr,
+        Application, ContBarrier, ContPtr, ContinuationPtr, DynState, FuncPtr, ProcDebugInfo,
+        Procedure, ProcedureInner, UserPtr,
     },
     registry::Registry,
     symbols::Symbol,
@@ -186,6 +186,19 @@ impl Runtime {
     pub fn source_cache(&self) -> MutexGuard<'_, SourceCache> {
         self.0.source_cache.lock()
     }
+
+    /// Takes the runtime's persistent root dynamic state, leaving a fresh
+    /// one behind. Paired with [`Runtime::restore_dyn_state`] to publish the
+    /// root state for a top-level evaluation without holding the runtime
+    /// lock for the evaluation's duration.
+    pub(crate) fn checkout_dyn_state(&self) -> DynState {
+        std::mem::take(&mut self.0.dyn_state.lock())
+    }
+
+    /// Checks a dynamic state back in as the runtime's root state.
+    pub(crate) fn restore_dyn_state(&self, state: DynState) {
+        *self.0.dyn_state.lock() = state;
+    }
 }
 
 #[allow(unused)]
@@ -220,6 +233,11 @@ pub(crate) struct RuntimeInner {
     pub(crate) globals_pool: Mutex<HashSet<Global>>,
     pub(crate) debug_info: DebugInfo,
     pub(crate) source_cache: Mutex<SourceCache>,
+    /// The root dynamic state, persistent for the runtime's lifetime.
+    /// Checked out for the duration of each top-level evaluation (see
+    /// [`Runtime::checkout_dyn_state`]) so parameter roots, current ports,
+    /// etc. outlive any single eval call.
+    dyn_state: Mutex<DynState>,
 }
 
 impl Default for RuntimeInner {
@@ -253,6 +271,7 @@ impl RuntimeInner {
             globals_pool: Mutex::new(HashSet::new()),
             debug_info: DebugInfo::default(),
             source_cache: Mutex::new(SourceCache::default()),
+            dyn_state: Mutex::new(DynState::default()),
         }
     }
 }
@@ -505,10 +524,8 @@ unsafe extern "C" fn set_continuation_mark(
     unsafe {
         let tag = Value::from_raw_inc_rc(tag);
         let val = Value::from_raw_inc_rc(val);
-        barrier
-            .as_mut()
-            .unwrap()
-            .set_continuation_mark(tag.cast().unwrap(), val);
+        let barrier = barrier.as_mut().unwrap_unchecked();
+        barrier.set_continuation_mark(tag.cast().unwrap(), val);
     }
 }
 

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     exceptions::{CompoundCondition, Exception, Message, SyntaxViolation, Who},
     gc::Trace,
     ports::Port,
-    proc::{ContBarrier, Procedure},
+    proc::Procedure,
     records::{Embeddable, Embedded, RecordTypeDescriptor, rtd},
     registry::bridge,
     symbols::Symbol,
@@ -286,8 +286,7 @@ impl Syntax {
         input.add_scope(intro_scope);
 
         // Call the transformer with the input:
-        let transformer_output =
-            maybe_await!(transformer.call(&[Value::from(input)], &mut ContBarrier::new()))?;
+        let transformer_output = maybe_await!(transformer.call(&[Value::from(input)]))?;
 
         let output: Value = transformer_output.expect1()?;
         let mut output = Syntax::wrap(output, self.span());

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -22,6 +22,8 @@ use crate::{
 pub struct JoinHandle {
     #[trace(skip)]
     id: ThreadId,
+    #[trace(skip)]
+    thread: Mutex<Option<thread::JoinHandle<()>>>,
     result: Gc<Mutex<Result<Vec<Value>, Exception>>>,
 }
 
@@ -61,19 +63,39 @@ pub fn spawn(thunk: Procedure) -> Result<Vec<Value>, Exception> {
         });
     });
     let id = join_handle.thread().id();
-    Ok(vec![Value::from(JoinHandle { id, result: cell })])
+    Ok(vec![Value::from(JoinHandle {
+        id,
+        thread: Mutex::new(Some(join_handle)),
+        result: cell,
+    })])
 }
 
 #[bridge(name = "join", lib = "(threads (1))")]
 pub fn join(handle: Embedded<JoinHandle>) -> Result<Vec<Value>, Exception> {
+    join_inner(&handle)
+}
+
+fn join_inner(handle: &JoinHandle) -> Result<Vec<Value>, Exception> {
     let curr_id = thread::current().id();
     if curr_id == handle.id {
-        Err(Exception::error(format!(
+        return Err(Exception::error(format!(
             "thread {curr_id:?} attempted to join itself"
-        )))
-    } else {
-        handle.result.lock().clone()
+        )));
     }
+    // The scrutinee's MutexGuard is held across join() (if-let temporary
+    // scope), which is what blocks concurrent joiners until the thread has
+    // finished; don't hoist the lock() into its own binding.
+    if let Some(thread) = handle.thread.lock().take()
+        && let Err(payload) = thread.join()
+    {
+        let msg = payload
+            .downcast_ref::<&str>()
+            .map(ToString::to_string)
+            .or_else(|| payload.downcast_ref::<String>().cloned())
+            .unwrap_or_else(|| "unknown panic".to_string());
+        *handle.result.lock() = Err(Exception::error(format!("thread panicked: {msg}")));
+    }
+    handle.result.lock().clone()
 }
 
 #[bridge(name = "sleep", lib = "(threads (1))")]
@@ -85,4 +107,33 @@ pub fn sleep(ms: u64) -> Result<Vec<Value>, Exception> {
 #[bridge(name = "join-handle?", lib = "(threads (1))")]
 pub fn join_handle_pred(obj: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(obj.is_a::<Embedded<JoinHandle>>())])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::exceptions::{CompoundCondition, Message};
+
+    fn exception_message(err: &Exception) -> String {
+        let cond: Embedded<CompoundCondition> = Option::from(&err.0).expect("compound condition");
+        cond.0
+            .iter()
+            .find_map(|c| Option::<Embedded<Message>>::from(c).map(|m| m.message.clone()))
+            .expect("message condition")
+    }
+
+    #[test]
+    fn join_surfaces_panics() {
+        let thread = thread::spawn(|| panic!("boom"));
+        let handle = JoinHandle {
+            id: thread.thread().id(),
+            thread: Mutex::new(Some(thread)),
+            result: Gc::new(Mutex::new(Ok(Vec::new()))),
+        };
+        let err = join_inner(&handle).unwrap_err();
+        assert!(exception_message(&err).contains("boom"));
+        // Subsequent joins see the persisted error, not the default cell.
+        let err = join_inner(&handle).unwrap_err();
+        assert!(exception_message(&err).contains("boom"));
+    }
 }

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -13,7 +13,7 @@ use scheme_rs_macros::bridge;
 use crate::{
     exceptions::Exception,
     gc::{Gc, Trace},
-    proc::{ContBarrier, Procedure},
+    proc::{Procedure, dyn_state_snapshot, with_dyn_state_sync},
     records::{Embeddable, Embedded, RecordTypeDescriptor, rtd},
     value::Value,
 };
@@ -41,18 +41,24 @@ unsafe impl Embeddable for JoinHandle {
 pub fn spawn(thunk: Procedure) -> Result<Vec<Value>, Exception> {
     let cell = Gc::new(Mutex::new(Ok(Vec::new())));
     let cell_cloned = cell.clone();
+    // Snapshot the current dynamic state now, on the spawning thread: the
+    // spawned thread starts a new dynamic extent and must not run the
+    // parent's winders or see its exception handlers.
+    let snapshot = dyn_state_snapshot();
     let join_handle = thread::spawn(move || {
         let mut cell_write = cell_cloned.lock();
 
-        #[cfg(not(feature = "async"))]
-        {
-            *cell_write = thunk.call(&[], &mut ContBarrier::new());
-        }
+        with_dyn_state_sync(snapshot, || {
+            #[cfg(not(feature = "async"))]
+            {
+                *cell_write = thunk.call(&[]);
+            }
 
-        #[cfg(feature = "async")]
-        {
-            *cell_write = thunk.call_sync(&[], &mut ContBarrier::new());
-        }
+            #[cfg(feature = "async")]
+            {
+                *cell_write = thunk.call_sync(&[]);
+            }
+        });
     });
     let id = join_handle.thread().id();
     Ok(vec![Value::from(JoinHandle { id, result: cell })])

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -47,6 +47,10 @@ pub fn spawn(thunk: Procedure) -> Result<Vec<Value>, Exception> {
     // spawned thread starts a new dynamic extent and must not run the
     // parent's winders or see its exception handlers.
     let snapshot = dyn_state_snapshot();
+    // Capture the runtime handle so the child thread can block on the thunk
+    // inside the reactor context, letting async bridges use timers and IO.
+    #[cfg(feature = "async")]
+    let handle = tokio::runtime::Handle::try_current().ok();
     let join_handle = thread::spawn(move || {
         let mut cell_write = cell_cloned.lock();
 
@@ -58,7 +62,10 @@ pub fn spawn(thunk: Procedure) -> Result<Vec<Value>, Exception> {
 
             #[cfg(feature = "async")]
             {
-                *cell_write = thunk.call_sync(&[]);
+                *cell_write = match handle {
+                    Some(handle) => handle.block_on(thunk.call(&[])),
+                    None => futures::executor::block_on(thunk.call(&[])),
+                };
             }
         });
     });

--- a/tests/blockon_pending.rs
+++ b/tests/blockon_pending.rs
@@ -1,0 +1,17 @@
+#![cfg(all(feature = "async", feature = "tokio"))]
+
+#[allow(unused)]
+mod common;
+
+// multi_thread is required: the main test thread blocks in join() while
+// another worker must drive the timer that completes the spawned thunk.
+#[tokio::test(flavor = "multi_thread")]
+async fn blockon_pending() {
+    use scheme_rs::runtime::Runtime;
+    use std::path::Path;
+
+    let rt = Runtime::handle();
+    rt.run_program(Path::new("tests/blockon_pending.scm"))
+        .await
+        .expect("Test blockon_pending failed");
+}

--- a/tests/blockon_pending.scm
+++ b/tests/blockon_pending.scm
@@ -1,0 +1,7 @@
+(import (rnrs) (test) (only (threads) spawn join) (only (async) sleep))
+
+;; sleep from (async) suspends on a tokio timer, forcing a real Poll::Pending
+;; round-trip through the block_on in the spawned OS thread instead of
+;; first-poll completion.
+(let ((h (spawn (lambda () (sleep 5) 'woke))))
+  (assert-equal? (join h) 'woke))

--- a/tests/dynamic_state_inheritance.rs
+++ b/tests/dynamic_state_inheritance.rs
@@ -1,0 +1,3 @@
+mod common;
+
+common::run_test!(dynamic_state_inheritance);

--- a/tests/dynamic_state_inheritance.scm
+++ b/tests/dynamic_state_inheritance.scm
@@ -1,0 +1,43 @@
+(import (rnrs) (test) (threads (1)))
+
+;; 1. A hashtable hash function must observe the exception handler installed
+;; by its caller. Without re-entry sharing the caller's DynState, it would
+;; get a fresh, empty one, so raise-continuable finds no handler and the
+;; guard below would produce 'no-handler-seen.
+(define ht
+  (make-hashtable
+   (lambda (k) (raise-continuable 'need-hash))
+   eq?))
+
+(define handler-result
+  (guard (e (#t 'no-handler-seen))
+    (with-exception-handler
+      (lambda (c) 42)
+      (lambda ()
+        (hashtable-set! ht 'a 1)
+        (hashtable-ref ht 'a #f)))))
+
+(assert-equal? handler-result 1)
+
+;; 2. Escape procedures still cannot cross the Rust re-entry frame: the
+;; fresh barrier id at the callback boundary rejects the jump.
+(assert-equal?
+ (call/cc
+  (lambda (k)
+    (let ((ht2 (make-hashtable (lambda (key) (k 'escaped)) eq?)))
+      (guard (e (#t 'blocked))
+        (hashtable-set! ht2 'x 1)
+        'not-blocked))))
+ 'blocked)
+
+;; 3. A spawned thread must not run the parent's winders. Each parent
+;; winder fires exactly once, from the parent.
+(define order '())
+(dynamic-wind
+    (lambda () (set! order (cons 'in order)))
+    (lambda ()
+      (join (spawn (lambda ()
+                     (guard (e (#t 'caught))
+                       (error 'child "boom"))))))
+    (lambda () (set! order (cons 'out order))))
+(assert-equal? order '(out in))

--- a/tests/thread_async_bridge.rs
+++ b/tests/thread_async_bridge.rs
@@ -1,0 +1,3 @@
+mod common;
+
+common::run_test!(thread_async_bridge);

--- a/tests/thread_async_bridge.scm
+++ b/tests/thread_async_bridge.scm
@@ -1,0 +1,11 @@
+(import (rnrs) (threads) (test))
+
+;; A spawned OS thread must be able to run async bridges: display compiles
+;; to an AsyncBridge under the async feature. This used to raise "attempt
+;; to apply async function in a sync-only context".
+(define h
+  (spawn (lambda ()
+           (display "")
+           'done)))
+
+(assert-equal? (join h) 'done)

--- a/tests/thread_join.rs
+++ b/tests/thread_join.rs
@@ -1,0 +1,3 @@
+mod common;
+
+common::run_test!(thread_join);

--- a/tests/thread_join.scm
+++ b/tests/thread_join.scm
@@ -1,0 +1,5 @@
+(import (rnrs) (threads) (test))
+
+;; join must wait for the thread to finish even when it wins the race to
+;; the result cell.
+(assert-equal? (join (spawn (lambda () 42))) 42)


### PR DESCRIPTION
- `join` fix: it read the result cell guarded only by a mutex the child locks as its first action, returning the initial empty result if it won that race. It now holds the `std::thread::JoinHandle`, joins before reading, and stores a panicking thunk's payload as an exception that every joiner sees.
- `spawn` captures `Handle::try_current()` before `thread::spawn`. The child runs the thunk under `handle.block_on` when a runtime exists (timers and IO work) and under `futures::executor::block_on` otherwise. The fallback is safe because nothing nests block_on on one thread: `call_sync` raises instead of blocking.
- Tests: an async bridge (`display`) inside a spawn thunk, which raised "attempt to apply async function in a sync-only context" before; a timer thunk driving a real `Poll::Pending` round-trip through `Handle::block_on` on a multi_thread runtime; the join race pattern plus a panic-propagation unit test.