### PR TITLE
Better record layout

### DIFF
--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -1542,7 +1542,7 @@ pub fn define_condition_type(tokens: TokenStream) -> TokenStream {
 
         }
 
-        impl ::scheme_rs::records::Embeddable for #rust_name {
+        unsafe impl ::scheme_rs::records::Embeddable for #rust_name {
             fn rtd() -> std::sync::Arc<::scheme_rs::records::RecordTypeDescriptor> {
                 ::scheme_rs::records::rtd!(
                     ty: #rust_name,
@@ -1561,7 +1561,6 @@ pub fn define_condition_type(tokens: TokenStream) -> TokenStream {
                 #parent::rtd()
                     .is_subtype_of(rtd)
                     .then(|| &self.parent as &dyn ::scheme_rs::records::Embeddable)
-                          // ::scheme_rs::records::into_scheme_compatible(self.parent.clone()))
             }
 
             fn get_field(&self, k: usize) -> Result<::scheme_rs::value::Value, ::scheme_rs::exceptions::Exception> {

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -1569,14 +1569,26 @@ pub fn define_condition_type(tokens: TokenStream) -> TokenStream {
                     _ => Err(Exception::error(format!("invalid record field: {k}"))),
                 }
             }
+
+            fn debug_fmt(
+                &self,
+                _circular_values: &mut indexmap::IndexMap<::scheme_rs::value::Value, bool>,
+                f: &mut std::fmt::Formatter<'_>
+            ) -> std::fmt::Result {
+                use std::fmt::Debug;
+                write!(f, "#<{}", #scheme_name)?;
+                #dbg
+                write!(f, ">")?;
+                Ok(())
+            }
         }
 
         impl std::fmt::Debug for #rust_name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                #dbg
-                Ok(())
+                self.debug_fmt(&mut indexmap::IndexMap::default(), f)
             }
         }
+
     }
     .into()
 }

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -1134,6 +1134,7 @@ impl RtdField {
 
 struct Rtd {
     name: LitStr,
+    ty: Type,
     parent: Option<Expr>,
     opaque: Option<Expr>,
     sealed: Option<LitBool>,
@@ -1146,6 +1147,7 @@ struct Rtd {
 impl Parse for Rtd {
     fn parse(input: ParseStream) -> Result<Self> {
         let mut name = None;
+        let mut ty = None;
         let mut parent = None;
         let mut opaque = None;
         let mut sealed = None;
@@ -1161,6 +1163,12 @@ impl Parse for Rtd {
                 }
                 let _: Token![:] = input.parse()?;
                 name = Some(input.parse()?);
+            } else if keyword == "ty" {
+                if ty.is_some() {
+                    return Err(Error::new(keyword.span(), "duplicate definition of ty"));
+                }
+                let _: Token![:] = input.parse()?;
+                ty = Some(input.parse()?);
             } else if keyword == "parent" {
                 if parent.is_some() {
                     return Err(Error::new(keyword.span(), "duplicate definition of parent"));
@@ -1222,6 +1230,10 @@ impl Parse for Rtd {
             return Err(Error::new(input.span(), "name field is required"));
         };
 
+        let Some(ty) = ty else {
+            return Err(Error::new(input.span(), "ty field is required"));
+        };
+
         if !sealed.as_ref().map_or(false, LitBool::value) && constructor.is_none() {
             return Err(Error::new(
                 input.span(),
@@ -1231,6 +1243,7 @@ impl Parse for Rtd {
 
         Ok(Rtd {
             name,
+            ty,
             parent,
             opaque,
             sealed,
@@ -1247,6 +1260,7 @@ impl Parse for Rtd {
 pub fn rtd(tokens: TokenStream) -> TokenStream {
     let Rtd {
         name,
+        ty,
         parent,
         opaque,
         sealed,
@@ -1256,6 +1270,25 @@ pub fn rtd(tokens: TokenStream) -> TokenStream {
         lib,
     } = parse_macro_input!(tokens as Rtd);
 
+    let num_fields = fields.as_ref().map_or(0, Vec::len);
+    let num_embedded_fields = match &parent {
+        Some(parent) => quote!({
+            let parent = <#parent as ::scheme_rs::records::Embeddable>::rtd();
+            parent.embedded_vtable.map_or(0, |vt| vt.embedded_fields) + #num_fields
+        }),
+        None => {
+            quote!(#num_fields)
+        }
+    };
+
+    let num_inherited_fields = match &parent {
+        Some(parent) => quote!({
+            let parent = <#parent as ::scheme_rs::records::Embeddable>::rtd();
+            parent.num_fields()
+        }),
+        None => quote!(0),
+    };
+
     let fields = fields
         .into_iter()
         .flatten()
@@ -1263,14 +1296,14 @@ pub fn rtd(tokens: TokenStream) -> TokenStream {
         .collect::<Vec<_>>();
     let inherits = match parent {
         Some(parent) => quote!({
-            let parent = <#parent as ::scheme_rs::records::SchemeCompatible>::rtd();
+            let parent = <#parent as ::scheme_rs::records::Embeddable>::rtd();
             let mut inherits = parent.inherits.clone();
             inherits.insert(::by_address::ByAddress(parent));
             inherits
         }),
         None => quote!(Default::default()),
     };
-    let rust_parent_constructor = match constructor {
+    let embedded_constructor = match constructor {
         Some(constructor) => {
             let num_inputs = constructor.inputs.len();
             let inputs = 0..num_inputs;
@@ -1281,7 +1314,12 @@ pub fn rtd(tokens: TokenStream) -> TokenStream {
                         return Err(::scheme_rs::exceptions::Exception::wrong_num_of_args(#num_inputs, vals.len()));
                     }
                     let constructor: fn(#(#types,)*) -> Result<_, ::scheme_rs::exceptions::Exception> = #constructor;
-                    Ok(::scheme_rs::records::into_scheme_compatible(::scheme_rs::gc::Gc::new((constructor)(#(vals[#inputs].clone(),)*)?)))
+                    let value = (constructor)(#(vals[#inputs].clone(),)*)?;
+                    Ok(Box::new(move |dst: *mut ()| {
+                        unsafe {
+                            dst.cast::<#ty>().write(value);
+                        }
+                    }))
                 })
             }))
         }
@@ -1314,10 +1352,10 @@ pub fn rtd(tokens: TokenStream) -> TokenStream {
                         opaque: #opaque,
                         sealed: #sealed,
                         uid: #uid,
-                        field_index_offset: 0,
+                        num_inherited_fields: #num_inherited_fields,
                         fields: vec![ #( #fields, )* ],
-                        rust_parent_constructor: #rust_parent_constructor,
-                        rust_type: true
+                        embedded_constructor: #embedded_constructor,
+                        embedded_vtable: Some(::scheme_rs::records::EmbeddableVTable::new::<#ty>(#num_embedded_fields)),
                     })
                 });
             #bridge
@@ -1499,14 +1537,15 @@ pub fn define_condition_type(tokens: TokenStream) -> TokenStream {
     quote! {
         #[derive(Clone, ::scheme_rs::gc::Trace)]
         pub struct #rust_name {
-            pub parent: ::scheme_rs::gc::Gc<#parent>,
+            pub parent: #parent,
             #( pub #field_names: #field_tys, )*
 
         }
 
-        impl ::scheme_rs::records::SchemeCompatible for #rust_name {
+        impl ::scheme_rs::records::Embeddable for #rust_name {
             fn rtd() -> std::sync::Arc<::scheme_rs::records::RecordTypeDescriptor> {
                 ::scheme_rs::records::rtd!(
+                    ty: #rust_name,
                     name: #scheme_name,
                     parent: #parent,
                     #lib
@@ -1515,13 +1554,14 @@ pub fn define_condition_type(tokens: TokenStream) -> TokenStream {
                 )
             }
 
-            fn extract_embedded_record(
+            fn parent_record(
                 &self,
                 rtd: &std::sync::Arc<::scheme_rs::records::RecordTypeDescriptor>
-            ) -> Option<::scheme_rs::gc::Gc<dyn ::scheme_rs::records::SchemeCompatible>> {
+            ) -> Option<&dyn ::scheme_rs::records::Embeddable> {
                 #parent::rtd()
                     .is_subtype_of(rtd)
-                    .then(|| ::scheme_rs::records::into_scheme_compatible(self.parent.clone()))
+                    .then(|| &self.parent as &dyn ::scheme_rs::records::Embeddable)
+                          // ::scheme_rs::records::into_scheme_compatible(self.parent.clone()))
             }
 
             fn get_field(&self, k: usize) -> Result<::scheme_rs::value::Value, ::scheme_rs::exceptions::Exception> {

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -67,9 +67,9 @@ pub fn atomic_box_set(ab: Embedded<AtomicBox>, new_val: &Value) -> Result<Vec<Va
 }
 
 #[bridge(name = "atomic-box-swap!", lib = "(srfi :230)")]
-pub fn atomic_box_swap(ab: Embedded<AtomicBox>, new_val: &Value) -> Result<Vec<Value>, Exception> {
+pub fn atomic_box_swap(ab: Embedded<AtomicBox>, new_val: &Value) -> Value {
     let old = ab.inner.swap(Gc::new(new_val.clone()));
-    Ok(vec![Value::clone(&old)])
+    Value::clone(&old)
 }
 
 #[bridge(name = "atomic-box-compare-and-swap!", lib = "(srfi :230)")]

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -6,7 +6,7 @@ use scheme_rs_macros::bridge;
 use crate::{
     exceptions::Exception,
     gc::{Gc, OpaqueGcPtr, Trace},
-    records::{Record, RecordTypeDescriptor, SchemeCompatible, rtd},
+    records::{Embeddable, Embedded, RecordTypeDescriptor, rtd},
     value::Value,
 };
 
@@ -29,9 +29,10 @@ unsafe impl Trace for AtomicBox {
     }
 }
 
-impl SchemeCompatible for AtomicBox {
+impl Embeddable for AtomicBox {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(
+            ty: AtomicBox,
             name: "atomic-box",
             opaque: true,
             sealed: true,
@@ -41,7 +42,7 @@ impl SchemeCompatible for AtomicBox {
 
 #[bridge(name = "atomic-box?", lib = "(srfi :230)")]
 pub fn atomic_box_p(obj: &Value) -> Result<Vec<Value>, Exception> {
-    let is_atomic_box = obj.cast_to_rust_type::<AtomicBox>().is_some();
+    let is_atomic_box = obj.cast_to::<Embedded<AtomicBox>>().is_some();
     Ok(vec![Value::from(is_atomic_box)])
 }
 
@@ -50,37 +51,33 @@ pub fn make_atomic_box(val: &Value) -> Result<Vec<Value>, Exception> {
     let ab = AtomicBox {
         inner: ArcSwapAny::new(Gc::new(val.clone())),
     };
-    Ok(vec![Value::from(Record::from_rust_type(ab))])
+    Ok(vec![Value::from(ab)])
 }
 
 #[bridge(name = "atomic-box-ref", lib = "(srfi :230)")]
-pub fn atomic_box_ref(box_val: &Value) -> Result<Vec<Value>, Exception> {
-    let ab = box_val.try_to_rust_type::<AtomicBox>()?;
+pub fn atomic_box_ref(ab: Embedded<AtomicBox>) -> Result<Vec<Value>, Exception> {
     let guard = ab.inner.load();
     Ok(vec![Value::clone(&guard)])
 }
 
 #[bridge(name = "atomic-box-set!", lib = "(srfi :230)")]
-pub fn atomic_box_set(box_val: &Value, new_val: &Value) -> Result<Vec<Value>, Exception> {
-    let ab = box_val.try_to_rust_type::<AtomicBox>()?;
+pub fn atomic_box_set(ab: Embedded<AtomicBox>, new_val: &Value) -> Result<Vec<Value>, Exception> {
     ab.inner.store(Gc::new(new_val.clone()));
     Ok(vec![Value::undefined()])
 }
 
 #[bridge(name = "atomic-box-swap!", lib = "(srfi :230)")]
-pub fn atomic_box_swap(box_val: &Value, new_val: &Value) -> Result<Vec<Value>, Exception> {
-    let ab = box_val.try_to_rust_type::<AtomicBox>()?;
+pub fn atomic_box_swap(ab: Embedded<AtomicBox>, new_val: &Value) -> Result<Vec<Value>, Exception> {
     let old = ab.inner.swap(Gc::new(new_val.clone()));
     Ok(vec![Value::clone(&old)])
 }
 
 #[bridge(name = "atomic-box-compare-and-swap!", lib = "(srfi :230)")]
 pub fn atomic_box_compare_and_swap(
-    box_val: &Value,
+    ab: Embedded<AtomicBox>,
     expected: &Value,
     desired: &Value,
 ) -> Result<Vec<Value>, Exception> {
-    let ab = box_val.try_to_rust_type::<AtomicBox>()?;
     let expected_bits = Value::as_raw(expected);
     let desired_gc = Gc::new(desired.clone());
     let prev = ab.inner.rcu(|current| {

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -42,7 +42,7 @@ unsafe impl Embeddable for AtomicBox {
 
 #[bridge(name = "atomic-box?", lib = "(srfi :230)")]
 pub fn atomic_box_p(obj: &Value) -> Result<Vec<Value>, Exception> {
-    let is_atomic_box = obj.cast_to::<Embedded<AtomicBox>>().is_some();
+    let is_atomic_box = obj.cast::<Embedded<AtomicBox>>().is_some();
     Ok(vec![Value::from(is_atomic_box)])
 }
 

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -29,7 +29,7 @@ unsafe impl Trace for AtomicBox {
     }
 }
 
-impl Embeddable for AtomicBox {
+unsafe impl Embeddable for AtomicBox {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(
             ty: AtomicBox,

--- a/src/character.rs
+++ b/src/character.rs
@@ -26,7 +26,7 @@ pub fn char_to_integer(ch: &Value) -> Result<Vec<Value>, Exception> {
 
 #[bridge(name = "integer->char", lib = "(rnrs base builtins (6))")]
 pub fn integer_to_char(int: &Value) -> Result<Vec<Value>, Exception> {
-    let int: usize = int.try_to_scheme_type()?;
+    let int: usize = int.try_to()?;
     if let Ok(int) = <usize as TryInto<u32>>::try_into(int)
         && let Some(ch) = char::from_u32(int)
     {

--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -728,6 +728,7 @@ impl CompilationUnit<'_, '_> {
         result
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn fixnum_binop_codegen(
         &mut self,
         primop: PrimOp,

--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     proc::{ContinuationPtr, FuncPtr, ProcDebugInfo, Procedure},
     runtime::{DebugInfo, Runtime},
-    value::{FALSE_VALUE, NULL_VALUE, TAG, TRUE_VALUE, Tag, Value as SchemeValue},
+    value::{FALSE_VALUE, NULL_VALUE, TAG, TRUE_VALUE, Tag, UNDEFINED_VALUE, Value as SchemeValue},
 };
 
 use super::*;
@@ -417,7 +417,7 @@ impl CompilationUnit<'_, '_> {
         let cond = self
             .builder
             .ins()
-            .icmp_imm(IntCC::Equal, cell_value, Tag::Record as i64);
+            .icmp_imm(IntCC::Equal, cell_value, UNDEFINED_VALUE as i64);
 
         let undefined_block = self.builder.create_block();
         let defined_block = self.builder.create_block();
@@ -514,7 +514,10 @@ impl CompilationUnit<'_, '_> {
         );
         let expanded = self.builder.inst_results(call)[0];
 
-        let cond = self.builder.ins().icmp_imm(IntCC::Equal, expanded, 0);
+        let cond = self
+            .builder
+            .ins()
+            .icmp_imm(IntCC::Equal, expanded, UNDEFINED_VALUE as i64);
         let failure_block = self.builder.create_block();
         let success_block = self.builder.create_block();
         self.builder
@@ -656,7 +659,7 @@ impl CompilationUnit<'_, '_> {
             let cond = self
                 .builder
                 .ins()
-                .icmp_imm(IntCC::Equal, result, Tag::Record as i64);
+                .icmp_imm(IntCC::Equal, result, UNDEFINED_VALUE as i64);
 
             let failure_block = self.builder.create_block();
             let success_block = self.builder.create_block();

--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -390,7 +390,7 @@ impl CompilationUnit<'_, '_> {
                 (cell, global.name.0)
             }
             CpsValue::Const(val)
-                if let Some(proc) = val.cast_to_scheme_type::<Procedure>()
+                if let Some(proc) = val.cast_to::<Procedure>()
                     && let Some(known) = proc.to_known() =>
             {
                 // Known functions get converted to i64 constants

--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -15,7 +15,10 @@ use crate::{
     },
     proc::{ContinuationPtr, FuncPtr, ProcDebugInfo, Procedure},
     runtime::{DebugInfo, Runtime},
-    value::{FALSE_VALUE, NULL_VALUE, TAG, TRUE_VALUE, Tag, UNDEFINED_VALUE, Value as SchemeValue},
+    value::{
+        FALSE_VALUE, FIXNUM_MAX, FIXNUM_MIN, NULL_VALUE, TAG, TRUE_VALUE, Tag, UNDEFINED_VALUE,
+        Value as SchemeValue,
+    },
 };
 
 use super::*;
@@ -93,6 +96,8 @@ pub(crate) struct RuntimeFunctions {
     // Math primops:
     add: FuncId,
     sub: FuncId,
+    i64_to_number: FuncId,
+    i128_to_number: FuncId,
     mul: FuncId,
     div: FuncId,
     equal: FuncId,
@@ -587,22 +592,61 @@ impl CompilationUnit<'_, '_> {
         deferred_procs: &mut Vec<ProcedureBundle>,
         deferred_local_conts: &mut Vec<ProcedureBundle>,
     ) {
+        let arg_vals: Vec<Value> = vals.iter().map(|val| self.value_codegen(val)).collect();
+
+        // If we have two arguments and the operator is a numeric primop, we can
+        // generate faster code.
+        if let [lhs, rhs] = arg_vals[..]
+            && matches!(
+                primop,
+                PrimOp::Add
+                    | PrimOp::Sub
+                    | PrimOp::Mul
+                    | PrimOp::Equal
+                    | PrimOp::Lesser
+                    | PrimOp::Greater
+                    | PrimOp::LesserEqual
+                    | PrimOp::GreaterEqual
+            )
+        {
+            self.fixnum_binop_codegen(
+                primop,
+                lhs,
+                rhs,
+                dest,
+                cexpr,
+                deferred_procs,
+                deferred_local_conts,
+            );
+        } else {
+            let result = self.slow_value_primop_codegen(primop, &arg_vals);
+
+            self.rebinds.rebind(dest, IrValue::Value(result));
+
+            if primop.info().needs_drop {
+                self.push_alloc(result);
+            }
+
+            self.cps_codegen(cexpr, deferred_procs, deferred_local_conts);
+        }
+    }
+
+    fn slow_value_primop_codegen(&mut self, primop: PrimOp, arg_vals: &[Value]) -> Value {
         let primop_info = primop.info();
 
         let mut args = if primop_info.variadic {
             // Put the values into an array:
-            let args = self.alloc_array(vals.len());
+            let array = self.alloc_array(arg_vals.len());
 
-            for (i, val) in vals.iter().enumerate() {
-                let val = self.value_codegen(val);
-                self.array_store(args, i, val);
+            for (i, val) in arg_vals.iter().enumerate() {
+                self.array_store(array, i, *val);
             }
 
-            let vals_addr = self.builder.ins().stack_addr(types::I64, args, 0);
-            let num_vals = self.builder.ins().iconst(types::I32, vals.len() as i64);
+            let vals_addr = self.builder.ins().stack_addr(types::I64, array, 0);
+            let num_vals = self.builder.ins().iconst(types::I32, arg_vals.len() as i64);
             vec![vals_addr, num_vals]
         } else {
-            vals.iter().map(|val| self.value_codegen(val)).collect()
+            arg_vals.to_vec()
         };
 
         // Call the respective runtime function:
@@ -620,13 +664,13 @@ impl CompilationUnit<'_, '_> {
             PrimOp::List => self.runtime_funcs.list,
             PrimOp::Car => self.runtime_funcs.car,
             PrimOp::Cdr => self.runtime_funcs.cdr,
-            PrimOp::CallKnown0 => match vals.len() {
+            PrimOp::CallKnown0 => match arg_vals.len() {
                 2 => self.runtime_funcs.call_known_1x0,
                 3 => self.runtime_funcs.call_known_2x0,
                 4 => self.runtime_funcs.call_known_3x0,
                 _ => unreachable!(),
             },
-            PrimOp::CallKnown1 => match vals.len() {
+            PrimOp::CallKnown1 => match arg_vals.len() {
                 1 => self.runtime_funcs.call_known_0x1,
                 2 => self.runtime_funcs.call_known_1x1,
                 3 => self.runtime_funcs.call_known_2x1,
@@ -681,9 +725,171 @@ impl CompilationUnit<'_, '_> {
             self.builder.seal_block(success_block);
         }
 
+        result
+    }
+
+    fn fixnum_binop_codegen(
+        &mut self,
+        primop: PrimOp,
+        lhs: Value,
+        rhs: Value,
+        dest: Local,
+        cexpr: Cps,
+        deferred_procs: &mut Vec<ProcedureBundle>,
+        deferred_local_conts: &mut Vec<ProcedureBundle>,
+    ) {
+        // Both operands are fixnums iff the low bit of their bitwise-and is set.
+        let anded = self.builder.ins().band(lhs, rhs);
+        let low_bit = self.builder.ins().band_imm(anded, 1);
+        let both_fixnums = self.builder.ins().icmp_imm(IntCC::Equal, low_bit, 1);
+
+        let fast_block = self.builder.create_block();
+        let slow_block = self.builder.create_block();
+        let merge_block = self.builder.create_block();
+        self.builder.append_block_param(merge_block, types::I64);
+
+        self.builder
+            .ins()
+            .brif(both_fixnums, fast_block, &[], slow_block, &[]);
+
+        // Fast path: both operands are fixnums.
+        self.builder.switch_to_block(fast_block);
+        self.builder.seal_block(fast_block);
+        match primop {
+            PrimOp::Equal
+            | PrimOp::Lesser
+            | PrimOp::Greater
+            | PrimOp::LesserEqual
+            | PrimOp::GreaterEqual => {
+                // Since both operands have their lowest bit set, we can
+                // compare them as i64s.
+                let cc = match primop {
+                    PrimOp::Equal => IntCC::Equal,
+                    PrimOp::Lesser => IntCC::SignedLessThan,
+                    PrimOp::Greater => IntCC::SignedGreaterThan,
+                    PrimOp::LesserEqual => IntCC::SignedLessThanOrEqual,
+                    PrimOp::GreaterEqual => IntCC::SignedGreaterThanOrEqual,
+                    _ => unreachable!(),
+                };
+                let cmp = self.builder.ins().icmp(cc, lhs, rhs);
+                let true_val = self.builder.ins().iconst(types::I64, TRUE_VALUE as i64);
+                let false_val = self.builder.ins().iconst(types::I64, FALSE_VALUE as i64);
+                let result = self.builder.ins().select(cmp, true_val, false_val);
+                self.builder
+                    .ins()
+                    .jump(merge_block, &[BlockArg::Value(result)]);
+            }
+            PrimOp::Add | PrimOp::Sub => {
+                let lhs = self.builder.ins().sshr_imm(lhs, 1);
+                let rhs = self.builder.ins().sshr_imm(rhs, 1);
+                let value = match primop {
+                    PrimOp::Add => self.builder.ins().iadd(lhs, rhs),
+                    PrimOp::Sub => self.builder.ins().isub(lhs, rhs),
+                    _ => unreachable!(),
+                };
+
+                // Check if we're in range of an i64
+                let ge_min =
+                    self.builder
+                        .ins()
+                        .icmp_imm(IntCC::SignedGreaterThanOrEqual, value, FIXNUM_MIN);
+                let le_max =
+                    self.builder
+                        .ins()
+                        .icmp_imm(IntCC::SignedLessThanOrEqual, value, FIXNUM_MAX);
+                let in_range = self.builder.ins().band(ge_min, le_max);
+
+                let encode_block = self.builder.create_block();
+                let overflow_block = self.builder.create_block();
+                self.builder
+                    .ins()
+                    .brif(in_range, encode_block, &[], overflow_block, &[]);
+
+                // Convert back to a Value
+                self.builder.switch_to_block(encode_block);
+                self.builder.seal_block(encode_block);
+                let shifted = self.builder.ins().ishl_imm(value, 1);
+                let result = self.builder.ins().bor_imm(shifted, 1);
+                self.builder
+                    .ins()
+                    .jump(merge_block, &[BlockArg::Value(result)]);
+
+                // The fixnum overflows 63 bits, allocate
+                self.builder.switch_to_block(overflow_block);
+                self.builder.seal_block(overflow_block);
+                let i64_to_number = self
+                    .module
+                    .declare_func_in_func(self.runtime_funcs.i64_to_number, self.builder.func);
+                let call = self.builder.ins().call(i64_to_number, &[value]);
+                let result = self.builder.inst_results(call)[0];
+                self.builder
+                    .ins()
+                    .jump(merge_block, &[BlockArg::Value(result)]);
+            }
+            PrimOp::Mul => {
+                let lhs = self.builder.ins().sshr_imm(lhs, 1);
+                let rhs = self.builder.ins().sshr_imm(rhs, 1);
+
+                let value = self.builder.ins().imul(lhs, rhs);
+                let hi = self.builder.ins().smulhi(lhs, rhs);
+                let sign = self.builder.ins().sshr_imm(value, 63);
+                let fits_i64 = self.builder.ins().icmp(IntCC::Equal, hi, sign);
+
+                let ge_min =
+                    self.builder
+                        .ins()
+                        .icmp_imm(IntCC::SignedGreaterThanOrEqual, value, FIXNUM_MIN);
+                let le_max =
+                    self.builder
+                        .ins()
+                        .icmp_imm(IntCC::SignedLessThanOrEqual, value, FIXNUM_MAX);
+                let in_fixnum = self.builder.ins().band(ge_min, le_max);
+                let in_range = self.builder.ins().band(fits_i64, in_fixnum);
+
+                let encode_block = self.builder.create_block();
+                let overflow_block = self.builder.create_block();
+                self.builder
+                    .ins()
+                    .brif(in_range, encode_block, &[], overflow_block, &[]);
+
+                self.builder.switch_to_block(encode_block);
+                self.builder.seal_block(encode_block);
+                let shifted = self.builder.ins().ishl_imm(value, 1);
+                let result = self.builder.ins().bor_imm(shifted, 1);
+                self.builder
+                    .ins()
+                    .jump(merge_block, &[BlockArg::Value(result)]);
+
+                // Overflow: convert to a bignum
+                self.builder.switch_to_block(overflow_block);
+                self.builder.seal_block(overflow_block);
+                let i128_to_number = self
+                    .module
+                    .declare_func_in_func(self.runtime_funcs.i128_to_number, self.builder.func);
+                let call = self.builder.ins().call(i128_to_number, &[value, hi]);
+                let result = self.builder.inst_results(call)[0];
+                self.builder
+                    .ins()
+                    .jump(merge_block, &[BlockArg::Value(result)]);
+            }
+            _ => unreachable!(),
+        }
+
+        self.builder.switch_to_block(slow_block);
+        self.builder.seal_block(slow_block);
+        let result = self.slow_value_primop_codegen(primop, &[lhs, rhs]);
+        self.builder
+            .ins()
+            .jump(merge_block, &[BlockArg::Value(result)]);
+
+        // Merge the two paths.
+        self.builder.switch_to_block(merge_block);
+        self.builder.seal_block(merge_block);
+        let result = self.builder.block_params(merge_block)[0];
+
         self.rebinds.rebind(dest, IrValue::Value(result));
 
-        if primop_info.needs_drop {
+        if primop.info().needs_drop {
             self.push_alloc(result);
         }
 

--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -390,7 +390,7 @@ impl CompilationUnit<'_, '_> {
                 (cell, global.name.0)
             }
             CpsValue::Const(val)
-                if let Some(proc) = val.cast_to::<Procedure>()
+                if let Some(proc) = val.cast::<Procedure>()
                     && let Some(known) = proc.to_known() =>
             {
                 // Known functions get converted to i64 constants

--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -414,7 +414,10 @@ impl CompilationUnit<'_, '_> {
         let cell_value = self.builder.inst_results(call)[0];
 
         // Check if the cell is undefined:
-        let cond = self.builder.ins().icmp_imm(IntCC::Equal, cell_value, 0);
+        let cond = self
+            .builder
+            .ins()
+            .icmp_imm(IntCC::Equal, cell_value, Tag::Record as i64);
 
         let undefined_block = self.builder.create_block();
         let defined_block = self.builder.create_block();
@@ -650,7 +653,10 @@ impl CompilationUnit<'_, '_> {
         // Check for error if we need to:
         if let Some(error_slot) = error_slot {
             // Check if the result is undefined:
-            let cond = self.builder.ins().icmp_imm(IntCC::Equal, result, 0);
+            let cond = self
+                .builder
+                .ins()
+                .icmp_imm(IntCC::Equal, result, Tag::Record as i64);
 
             let failure_block = self.builder.create_block();
             let success_block = self.builder.create_block();
@@ -1026,7 +1032,7 @@ impl CompilationUnit<'_, '_> {
         for (i, env_var) in bundle.env.iter().enumerate() {
             let val = if fix_vals.contains(env_var) {
                 // Undefined
-                self.builder.ins().iconst(types::I64, 0)
+                self.builder.ins().iconst(types::I64, Tag::Record as i64)
             } else {
                 match *self.rebinds.fetch_bind(env_var) {
                     IrValue::Cell(ptr) => ptr,

--- a/src/cps/compile.rs
+++ b/src/cps/compile.rs
@@ -11,7 +11,6 @@ use crate::{
     exceptions::Exception,
     expand::{ExpansionCombiner, SyntaxRule},
     proc::Procedure,
-    records::Record,
     runtime::Runtime,
     syntax::{Identifier, Syntax},
     value::Value as RuntimeValue,
@@ -521,7 +520,7 @@ fn compile_apply_args(
             return if let Value::Var(Var::Local(frame)) = frame {
                 Cps::PrimOp(
                     PrimOp::GetFrame,
-                    vec![op, Value::from(RuntimeValue::from_rust_type(span))],
+                    vec![op, Value::from(RuntimeValue::from(span))],
                     frame,
                     Box::new(app),
                 )
@@ -847,8 +846,8 @@ impl Compile for SyntaxQuote {
         }
 
         let mut args = vec![
-            Value::from(RuntimeValue::from_rust_type(self.template.clone())),
-            Value::from(RuntimeValue::from_rust_type(ExpansionCombiner { uses })),
+            Value::from(RuntimeValue::from(self.template.clone())),
+            Value::from(RuntimeValue::from(ExpansionCombiner { uses })),
         ];
 
         for expansion in expansions_seen.iter() {
@@ -924,10 +923,12 @@ fn compile_syntax_rules(
                     Box::new(Cps::App(Value::from(k2), Vec::new())),
                 )),
                 [rule, tail @ ..] => {
-                    let pattern = Record::from_rust_type(rule.pattern.clone());
                     Box::new(Cps::PrimOp(
                         PrimOp::Matches,
-                        vec![Value::from(RuntimeValue::from(pattern)), Value::from(arg)],
+                        vec![
+                            Value::from(RuntimeValue::from(rule.pattern.clone())),
+                            Value::from(arg),
+                        ],
                         rule.binds,
                         {
                             let match_result = if rule.fender.is_some() {

--- a/src/docs.md
+++ b/src/docs.md
@@ -63,7 +63,7 @@ let vals = env.eval(
     "
 )
 .unwrap();
-let factorial = vals[0].cast_to::<Procedure>().unwrap();
+let factorial = vals[0].cast::<Procedure>().unwrap();
 ```
 
 ## Procedures
@@ -95,7 +95,7 @@ anywhere.
 # .unwrap()
 # .try_into()
 # .unwrap();
-# let factorial = factorial.cast_to::<Procedure>().unwrap();
+# let factorial = factorial.cast::<Procedure>().unwrap();
 let [result] = factorial
     .call(
         &[Value::from(5)],
@@ -160,7 +160,7 @@ let val = env.eval(
   "
 )
 .unwrap();
-assert_eq!(val[0].cast_to::<u64>().unwrap(), 17);
+assert_eq!(val[0].cast::<u64>().unwrap(), 17);
 # }
 ```
 
@@ -192,7 +192,7 @@ struct Vec3 {
     y: f64
 }
 
-impl Embeddable for Vec3 {
+unsafe impl Embeddable for Vec3 {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(
             ty: Vec3,
@@ -231,7 +231,7 @@ embedded Rust type, cast to an [`Embedded<T>`](records::Embedded), e.g.
 ```rust
 # use scheme_rs::value::Value;
 # let pi = Value::from(3.14159268);
-assert_eq!(pi.cast_to::<f64>(), Some(3.14159268));
+assert_eq!(pi.cast::<f64>(), Some(3.14159268));
 ```
 
 See [the `value` module for more information](value).

--- a/src/docs.md
+++ b/src/docs.md
@@ -63,7 +63,7 @@ let vals = env.eval(
     "
 )
 .unwrap();
-let factorial = vals[0].cast_to_scheme_type::<Procedure>().unwrap();
+let factorial = vals[0].cast_to::<Procedure>().unwrap();
 ```
 
 ## Procedures
@@ -95,7 +95,7 @@ anywhere.
 # .unwrap()
 # .try_into()
 # .unwrap();
-# let factorial = factorial.cast_to_scheme_type::<Procedure>().unwrap();
+# let factorial = factorial.cast_to::<Procedure>().unwrap();
 let [result] = factorial
     .call(
         &[Value::from(5)],
@@ -160,7 +160,7 @@ let val = env.eval(
   "
 )
 .unwrap();
-assert_eq!(val[0].cast_to_scheme_type::<u64>().unwrap(), 17);
+assert_eq!(val[0].cast_to::<u64>().unwrap(), 17);
 # }
 ```
 
@@ -180,11 +180,11 @@ let pi = Value::from(3.14159268);
 let pair = Value::from((Value::from(1), Value::from((Value::from(2), Value::from(())))));
 ```
 
-Rust objects that implement [`SchemeCompatible`](records::SchemeCompatible) can 
-be converted using the [`from_rust_type`](value::Value::from_rust_type) function:
+Rust objects that implement [`Embeddable`](records::Embeddable) can 
+be converted using `Value::from`:
 
 ```rust
-# use scheme_rs::{value::Value, records::{rtd, SchemeCompatible, RecordTypeDescriptor}, gc::Trace, exceptions::Exception};
+# use scheme_rs::{value::Value, records::{rtd, Embeddable, RecordTypeDescriptor}, gc::Trace, exceptions::Exception};
 # use std::sync::Arc;
 #[derive(Debug, Trace)]
 struct Vec3 {
@@ -192,15 +192,16 @@ struct Vec3 {
     y: f64
 }
 
-impl SchemeCompatible for Vec3 {
+impl Embeddable for Vec3 {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(
+            ty: Vec3,
             name: "vec3",
             fields: ["x", "y"],
             constructor: |x, y| {
                 Ok(Vec3 {
-                    x: x.try_to_scheme_type()?,
-                    y: y.try_to_scheme_type()?,
+                    x: x.try_to()?,
+                    y: y.try_to()?,
                 })
             }
         )
@@ -215,22 +216,22 @@ impl SchemeCompatible for Vec3 {
     }
 }
 
-let pos = Value::from_rust_type(Vec3 { x: 1.0, y: 2.0 });
+let pos = Value::from(Vec3 { x: 1.0, y: 2.0 });
 ```
 
-`Values` can be converted back to Rust types with the 
-- [`cast_to_scheme_type`](value::Value::cast_to_scheme_type)
-- [`try_to_scheme_type`](value::Value::try_to_scheme_type)
-- [`cast_to_rust_type`](value::Value::cast_to_rust_type)
-- and [`try_to_rust_type`](value::Value::try_to_rust_type) functions.
+`Values` can be converted back to primitive Rust types with the 
+- [`cast_to`](value::Value::cast_to)
+- and [`try_to`](value::Value::try_to) functions.
 
-The `cast_*` functions convert values to `Option<_>`, and the `try_*` functions 
-provide more detailed error conditions of the conversion failure.
+The `cast_to` function converts values to `Option<_>`, and `try_to` 
+provides more detailed error conditions of the conversion failure. To recover an
+embedded Rust type, cast to an [`Embedded<T>`](records::Embedded), e.g.
+`value.try_to::<Embedded<Vec3>>()`.
 
 ```rust
 # use scheme_rs::value::Value;
 # let pi = Value::from(3.14159268);
-assert_eq!(pi.cast_to_scheme_type::<f64>(), Some(3.14159268));
+assert_eq!(pi.cast_to::<f64>(), Some(3.14159268));
 ```
 
 See [the `value` module for more information](value).

--- a/src/enumerations.rs
+++ b/src/enumerations.rs
@@ -29,7 +29,7 @@ impl EnumerationType {
     }
 }
 
-impl Embeddable for EnumerationType {
+unsafe impl Embeddable for EnumerationType {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(ty: EnumerationType, name: "enum-universe", sealed: true, opaque: true)
     }
@@ -75,7 +75,7 @@ impl EnumerationSet {
     }
 }
 
-impl Embeddable for EnumerationSet {
+unsafe impl Embeddable for EnumerationSet {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(ty: EnumerationSet, name: "enum-set", sealed: true, opaque: true)
     }

--- a/src/enumerations.rs
+++ b/src/enumerations.rs
@@ -7,10 +7,10 @@ use scheme_rs_macros::{bridge, cps_bridge};
 
 use crate::{
     exceptions::Exception,
-    gc::{Gc, Trace},
+    gc::Trace,
     lists::List,
     proc::{Application, ContBarrier, FuncPtr, Procedure},
-    records::{Record, RecordTypeDescriptor, SchemeCompatible, rtd},
+    records::{Embeddable, Embedded, RecordTypeDescriptor, rtd},
     runtime::Runtime,
     symbols::Symbol,
     value::Value,
@@ -29,15 +29,15 @@ impl EnumerationType {
     }
 }
 
-impl SchemeCompatible for EnumerationType {
+impl Embeddable for EnumerationType {
     fn rtd() -> Arc<RecordTypeDescriptor> {
-        rtd!(name: "enum-universe", sealed: true, opaque: true)
+        rtd!(ty: EnumerationType, name: "enum-universe", sealed: true, opaque: true)
     }
 }
 
 #[derive(Trace)]
 pub struct EnumerationSet {
-    enum_type: Gc<EnumerationType>,
+    enum_type: Embedded<EnumerationType>,
     set: IndexSet<Symbol>,
 }
 
@@ -51,15 +51,18 @@ impl fmt::Debug for EnumerationSet {
 }
 
 impl EnumerationSet {
-    pub fn new(enum_type: &Gc<EnumerationType>, set: impl IntoIterator<Item = Symbol>) -> Self {
+    pub fn new(
+        enum_type: &Embedded<EnumerationType>,
+        set: impl IntoIterator<Item = Symbol>,
+    ) -> Self {
         Self {
             enum_type: enum_type.clone(),
             set: set.into_iter().collect(),
         }
     }
 
-    pub fn type_check(&self, ty: &Gc<EnumerationType>) -> Result<(), Exception> {
-        if !Gc::ptr_eq(&self.enum_type, ty) {
+    pub fn type_check(&self, ty: &Embedded<EnumerationType>) -> Result<(), Exception> {
+        if !Embedded::ptr_eq(&self.enum_type, ty) {
             Err(Exception::error("wrong enumeration type"))
         } else {
             Ok(())
@@ -72,9 +75,9 @@ impl EnumerationSet {
     }
 }
 
-impl SchemeCompatible for EnumerationSet {
+impl Embeddable for EnumerationSet {
     fn rtd() -> Arc<RecordTypeDescriptor> {
-        rtd!(name: "enum-set", sealed: true, opaque: true)
+        rtd!(ty: EnumerationSet, name: "enum-set", sealed: true, opaque: true)
     }
 }
 
@@ -82,25 +85,24 @@ impl SchemeCompatible for EnumerationSet {
 pub fn make_enumeration(symbols: List) -> Result<Vec<Value>, Exception> {
     let symbols = symbols
         .into_iter()
-        .map(|item| item.try_to_scheme_type())
+        .map(|item| item.try_to())
         .collect::<Result<IndexSet<Symbol>, Exception>>()?;
     let set = EnumerationSet {
         set: symbols.clone(),
-        enum_type: Gc::new(EnumerationType { symbols }),
+        enum_type: Embedded::new(EnumerationType { symbols }),
     };
-    Ok(vec![Value::from_rust_type(set)])
+    Ok(vec![Value::from(set)])
 }
 
 #[bridge(name = "enum-set-universe", lib = "(rnrs enums (6))")]
-pub fn enum_set_universe(enum_set: &Value) -> Result<Vec<Value>, Exception> {
-    let enum_set: Gc<EnumerationSet> = enum_set.try_to_rust_type()?;
+pub fn enum_set_universe(enum_set: Embedded<EnumerationSet>) -> Result<Vec<Value>, Exception> {
     let new_set = EnumerationSet {
-        enum_type: Gc::new(EnumerationType {
+        enum_type: Embedded::new(EnumerationType {
             symbols: enum_set.enum_type.symbols.clone(),
         }),
         set: enum_set.enum_type.symbols.clone(),
     };
-    Ok(vec![Value::from_rust_type(new_set)])
+    Ok(vec![Value::from(new_set)])
 }
 
 #[cps_bridge(def = "enum-set-constructor enum-set", lib = "(rnrs enums (6))")]
@@ -112,8 +114,8 @@ pub fn enum_set_constructor(
     _rest_args: &[Value],
     _barrier: &mut ContBarrier,
 ) -> Result<Application, Exception> {
-    let set = args[0].try_to_rust_type::<EnumerationSet>()?;
-    let universe = Value::from(Record::from_rust_gc_type(set.enum_type.clone()));
+    let set = args[0].try_to::<Embedded<EnumerationSet>>()?;
+    let universe = Value::from(set.enum_type.clone());
     let constructor = Procedure::new(
         runtime.clone(),
         vec![universe],
@@ -134,12 +136,12 @@ fn enum_set_constructor_fn(
     _barrier: &mut ContBarrier,
 ) -> Result<Application, Exception> {
     // env[0] is the universe:
-    let enum_type: Gc<EnumerationType> = env[0].try_to_rust_type()?;
+    let enum_type: Embedded<EnumerationType> = env[0].try_to()?;
     let set = args[0]
-        .try_to_scheme_type::<List>()?
+        .try_to::<List>()?
         .into_iter()
         .map(|symbol| {
-            let symbol = symbol.try_to_scheme_type::<Symbol>()?;
+            let symbol = symbol.try_to::<Symbol>()?;
             if !enum_type.symbols.contains(&symbol) {
                 Err(Exception::error(format!(
                     "universe does not contain {symbol}"
@@ -150,16 +152,11 @@ fn enum_set_constructor_fn(
         })
         .collect::<Result<IndexSet<_>, _>>()?;
     let enum_set = EnumerationSet { enum_type, set };
-    Ok(Application::new(
-        k,
-        None,
-        vec![Value::from_rust_type(enum_set)],
-    ))
+    Ok(Application::new(k, None, vec![Value::from(enum_set)]))
 }
 
 #[bridge(name = "enum-set->list", lib = "(rnrs enums (6))")]
-pub fn enum_set_to_list(enum_set: &Value) -> Result<Vec<Value>, Exception> {
-    let enum_set: Gc<EnumerationSet> = enum_set.try_to_rust_type()?;
+pub fn enum_set_to_list(enum_set: Embedded<EnumerationSet>) -> Result<Vec<Value>, Exception> {
     let mut set = enum_set
         .set
         .iter()
@@ -174,15 +171,18 @@ pub fn enum_set_to_list(enum_set: &Value) -> Result<Vec<Value>, Exception> {
 }
 
 #[bridge(name = "enum-set-member?", lib = "(rnrs enums (6))")]
-pub fn enum_set_member_pred(symbol: Symbol, enum_set: &Value) -> Result<Vec<Value>, Exception> {
-    let enum_set: Gc<EnumerationSet> = enum_set.try_to_rust_type()?;
+pub fn enum_set_member_pred(
+    symbol: Symbol,
+    enum_set: Embedded<EnumerationSet>,
+) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(enum_set.set.contains(&symbol))])
 }
 
 #[bridge(name = "enum-set-subset?", lib = "(rnrs enums (6))")]
-pub fn enum_set_subset_pred(enum_set1: &Value, enum_set2: &Value) -> Result<Vec<Value>, Exception> {
-    let enum_set1: Gc<EnumerationSet> = enum_set1.try_to_rust_type()?;
-    let enum_set2: Gc<EnumerationSet> = enum_set2.try_to_rust_type()?;
+pub fn enum_set_subset_pred(
+    enum_set1: Embedded<EnumerationSet>,
+    enum_set2: Embedded<EnumerationSet>,
+) -> Result<Vec<Value>, Exception> {
     let is_subset = enum_set1
         .enum_type
         .symbols
@@ -192,19 +192,21 @@ pub fn enum_set_subset_pred(enum_set1: &Value, enum_set2: &Value) -> Result<Vec<
 }
 
 #[bridge(name = "enum-set=?", lib = "(rnrs enums (6))")]
-pub fn enum_set_equal(enum_set1: &Value, enum_set2: &Value) -> Result<Vec<Value>, Exception> {
-    let enum_set1: Gc<EnumerationSet> = enum_set1.try_to_rust_type()?;
-    let enum_set2: Gc<EnumerationSet> = enum_set2.try_to_rust_type()?;
+pub fn enum_set_equal(
+    enum_set1: Embedded<EnumerationSet>,
+    enum_set2: Embedded<EnumerationSet>,
+) -> Result<Vec<Value>, Exception> {
     let is_equal = enum_set1.enum_type.symbols == enum_set2.enum_type.symbols
         && enum_set1.set == enum_set2.set;
     Ok(vec![Value::from(is_equal)])
 }
 
 #[bridge(name = "enum-set-union", lib = "(rnrs enums (6))")]
-pub fn enum_set_union(enum_set1: &Value, enum_set2: &Value) -> Result<Vec<Value>, Exception> {
-    let enum_set1: Gc<EnumerationSet> = enum_set1.try_to_rust_type()?;
-    let enum_set2: Gc<EnumerationSet> = enum_set2.try_to_rust_type()?;
-    if !Gc::ptr_eq(&enum_set1.enum_type, &enum_set2.enum_type) {
+pub fn enum_set_union(
+    enum_set1: Embedded<EnumerationSet>,
+    enum_set2: Embedded<EnumerationSet>,
+) -> Result<Vec<Value>, Exception> {
+    if !Embedded::ptr_eq(&enum_set1.enum_type, &enum_set2.enum_type) {
         return Err(Exception::error("enum sets must be of the same enum type"));
     }
     let union = enum_set1
@@ -212,7 +214,7 @@ pub fn enum_set_union(enum_set1: &Value, enum_set2: &Value) -> Result<Vec<Value>
         .union(&enum_set2.set)
         .copied()
         .collect::<IndexSet<_>>();
-    let set = Value::from_rust_type(EnumerationSet {
+    let set = Value::from(EnumerationSet {
         enum_type: enum_set1.enum_type.clone(),
         set: union,
     });
@@ -221,12 +223,10 @@ pub fn enum_set_union(enum_set1: &Value, enum_set2: &Value) -> Result<Vec<Value>
 
 #[bridge(name = "enum-set-intersection", lib = "(rnrs enums (6))")]
 pub fn enum_set_intersection(
-    enum_set1: &Value,
-    enum_set2: &Value,
+    enum_set1: Embedded<EnumerationSet>,
+    enum_set2: Embedded<EnumerationSet>,
 ) -> Result<Vec<Value>, Exception> {
-    let enum_set1: Gc<EnumerationSet> = enum_set1.try_to_rust_type()?;
-    let enum_set2: Gc<EnumerationSet> = enum_set2.try_to_rust_type()?;
-    if !Gc::ptr_eq(&enum_set1.enum_type, &enum_set2.enum_type) {
+    if !Embedded::ptr_eq(&enum_set1.enum_type, &enum_set2.enum_type) {
         return Err(Exception::error("enum sets must be of the same enum type"));
     }
     let intersection = enum_set1
@@ -234,7 +234,7 @@ pub fn enum_set_intersection(
         .intersection(&enum_set2.set)
         .copied()
         .collect::<IndexSet<_>>();
-    let set = Value::from_rust_type(EnumerationSet {
+    let set = Value::from(EnumerationSet {
         enum_type: enum_set1.enum_type.clone(),
         set: intersection,
     });
@@ -242,10 +242,11 @@ pub fn enum_set_intersection(
 }
 
 #[bridge(name = "enum-set-difference", lib = "(rnrs enums (6))")]
-pub fn enum_set_difference(enum_set1: &Value, enum_set2: &Value) -> Result<Vec<Value>, Exception> {
-    let enum_set1: Gc<EnumerationSet> = enum_set1.try_to_rust_type()?;
-    let enum_set2: Gc<EnumerationSet> = enum_set2.try_to_rust_type()?;
-    if !Gc::ptr_eq(&enum_set1.enum_type, &enum_set2.enum_type) {
+pub fn enum_set_difference(
+    enum_set1: Embedded<EnumerationSet>,
+    enum_set2: Embedded<EnumerationSet>,
+) -> Result<Vec<Value>, Exception> {
+    if !Embedded::ptr_eq(&enum_set1.enum_type, &enum_set2.enum_type) {
         return Err(Exception::error("enum sets must be of the same enum type"));
     }
     let difference = enum_set1
@@ -253,7 +254,7 @@ pub fn enum_set_difference(enum_set1: &Value, enum_set2: &Value) -> Result<Vec<V
         .difference(&enum_set2.set)
         .copied()
         .collect::<IndexSet<_>>();
-    let set = Value::from_rust_type(EnumerationSet {
+    let set = Value::from(EnumerationSet {
         enum_type: enum_set1.enum_type.clone(),
         set: difference,
     });
@@ -261,15 +262,14 @@ pub fn enum_set_difference(enum_set1: &Value, enum_set2: &Value) -> Result<Vec<V
 }
 
 #[bridge(name = "enum-set-complement", lib = "(rnrs enums (6))")]
-pub fn enum_set_complement(enum_set: &Value) -> Result<Vec<Value>, Exception> {
-    let enum_set: Gc<EnumerationSet> = enum_set.try_to_rust_type()?;
+pub fn enum_set_complement(enum_set: Embedded<EnumerationSet>) -> Result<Vec<Value>, Exception> {
     let complement = enum_set
         .enum_type
         .symbols
         .difference(&enum_set.set)
         .copied()
         .collect::<IndexSet<_>>();
-    let set = Value::from_rust_type(EnumerationSet {
+    let set = Value::from(EnumerationSet {
         enum_type: enum_set.enum_type.clone(),
         set: complement,
     });
@@ -277,16 +277,17 @@ pub fn enum_set_complement(enum_set: &Value) -> Result<Vec<Value>, Exception> {
 }
 
 #[bridge(name = "enum-set-projection", lib = "(rnrs enums (6))")]
-pub fn enum_set_projection(enum_set1: &Value, enum_set2: &Value) -> Result<Vec<Value>, Exception> {
-    let enum_set1: Gc<EnumerationSet> = enum_set1.try_to_rust_type()?;
-    let enum_set2: Gc<EnumerationSet> = enum_set2.try_to_rust_type()?;
+pub fn enum_set_projection(
+    enum_set1: Embedded<EnumerationSet>,
+    enum_set2: Embedded<EnumerationSet>,
+) -> Result<Vec<Value>, Exception> {
     let projection = enum_set1
         .set
         .iter()
         .filter(|sym| enum_set2.enum_type.symbols.contains(*sym))
         .copied()
         .collect::<IndexSet<_>>();
-    let set = Value::from_rust_type(EnumerationSet {
+    let set = Value::from(EnumerationSet {
         enum_type: enum_set2.enum_type.clone(),
         set: projection,
     });

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -41,7 +41,7 @@ pub fn eval(
     Ok(Application::new(k, None, result))
 }
 
-impl Embeddable for Environment {
+unsafe impl Embeddable for Environment {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(ty: Environment, name: "environment", sealed: true, opaque: true)
     }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -11,7 +11,7 @@ use crate::{
     env::{Environment, TopLevelEnvironment},
     exceptions::Exception,
     proc::{Application, ContBarrier, Procedure},
-    records::{Record, RecordTypeDescriptor, SchemeCompatible, rtd},
+    records::{Embeddable, Embedded, RecordTypeDescriptor, rtd},
     registry::cps_bridge,
     runtime::Runtime,
     syntax::{Span, Syntax},
@@ -31,7 +31,7 @@ pub fn eval(
     let [expression, environment] = args else {
         unreachable!()
     };
-    let env = environment.try_to_rust_type::<Environment>()?;
+    let env = environment.try_to::<Embedded<Environment>>()?;
     let expr = Syntax::datum_to_syntax(&env.get_scope_set(), expression.clone(), &Span::default());
     let ctxt = ParseContext::new(runtime, false);
     let mut mutable_vars = HashSet::default();
@@ -41,9 +41,9 @@ pub fn eval(
     Ok(Application::new(k, None, result))
 }
 
-impl SchemeCompatible for Environment {
+impl Embeddable for Environment {
     fn rtd() -> Arc<RecordTypeDescriptor> {
-        rtd!(name: "environment", sealed: true, opaque: true)
+        rtd!(ty: Environment, name: "environment", sealed: true, opaque: true)
     }
 }
 
@@ -69,6 +69,6 @@ pub fn environment(
     for import_set in import_sets {
         maybe_await!(env.import(import_set))?;
     }
-    let env = Value::from(Record::from_rust_type(env));
+    let env = Value::from(env);
     Ok(Application::new(k, None, vec![env]))
 }

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -246,7 +246,7 @@ impl Exception {
     }
 
     pub fn add_condition(self, condition: impl Embeddable) -> Self {
-        let mut conditions = if let Some(compound) = self.0.cast_to::<Embedded<CompoundCondition>>()
+        let mut conditions = if let Some(compound) = self.0.cast::<Embedded<CompoundCondition>>()
         {
             compound.0.clone()
         } else {
@@ -259,9 +259,9 @@ impl Exception {
     }
 
     pub fn simple_conditions(&self) -> Result<Vec<Value>, Exception> {
-        if self.0.cast_to::<Embedded<SimpleCondition>>().is_some() {
+        if self.0.cast::<Embedded<SimpleCondition>>().is_some() {
             Ok(vec![self.0.clone()])
-        } else if let Some(compound_condition) = self.0.cast_to::<Embedded<CompoundCondition>>() {
+        } else if let Some(compound_condition) = self.0.cast::<Embedded<CompoundCondition>>() {
             Ok(compound_condition.0.clone())
         } else {
             Err(Exception::error("not a simple or compound condition"))
@@ -270,7 +270,7 @@ impl Exception {
 
     pub fn condition<T: Embeddable>(&self) -> Result<Option<Embedded<T>>, Exception> {
         for condition in self.simple_conditions()?.into_iter() {
-            if let Some(condition) = condition.cast_to::<Embedded<T>>() {
+            if let Some(condition) = condition.cast::<Embedded<T>>() {
                 return Ok(Some(condition));
             }
         }
@@ -292,17 +292,17 @@ impl Exception {
 
         writeln!(f, "Uncaught exception:")?;
         for condition in conditions.into_iter().rev() {
-            if let Some(message) = condition.cast_to::<Embedded<Message>>() {
+            if let Some(message) = condition.cast::<Embedded<Message>>() {
                 writeln!(f, " - Message: {}", message.message)?;
-            } else if let Some(syntax) = condition.cast_to::<Embedded<SyntaxViolation>>() {
+            } else if let Some(syntax) = condition.cast::<Embedded<SyntaxViolation>>() {
                 writeln!(f, " - Syntax error in form: {:?}", syntax.form)?;
                 source_cache.pretty_print_condition(syntax.as_ref(), f)?;
-            } else if let Some(trace) = condition.cast_to::<Embedded<StackTrace>>() {
+            } else if let Some(trace) = condition.cast::<Embedded<StackTrace>>() {
                 if !trace.trace.is_empty() {
                     writeln!(f, " - Trace:")?;
                     source_cache.pretty_print_condition(trace.as_ref(), f)?;
                 }
-            } else if condition.cast_to::<Embedded<Assertion>>().is_some() {
+            } else if condition.cast::<Embedded<Assertion>>().is_some() {
                 writeln!(f, " - Assertion failed")?;
             } else {
                 writeln!(f, " - Condition: {condition:?}")?;
@@ -443,8 +443,8 @@ impl fmt::Debug for SimpleCondition {
 
 #[bridge(name = "condition?", lib = "(rnrs conditions (6))")]
 pub fn condition_pred(obj: &Value) -> Result<Vec<Value>, Exception> {
-    let is_condition = obj.cast_to::<Embedded<SimpleCondition>>().is_some()
-        || obj.cast_to::<Embedded<CompoundCondition>>().is_some();
+    let is_condition = obj.cast::<Embedded<SimpleCondition>>().is_some()
+        || obj.cast::<Embedded<CompoundCondition>>().is_some();
     Ok(vec![Value::from(is_condition)])
 }
 
@@ -541,7 +541,7 @@ define_condition_type!(
 impl PrettyCondition for StackTrace {
     fn span(&self) -> Span {
         let first = self.trace.first().unwrap();
-        let Some(syntax) = first.cast_to::<Embedded<Syntax>>() else {
+        let Some(syntax) = first.cast::<Embedded<Syntax>>() else {
             return Span::default();
         };
         syntax.span().clone()
@@ -549,7 +549,7 @@ impl PrettyCondition for StackTrace {
 
     fn pretty_print(&self, w: &mut impl fmt::Write) -> fmt::Result {
         for (i, trace) in self.trace.iter().enumerate() {
-            let Some(syntax) = trace.cast_to::<Embedded<Syntax>>() else {
+            let Some(syntax) = trace.cast::<Embedded<Syntax>>() else {
                 continue;
             };
             let span = syntax.span();
@@ -571,7 +571,7 @@ impl StackTrace {
     pub fn trace(&self) -> Vec<Syntax> {
         self.trace
             .iter()
-            .filter_map(|v| v.cast_to::<Embedded<Syntax>>())
+            .filter_map(|v| v.cast::<Embedded<Syntax>>())
             .map(|syntax| syntax.as_ref().clone())
             .collect()
     }
@@ -791,7 +791,7 @@ impl PrettyCondition for SyntaxViolation {
         self.subform
             .as_ref()
             .unwrap_or(&self.form)
-            .cast_to::<Embedded<Syntax>>()
+            .cast::<Embedded<Syntax>>()
             .unwrap()
             .span()
             .clone()
@@ -963,7 +963,7 @@ pub fn raise_builtin(
 
 /// Raises a non-continuable exception to the current exception handler.
 pub fn raise(runtime: Runtime, raised: Value, barrier: &mut ContBarrier) -> Application {
-    let raised = if let Some(condition) = raised.cast_to::<Exception>() {
+    let raised = if let Some(condition) = raised.cast::<Exception>() {
         let trace = barrier.current_marks(Symbol::intern("trace"));
         Value::from(condition.add_condition(StackTrace::new(trace)))
     } else {

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -15,7 +15,7 @@
 //! which can be used to extract a stack trace for the exception:
 //!
 //! ```
-//! # use scheme_rs::{exceptions::{Exception, Message, SyntaxViolation, StackTrace}, gc::Gc, syntax::Syntax};
+//! # use scheme_rs::{exceptions::{Exception, Message, SyntaxViolation, StackTrace}, records::Embedded, gc::Gc, syntax::Syntax};
 //! // Code from scheme-rs repl to print errors:
 //! fn print_exception(exception: Exception) {
 //!     let Ok(conditions) = exception.simple_conditions() else {
@@ -27,17 +27,17 @@
 //!     };
 //!     println!("Uncaught exception:");
 //!     for condition in conditions.into_iter() {
-//!         if let Some(message) = condition.cast_to_rust_type::<Message>() {
+//!         if let Some(message) = condition.cast_to::<Embedded<Message>>() {
 //!             println!(" - Message: {}", message.message);
-//!         } else if let Some(syntax) = condition.cast_to_rust_type::<SyntaxViolation>() {
+//!         } else if let Some(syntax) = condition.cast_to::<Embedded<SyntaxViolation>>() {
 //!             println!(" - Syntax error in form: {:?}", syntax.form);
 //!             if let Some(subform) = syntax.subform.as_ref() {
 //!                 println!("   (subform: {subform:?})");
 //!             }
-//!         } else if let Some(trace) = condition.cast_to_rust_type::<StackTrace>() {
+//!         } else if let Some(trace) = condition.cast_to::<Embedded<StackTrace>>() {
 //!             println!(" - Stack trace:");
 //!             for (i, trace) in trace.trace.iter().enumerate() {
-//!                 let syntax = trace.cast_to_scheme_type::<Gc<Syntax>>().unwrap();
+//!                 let syntax = trace.cast_to::<Gc<Syntax>>().unwrap();
 //!                 let span = syntax.span();
 //!                 let func_name = syntax.as_ident().unwrap().symbol();
 //!                 println!("{:>6}: {func_name}:{span}", i + 1);
@@ -57,7 +57,7 @@ use crate::{
         Application, ContBarrier, DynStackElem, FuncPtr, Procedure, halt_continuation,
         pop_dyn_stack,
     },
-    records::{Record, RecordTypeDescriptor, SchemeCompatible, rtd},
+    records::{Embeddable, Embedded, RecordTypeDescriptor, rtd},
     registry::{bridge, cps_bridge},
     runtime::{Runtime, RuntimeInner},
     symbols::Symbol,
@@ -85,113 +85,96 @@ pub struct Exception(pub Value);
 
 impl Exception {
     pub fn error(message: impl fmt::Display) -> Self {
-        Self(Value::from(Record::from_rust_type(
-            CompoundCondition::from((Assertion::new(), Message::new(message.to_string()))),
-        )))
-    }
-
-    pub fn syntax(form: Syntax, subform: Option<Syntax>) -> Self {
-        Self(Value::from(Record::from_rust_type(SyntaxViolation::new(
-            form, subform,
+        Self(Value::from(CompoundCondition::from((
+            Assertion::new(),
+            Message::new(message.to_string()),
         ))))
     }
 
+    pub fn syntax(form: Syntax, subform: Option<Syntax>) -> Self {
+        Self(Value::from(SyntaxViolation::new(form, subform)))
+    }
+
     pub fn undefined(ident: Identifier) -> Self {
-        Self(Value::from(Record::from_rust_type(
-            CompoundCondition::from((
-                Undefined::new(),
-                Message::new(format!("undefined variable {}", ident.sym)),
-            )),
-        )))
+        Self(Value::from(CompoundCondition::from((
+            Undefined::new(),
+            Message::new(format!("undefined variable {}", ident.sym)),
+        ))))
     }
 
     pub fn type_error(expected: &str, provided: &str) -> Self {
-        Self(Value::from(Record::from_rust_type(
-            CompoundCondition::from((
-                Assertion::new(),
-                Message::new(format!(
-                    "expected value of type {expected}, provided {provided}"
-                )),
+        Self(Value::from(CompoundCondition::from((
+            Assertion::new(),
+            Message::new(format!(
+                "expected value of type {expected}, provided {provided}"
             )),
-        )))
+        ))))
     }
 
     pub fn invalid_operator(provided: &str) -> Self {
-        Self(Value::from(Record::from_rust_type(
-            CompoundCondition::from((
-                Assertion::new(),
-                Message::new(format!(
-                    "invalid operator: expected procedure, provided {provided}"
-                )),
+        Self(Value::from(CompoundCondition::from((
+            Assertion::new(),
+            Message::new(format!(
+                "invalid operator: expected procedure, provided {provided}"
             )),
-        )))
+        ))))
     }
 
     pub fn invalid_index(index: usize, len: usize) -> Self {
-        Self(Value::from(Record::from_rust_type(
-            CompoundCondition::from((
-                Assertion::new(),
-                Message::new(format!(
-                    "index {index} out of bounds for collection of size {len}"
-                )),
+        Self(Value::from(CompoundCondition::from((
+            Assertion::new(),
+            Message::new(format!(
+                "index {index} out of bounds for collection of size {len}"
             )),
-        )))
+        ))))
     }
 
     pub fn invalid_range(range: Range<usize>, len: usize) -> Self {
-        Self(Value::from(Record::from_rust_type(
-            CompoundCondition::from((
-                Assertion::new(),
-                Message::new(format!(
-                    "range {range:?} out of bounds for collection of size {len}"
-                )),
+        Self(Value::from(CompoundCondition::from((
+            Assertion::new(),
+            Message::new(format!(
+                "range {range:?} out of bounds for collection of size {len}"
             )),
-        )))
+        ))))
     }
 
     pub fn wrong_num_of_unicode_chars(expected: usize, provided: usize) -> Self {
-        Self(Value::from(Record::from_rust_type(
-            CompoundCondition::from((
-                Assertion::new(),
-                Message::new(format!(
-                    "expected {expected} unicode characters from transform, received {provided}"
-                )),
+        Self(Value::from(CompoundCondition::from((
+            Assertion::new(),
+            Message::new(format!(
+                "expected {expected} unicode characters from transform, received {provided}"
             )),
-        )))
+        ))))
     }
 
     pub fn wrong_num_of_args(expected: usize, provided: usize) -> Self {
-        Self(Value::from(Record::from_rust_type(
-            CompoundCondition::from((
-                Assertion::new(),
-                Message::new(format!(
-                    "expected {expected} arguments, provided {provided}"
-                )),
+        Self(Value::from(CompoundCondition::from((
+            Assertion::new(),
+            Message::new(format!(
+                "expected {expected} arguments, provided {provided}"
             )),
-        )))
+        ))))
     }
 
     pub fn wrong_num_of_var_args(expected: Range<usize>, provided: usize) -> Self {
-        Self(Value::from(Record::from_rust_type(
-            CompoundCondition::from((
-                Assertion::new(),
-                Message::new(format!(
-                    "expected {} to {} arguments, provided {provided}",
-                    expected.start, expected.end
-                )),
+        Self(Value::from(CompoundCondition::from((
+            Assertion::new(),
+            Message::new(format!(
+                "expected {} to {} arguments, provided {provided}",
+                expected.start, expected.end
             )),
-        )))
+        ))))
     }
 
     pub fn no_cont() -> Self {
-        Self(Value::from_rust_type(CompoundCondition::from((
+        Self(Value::from(CompoundCondition::from((
             Assertion::new(),
             Message::new("no continuation argument passed to this function"),
         ))))
     }
 
     pub fn implementation_restriction(msg: impl fmt::Display) -> Self {
-        Self(Value::from_rust_type(CompoundCondition::from((
+        Self(Value::from(CompoundCondition::from((
             Assertion::new(),
             ImplementationRestriction::new(),
             Message::new(msg),
@@ -202,96 +185,92 @@ impl Exception {
     ///
     /// Example: Integer to a Complex
     pub fn conversion_error(expected: &str, provided: &str) -> Self {
-        Self(Value::from(Record::from_rust_type(
-            CompoundCondition::from((
-                Assertion::new(),
-                Message::new(format!("cannot convert {provided} into {expected}")),
-            )),
-        )))
+        Self(Value::from(CompoundCondition::from((
+            Assertion::new(),
+            Message::new(format!("cannot convert {provided} into {expected}")),
+        ))))
     }
 
     /// For when we cannot represent the value into the requested type.
     ///
     /// Example: an u128 number as an u8
     pub fn not_representable(value: &str, r#type: &str) -> Self {
-        Self(Value::from(Record::from_rust_type(
-            CompoundCondition::from((
-                Assertion::new(),
-                Message::new(format!("cannot represent '{value}' as {type}")),
-            )),
-        )))
+        Self(Value::from(CompoundCondition::from((
+            Assertion::new(),
+            Message::new(format!("cannot represent '{value}' as {type}")),
+        ))))
     }
 
     pub fn io_error(message: impl fmt::Display) -> Self {
-        Self(Value::from(Record::from_rust_type(
-            CompoundCondition::from((IoError::new(), Assertion::new(), Message::new(message))),
-        )))
+        Self(Value::from(CompoundCondition::from((
+            IoError::new(),
+            Assertion::new(),
+            Message::new(message),
+        ))))
     }
 
     pub fn io_read_error(message: impl fmt::Display) -> Self {
-        Self(Value::from(Record::from_rust_type(
-            CompoundCondition::from((IoReadError::new(), Assertion::new(), Message::new(message))),
-        )))
+        Self(Value::from(CompoundCondition::from((
+            IoReadError::new(),
+            Assertion::new(),
+            Message::new(message),
+        ))))
     }
 
     pub fn io_write_error(message: impl fmt::Display) -> Self {
-        Self(Value::from(Record::from_rust_type(
-            CompoundCondition::from((IoWriteError::new(), Assertion::new(), Message::new(message))),
-        )))
+        Self(Value::from(CompoundCondition::from((
+            IoWriteError::new(),
+            Assertion::new(),
+            Message::new(message),
+        ))))
     }
 
     pub fn io_decoding_error(message: impl fmt::Display, port: Value) -> Self {
-        Self(Value::from(Record::from_rust_type(
-            CompoundCondition::from((
-                IoDecodingError::new(port),
-                Assertion::new(),
-                Message::new(message),
-            )),
-        )))
+        Self(Value::from(CompoundCondition::from((
+            IoDecodingError::new(port),
+            Assertion::new(),
+            Message::new(message),
+        ))))
     }
 
     pub fn io_encoding_error(message: impl fmt::Display, port: Value, chr: char) -> Self {
-        Self(Value::from(Record::from_rust_type(
-            CompoundCondition::from((
-                IoEncodingError::new(port, chr),
-                Assertion::new(),
-                Message::new(message),
-            )),
-        )))
+        Self(Value::from(CompoundCondition::from((
+            IoEncodingError::new(port, chr),
+            Assertion::new(),
+            Message::new(message),
+        ))))
     }
 
     pub fn invalid_record_index(k: usize) -> Self {
         Self::error(format!("invalid record index: {k}"))
     }
 
-    pub fn add_condition(self, condition: impl SchemeCompatible) -> Self {
-        let mut conditions = if let Some(compound) = self.0.cast_to_rust_type::<CompoundCondition>()
+    pub fn add_condition(self, condition: impl Embeddable) -> Self {
+        let mut conditions = if let Some(compound) = self.0.cast_to::<Embedded<CompoundCondition>>()
         {
             compound.0.clone()
         } else {
             vec![self.0]
         };
 
-        conditions.push(Value::from(Record::from_rust_type(condition)));
+        conditions.push(Value::from(condition));
 
-        Self(Value::from(Record::from_rust_type(CompoundCondition(
-            conditions,
-        ))))
+        Self(Value::from(CompoundCondition(conditions)))
     }
 
     pub fn simple_conditions(&self) -> Result<Vec<Value>, Exception> {
-        if self.0.cast_to_rust_type::<SimpleCondition>().is_some() {
+        if self.0.cast_to::<Embedded<SimpleCondition>>().is_some() {
             Ok(vec![self.0.clone()])
-        } else if let Some(compound_condition) = self.0.cast_to_rust_type::<CompoundCondition>() {
+        } else if let Some(compound_condition) = self.0.cast_to::<Embedded<CompoundCondition>>() {
             Ok(compound_condition.0.clone())
         } else {
             Err(Exception::error("not a simple or compound condition"))
         }
     }
 
-    pub fn condition<T: SchemeCompatible>(&self) -> Result<Option<Gc<T>>, Exception> {
+    pub fn condition<T: Embeddable>(&self) -> Result<Option<Embedded<T>>, Exception> {
         for condition in self.simple_conditions()?.into_iter() {
-            if let Some(condition) = condition.cast_to_rust_type::<T>() {
+            if let Some(condition) = condition.cast_to::<Embedded<T>>() {
                 return Ok(Some(condition));
             }
         }
@@ -313,17 +292,17 @@ impl Exception {
 
         writeln!(f, "Uncaught exception:")?;
         for condition in conditions.into_iter().rev() {
-            if let Some(message) = condition.cast_to_rust_type::<Message>() {
+            if let Some(message) = condition.cast_to::<Embedded<Message>>() {
                 writeln!(f, " - Message: {}", message.message)?;
-            } else if let Some(syntax) = condition.cast_to_rust_type::<SyntaxViolation>() {
+            } else if let Some(syntax) = condition.cast_to::<Embedded<SyntaxViolation>>() {
                 writeln!(f, " - Syntax error in form: {:?}", syntax.form)?;
                 source_cache.pretty_print_condition(syntax.as_ref(), f)?;
-            } else if let Some(trace) = condition.cast_to_rust_type::<StackTrace>() {
+            } else if let Some(trace) = condition.cast_to::<Embedded<StackTrace>>() {
                 if !trace.trace.is_empty() {
                     writeln!(f, " - Trace:")?;
                     source_cache.pretty_print_condition(trace.as_ref(), f)?;
                 }
-            } else if condition.cast_to_rust_type::<Assertion>().is_some() {
+            } else if condition.cast_to::<Embedded<Assertion>>().is_some() {
                 writeln!(f, " - Assertion failed")?;
             } else {
                 writeln!(f, " - Condition: {condition:?}")?;
@@ -355,25 +334,25 @@ impl From<std::io::Error> for Exception {
 
 impl From<SimpleCondition> for Exception {
     fn from(simple: SimpleCondition) -> Self {
-        Self(Value::from(Record::from_rust_type(simple)))
+        Self(Value::from(simple))
     }
 }
 
 impl From<Warning> for Exception {
     fn from(warning: Warning) -> Self {
-        Self(Value::from(Record::from_rust_type(warning)))
+        Self(Value::from(warning))
     }
 }
 
 impl From<Serious> for Exception {
     fn from(serious: Serious) -> Self {
-        Self(Value::from(Record::from_rust_type(serious)))
+        Self(Value::from(serious))
     }
 }
 
 impl From<Message> for Exception {
     fn from(message: Message) -> Self {
-        Self(Value::from(Record::from_rust_type(message)))
+        Self(Value::from(message))
     }
 }
 
@@ -445,11 +424,12 @@ impl SimpleCondition {
     }
 }
 
-impl SchemeCompatible for SimpleCondition {
+impl Embeddable for SimpleCondition {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(
             lib: "(rnrs conditions (6))",
             name: "&condition",
+            ty: SimpleCondition,
             constructor: || Ok(SimpleCondition)
         )
     }
@@ -463,8 +443,8 @@ impl fmt::Debug for SimpleCondition {
 
 #[bridge(name = "condition?", lib = "(rnrs conditions (6))")]
 pub fn condition_pred(obj: &Value) -> Result<Vec<Value>, Exception> {
-    let is_condition = obj.cast_to_rust_type::<SimpleCondition>().is_some()
-        || obj.cast_to_rust_type::<CompoundCondition>().is_some();
+    let is_condition = obj.cast_to::<Embedded<SimpleCondition>>().is_some()
+        || obj.cast_to::<Embedded<CompoundCondition>>().is_some();
     Ok(vec![Value::from(is_condition)])
 }
 
@@ -477,7 +457,7 @@ define_condition_type!(
         message: String,
     },
     constructor: |message| {
-        Ok(Message { parent: Gc::new(SimpleCondition::new()), message: message.to_string() })
+        Ok(Message { parent: SimpleCondition::new(), message: message.to_string() })
     },
     debug: |this, f| {
         write!(f, " ")?;
@@ -488,7 +468,7 @@ define_condition_type!(
 impl Message {
     pub fn new(message: impl fmt::Display) -> Self {
         Self {
-            parent: Gc::new(SimpleCondition::new()),
+            parent: SimpleCondition::new(),
             message: message.to_string(),
         }
     }
@@ -504,7 +484,7 @@ define_condition_type!(
 impl Warning {
     pub fn new() -> Self {
         Self {
-            parent: Gc::new(SimpleCondition::new()),
+            parent: SimpleCondition::new(),
         }
     }
 }
@@ -525,7 +505,7 @@ define_condition_type!(
 impl Serious {
     pub fn new() -> Self {
         Self {
-            parent: Gc::new(SimpleCondition::new()),
+            parent: SimpleCondition::new(),
         }
     }
 }
@@ -546,7 +526,7 @@ define_condition_type!(
     },
     constructor: |trace| {
         Ok(StackTrace {
-            parent: Gc::new(SimpleCondition::new()),
+            parent: SimpleCondition::new(),
             trace: trace.clone().try_into()?,
         })
     },
@@ -561,7 +541,7 @@ define_condition_type!(
 impl PrettyCondition for StackTrace {
     fn span(&self) -> Span {
         let first = self.trace.first().unwrap();
-        let Some(syntax) = first.cast_to_scheme_type::<Gc<Syntax>>() else {
+        let Some(syntax) = first.cast_to::<Gc<Syntax>>() else {
             return Span::default();
         };
         syntax.span().clone()
@@ -569,7 +549,7 @@ impl PrettyCondition for StackTrace {
 
     fn pretty_print(&self, w: &mut impl fmt::Write) -> fmt::Result {
         for (i, trace) in self.trace.iter().enumerate() {
-            let Some(syntax) = trace.cast_to_scheme_type::<Gc<Syntax>>() else {
+            let Some(syntax) = trace.cast_to::<Gc<Syntax>>() else {
                 continue;
             };
             let span = syntax.span();
@@ -583,13 +563,17 @@ impl PrettyCondition for StackTrace {
 impl StackTrace {
     pub fn new(trace: Vec<Value>) -> Self {
         Self {
-            parent: Gc::new(SimpleCondition::new()),
+            parent: SimpleCondition::new(),
             trace: Vector::from(trace),
         }
     }
 
     pub fn trace(&self) -> Vec<Syntax> {
-        todo!()
+        self.trace
+            .iter()
+            .filter_map(|v| v.cast_to::<Gc<Syntax>>())
+            .map(|syntax| syntax.as_ref().clone())
+            .collect()
     }
 }
 
@@ -603,7 +587,7 @@ define_condition_type!(
 impl Error {
     pub fn new() -> Self {
         Self {
-            parent: Gc::new(Serious::new()),
+            parent: Serious::new(),
         }
     }
 }
@@ -623,7 +607,7 @@ define_condition_type!(
         library: String,
     },
     constructor: |lib| {
-        Ok(ImportError {  parent: Gc::new(Error::new()), library: lib.to_string() })
+        Ok(ImportError {  parent: Error::new(), library: lib.to_string() })
     },
     debug: |this, f| {
         write!(f, " library: {}", this.library)
@@ -633,7 +617,7 @@ define_condition_type!(
 impl ImportError {
     pub fn new(library: String) -> Self {
         Self {
-            parent: Gc::new(Error::new()),
+            parent: Error::new(),
             library,
         }
     }
@@ -649,7 +633,7 @@ define_condition_type!(
 impl Violation {
     pub fn new() -> Self {
         Self {
-            parent: Gc::new(Serious::new()),
+            parent: Serious::new(),
         }
     }
 }
@@ -670,7 +654,7 @@ define_condition_type!(
 impl Assertion {
     pub fn new() -> Self {
         Self {
-            parent: Gc::new(Violation::new()),
+            parent: Violation::new(),
         }
     }
 }
@@ -690,7 +674,7 @@ define_condition_type!(
         irritants: Value,
     },
     constructor: |irritants| {
-        Ok(Irritants { parent: Gc::new(SimpleCondition::new()), irritants })
+        Ok(Irritants { parent: SimpleCondition::new(), irritants })
     },
     debug: |this, f| {
         write!(f, " irritants: {:?}", this.irritants)
@@ -700,7 +684,7 @@ define_condition_type!(
 impl Irritants {
     pub fn new(irritants: Value) -> Self {
         Irritants {
-            parent: Gc::new(SimpleCondition::new()),
+            parent: SimpleCondition::new(),
             irritants,
         }
     }
@@ -715,7 +699,7 @@ define_condition_type!(
         who: Value,
     },
     constructor: |who| {
-        Ok(Who { parent: Gc::new(SimpleCondition::new()), who, })
+        Ok(Who { parent: SimpleCondition::new(), who, })
     },
     debug: |this, f| {
         write!(f, " who: {:?}", this.who)
@@ -725,7 +709,7 @@ define_condition_type!(
 impl Who {
     pub fn new(who: Value) -> Self {
         Who {
-            parent: Gc::new(SimpleCondition::new()),
+            parent: SimpleCondition::new(),
             who,
         }
     }
@@ -741,7 +725,7 @@ define_condition_type!(
 impl Default for NonContinuable {
     fn default() -> Self {
         Self {
-            parent: Gc::new(Violation::new()),
+            parent: Violation::new(),
         }
     }
 }
@@ -761,7 +745,7 @@ impl ImplementationRestriction {
 impl Default for ImplementationRestriction {
     fn default() -> Self {
         Self {
-            parent: Gc::new(Violation::new()),
+            parent: Violation::new(),
         }
     }
 }
@@ -776,7 +760,7 @@ define_condition_type!(
 impl Lexical {
     pub fn new() -> Self {
         Self {
-            parent: Gc::new(Violation::new()),
+            parent: Violation::new(),
         }
     }
 }
@@ -798,7 +782,7 @@ define_condition_type!(
     },
     constructor: |form, subform| {
         let subform = if subform.is_true() { Some(subform) } else { None };
-        Ok(SyntaxViolation { parent: Gc::new(Violation::new()), form, subform })
+        Ok(SyntaxViolation { parent: Violation::new(), form, subform })
     },
 );
 
@@ -807,7 +791,7 @@ impl PrettyCondition for SyntaxViolation {
         self.subform
             .as_ref()
             .unwrap_or(&self.form)
-            .cast_to_scheme_type::<Gc<Syntax>>()
+            .cast_to::<Gc<Syntax>>()
             .unwrap()
             .span()
             .clone()
@@ -817,7 +801,7 @@ impl PrettyCondition for SyntaxViolation {
 impl SyntaxViolation {
     pub fn new(form: Syntax, subform: Option<Syntax>) -> Self {
         Self {
-            parent: Gc::new(Violation::new()),
+            parent: Violation::new(),
             form: Value::from(form),
             subform: subform.map(Value::from),
         }
@@ -825,7 +809,7 @@ impl SyntaxViolation {
 
     pub fn new_from_values(form: Value, subform: Option<Value>) -> Self {
         Self {
-            parent: Gc::new(Violation::new()),
+            parent: Violation::new(),
             form,
             subform,
         }
@@ -842,7 +826,7 @@ define_condition_type!(
 impl Undefined {
     pub fn new() -> Self {
         Self {
-            parent: Gc::new(Violation::new()),
+            parent: Violation::new(),
         }
     }
 }
@@ -856,11 +840,12 @@ impl Default for Undefined {
 #[derive(Clone, Trace)]
 pub struct CompoundCondition(pub(crate) Vec<Value>);
 
-impl SchemeCompatible for CompoundCondition {
+impl Embeddable for CompoundCondition {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(
             lib: "(rnrs conditions (6))",
             name: "compound-condition",
+            ty: CompoundCondition,
             sealed: true,
             opaque: true
         )
@@ -882,36 +867,31 @@ where
     CompoundCondition: From<T>,
 {
     fn from(value: T) -> Self {
-        Self(Value::from(Record::from_rust_type(
-            CompoundCondition::from(value),
-        )))
+        Self(Value::from(CompoundCondition::from(value)))
     }
 }
 
 impl<A, B> From<(A, B)> for CompoundCondition
 where
-    A: SchemeCompatible,
-    B: SchemeCompatible,
+    A: Embeddable,
+    B: Embeddable,
 {
     fn from(value: (A, B)) -> Self {
-        Self(vec![
-            Value::from(Record::from_rust_type(value.0)),
-            Value::from(Record::from_rust_type(value.1)),
-        ])
+        Self(vec![Value::from(value.0), Value::from(value.1)])
     }
 }
 
 impl<A, B, C> From<(A, B, C)> for CompoundCondition
 where
-    A: SchemeCompatible,
-    B: SchemeCompatible,
-    C: SchemeCompatible,
+    A: Embeddable,
+    B: Embeddable,
+    C: Embeddable,
 {
     fn from(value: (A, B, C)) -> Self {
         Self(vec![
-            Value::from(Record::from_rust_type(value.0)),
-            Value::from(Record::from_rust_type(value.1)),
-            Value::from(Record::from_rust_type(value.2)),
+            Value::from(value.0),
+            Value::from(value.1),
+            Value::from(value.2),
         ])
     }
 }
@@ -921,9 +901,7 @@ pub fn condition(conditions: &[Value]) -> Result<Vec<Value>, Exception> {
     match conditions {
         // TODO: Check if this is a condition
         [simple_condition] => Ok(vec![simple_condition.clone()]),
-        conditions => Ok(vec![Value::from(Record::from_rust_type(
-            CompoundCondition(conditions.to_vec()),
-        ))]),
+        conditions => Ok(vec![Value::from(CompoundCondition(conditions.to_vec()))]),
     }
 }
 
@@ -985,7 +963,7 @@ pub fn raise_builtin(
 
 /// Raises a non-continuable exception to the current exception handler.
 pub fn raise(runtime: Runtime, raised: Value, barrier: &mut ContBarrier) -> Application {
-    let raised = if let Some(condition) = raised.cast_to_scheme_type::<Exception>() {
+    let raised = if let Some(condition) = raised.cast_to::<Exception>() {
         let trace = barrier.current_marks(Symbol::intern("trace"));
         Value::from(condition.add_condition(StackTrace::new(trace)))
     } else {
@@ -1084,7 +1062,7 @@ unsafe extern "C" fn reraise_exception(
     unsafe {
         let runtime = Runtime(Gc::from_raw_inc_rc(runtime));
 
-        let exception = Value::from_rust_type(NonContinuable::default());
+        let exception = Value::from(NonContinuable::default());
 
         Box::into_raw(Box::new(Application::new(
             Procedure::new(
@@ -1127,12 +1105,10 @@ pub fn raise_continuable(
 pub fn error(who: &Value, message: &Value, irritants: &[Value]) -> Result<Vec<Value>, Exception> {
     let mut conditions = Vec::new();
     if who.is_true() {
-        conditions.push(Value::from_rust_type(Who::new(who.clone())));
+        conditions.push(Value::from(Who::new(who.clone())));
     }
-    conditions.push(Value::from_rust_type(Message::new(message)));
-    conditions.push(Value::from_rust_type(Irritants::new(slice_to_list(
-        irritants,
-    ))));
+    conditions.push(Value::from(Message::new(message)));
+    conditions.push(Value::from(Irritants::new(slice_to_list(irritants))));
     Err(Exception(Value::from(Exception::from(CompoundCondition(
         conditions,
     )))))
@@ -1145,14 +1121,12 @@ pub fn assertion_violation(
     irritants: &[Value],
 ) -> Result<Vec<Value>, Exception> {
     let mut conditions = Vec::new();
-    conditions.push(Value::from_rust_type(Assertion::new()));
+    conditions.push(Value::from(Assertion::new()));
     if who.is_true() {
-        conditions.push(Value::from_rust_type(Who::new(who.clone())));
+        conditions.push(Value::from(Who::new(who.clone())));
     }
-    conditions.push(Value::from_rust_type(Message::new(message)));
-    conditions.push(Value::from_rust_type(Irritants::new(slice_to_list(
-        irritants,
-    ))));
+    conditions.push(Value::from(Message::new(message)));
+    conditions.push(Value::from(Irritants::new(slice_to_list(irritants))));
     Err(Exception(Value::from(Exception::from(CompoundCondition(
         conditions,
     )))))

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -541,7 +541,7 @@ define_condition_type!(
 impl PrettyCondition for StackTrace {
     fn span(&self) -> Span {
         let first = self.trace.first().unwrap();
-        let Some(syntax) = first.cast_to::<Gc<Syntax>>() else {
+        let Some(syntax) = first.cast_to::<Embedded<Syntax>>() else {
             return Span::default();
         };
         syntax.span().clone()
@@ -549,7 +549,7 @@ impl PrettyCondition for StackTrace {
 
     fn pretty_print(&self, w: &mut impl fmt::Write) -> fmt::Result {
         for (i, trace) in self.trace.iter().enumerate() {
-            let Some(syntax) = trace.cast_to::<Gc<Syntax>>() else {
+            let Some(syntax) = trace.cast_to::<Embedded<Syntax>>() else {
                 continue;
             };
             let span = syntax.span();
@@ -571,7 +571,7 @@ impl StackTrace {
     pub fn trace(&self) -> Vec<Syntax> {
         self.trace
             .iter()
-            .filter_map(|v| v.cast_to::<Gc<Syntax>>())
+            .filter_map(|v| v.cast_to::<Embedded<Syntax>>())
             .map(|syntax| syntax.as_ref().clone())
             .collect()
     }
@@ -791,7 +791,7 @@ impl PrettyCondition for SyntaxViolation {
         self.subform
             .as_ref()
             .unwrap_or(&self.form)
-            .cast_to::<Gc<Syntax>>()
+            .cast_to::<Embedded<Syntax>>()
             .unwrap()
             .span()
             .clone()

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -424,7 +424,7 @@ impl SimpleCondition {
     }
 }
 
-impl Embeddable for SimpleCondition {
+unsafe impl Embeddable for SimpleCondition {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(
             lib: "(rnrs conditions (6))",
@@ -840,7 +840,7 @@ impl Default for Undefined {
 #[derive(Clone, Trace)]
 pub struct CompoundCondition(pub(crate) Vec<Value>);
 
-impl Embeddable for CompoundCondition {
+unsafe impl Embeddable for CompoundCondition {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(
             lib: "(rnrs conditions (6))",

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -246,8 +246,7 @@ impl Exception {
     }
 
     pub fn add_condition(self, condition: impl Embeddable) -> Self {
-        let mut conditions = if let Some(compound) = self.0.cast::<Embedded<CompoundCondition>>()
-        {
+        let mut conditions = if let Some(compound) = self.0.cast::<Embedded<CompoundCondition>>() {
             compound.0.clone()
         } else {
             vec![self.0]

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -15,7 +15,7 @@
 //! which can be used to extract a stack trace for the exception:
 //!
 //! ```
-//! # use scheme_rs::{exceptions::{Exception, Message, SyntaxViolation, StackTrace}, records::Embedded, gc::Gc, syntax::Syntax};
+//! # use scheme_rs::{exceptions::{Exception, Message, SyntaxViolation, StackTrace}, records::Embedded, syntax::Syntax};
 //! // Code from scheme-rs repl to print errors:
 //! fn print_exception(exception: Exception) {
 //!     let Ok(conditions) = exception.simple_conditions() else {
@@ -27,17 +27,17 @@
 //!     };
 //!     println!("Uncaught exception:");
 //!     for condition in conditions.into_iter() {
-//!         if let Some(message) = condition.cast_to::<Embedded<Message>>() {
+//!         if let Some(message) = condition.cast::<Embedded<Message>>() {
 //!             println!(" - Message: {}", message.message);
-//!         } else if let Some(syntax) = condition.cast_to::<Embedded<SyntaxViolation>>() {
+//!         } else if let Some(syntax) = condition.cast::<Embedded<SyntaxViolation>>() {
 //!             println!(" - Syntax error in form: {:?}", syntax.form);
 //!             if let Some(subform) = syntax.subform.as_ref() {
 //!                 println!("   (subform: {subform:?})");
 //!             }
-//!         } else if let Some(trace) = condition.cast_to::<Embedded<StackTrace>>() {
+//!         } else if let Some(trace) = condition.cast::<Embedded<StackTrace>>() {
 //!             println!(" - Stack trace:");
 //!             for (i, trace) in trace.trace.iter().enumerate() {
-//!                 let syntax = trace.cast_to::<Gc<Syntax>>().unwrap();
+//!                 let syntax = trace.cast::<Embedded<Syntax>>().unwrap();
 //!                 let span = syntax.span();
 //!                 let func_name = syntax.as_ident().unwrap().symbol();
 //!                 println!("{:>6}: {func_name}:{span}", i + 1);
@@ -48,6 +48,7 @@
 //!     }
 //! }
 //! ```
+#![allow(clippy::derivable_impls)]
 
 use crate::{
     gc::{Gc, GcInner, Trace},
@@ -728,6 +729,7 @@ impl Default for NonContinuable {
         }
     }
 }
+
 define_condition_type!(
     lib: "(rnrs conditions (6))",
     rust_name: ImplementationRestriction,

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -5,7 +5,7 @@ use crate::{
     exceptions::Exception,
     gc::{Gc, Trace},
     proc::Procedure,
-    records::{Record, RecordTypeDescriptor, SchemeCompatible, rtd},
+    records::{Embeddable, Embedded, RecordTypeDescriptor, rtd},
     symbols::Symbol,
     syntax::{Identifier, Span, Syntax},
     value::Value,
@@ -364,9 +364,9 @@ fn match_vec(patterns: &[Pattern], expr: &Syntax, env: &mut MatchEnv) -> bool {
     }
 }
 
-impl SchemeCompatible for Pattern {
+impl Embeddable for Pattern {
     fn rtd() -> Arc<RecordTypeDescriptor> {
-        rtd!(name: "pattern", sealed: true, opaque: true)
+        rtd!(ty: Pattern, name: "pattern", sealed: true, opaque: true)
     }
 }
 
@@ -381,9 +381,9 @@ pub struct MatchEnv {
     binds: HashMap<Binding, Match>,
 }
 
-impl SchemeCompatible for MatchEnv {
+impl Embeddable for MatchEnv {
     fn rtd() -> Arc<RecordTypeDescriptor> {
-        rtd!(name: "match-env", sealed: true, opaque: true)
+        rtd!(ty: MatchEnv, name: "match-env", sealed: true, opaque: true)
     }
 }
 
@@ -392,23 +392,23 @@ pub struct ExpansionCombiner {
     pub(crate) uses: HashMap<Binding, usize>,
 }
 
-impl SchemeCompatible for ExpansionCombiner {
+impl Embeddable for ExpansionCombiner {
     fn rtd() -> Arc<RecordTypeDescriptor> {
-        rtd!(name: "expansion-combiner", sealed: true, opaque: true)
+        rtd!(ty: ExpansionCombiner, name: "expansion-combiner", sealed: true, opaque: true)
     }
 }
 
 #[runtime_fn]
 unsafe extern "C" fn matches(pattern: *const (), value: *const ()) -> *const () {
     let pattern = unsafe { Value::from_raw_inc_rc(pattern) };
-    let pattern = pattern.try_to_rust_type::<Pattern>().unwrap();
+    let pattern = pattern.try_to::<Embedded<Pattern>>().unwrap();
 
     let value = unsafe { Value::from_raw_inc_rc(value) };
     let syntax = Syntax::wrap(value, &Span::default());
 
     let mut env = MatchEnv::default();
     if pattern.matches(&syntax, &mut env) {
-        Value::into_raw(Value::from(Record::from_rust_type(env)))
+        Value::into_raw(Value::from(env))
     } else {
         Value::into_raw(Value::from(false))
     }
@@ -838,9 +838,9 @@ fn check_escaped_template(expr: &Syntax, env: &Environment) -> Vec<(Symbol, isiz
     }
 }
 
-impl SchemeCompatible for Template {
+impl Embeddable for Template {
     fn rtd() -> Arc<RecordTypeDescriptor> {
-        rtd!(name: "template", sealed: true, opaque: true)
+        rtd!(ty: Template, name: "template", sealed: true, opaque: true)
     }
 }
 
@@ -853,17 +853,17 @@ unsafe extern "C" fn expand_template(
     error: *mut Value,
 ) -> *const () {
     let template = unsafe { Value::from_raw_inc_rc(template) };
-    let template = template.try_to_rust_type::<Template>().unwrap();
+    let template = template.try_to::<Embedded<Template>>().unwrap();
 
     let expansion_combiner = unsafe { Value::from_raw_inc_rc(expansion_combiner) };
     let expansion_combiner = expansion_combiner
-        .try_to_rust_type::<ExpansionCombiner>()
+        .try_to::<Embedded<ExpansionCombiner>>()
         .unwrap();
 
     let envs = (0..num_expansions)
         .map(|i| {
             let env = unsafe { Value::from_raw_inc_rc(expansions.add(i as usize).read()) };
-            let env = env.try_to_rust_type::<MatchEnv>().unwrap();
+            let env = env.try_to::<Embedded<MatchEnv>>().unwrap();
             env.as_ref().clone()
         })
         .collect::<Vec<_>>();

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -364,7 +364,7 @@ fn match_vec(patterns: &[Pattern], expr: &Syntax, env: &mut MatchEnv) -> bool {
     }
 }
 
-impl Embeddable for Pattern {
+unsafe impl Embeddable for Pattern {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(ty: Pattern, name: "pattern", sealed: true, opaque: true)
     }
@@ -381,7 +381,7 @@ pub struct MatchEnv {
     binds: HashMap<Binding, Match>,
 }
 
-impl Embeddable for MatchEnv {
+unsafe impl Embeddable for MatchEnv {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(ty: MatchEnv, name: "match-env", sealed: true, opaque: true)
     }
@@ -392,7 +392,7 @@ pub struct ExpansionCombiner {
     pub(crate) uses: HashMap<Binding, usize>,
 }
 
-impl Embeddable for ExpansionCombiner {
+unsafe impl Embeddable for ExpansionCombiner {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(ty: ExpansionCombiner, name: "expansion-combiner", sealed: true, opaque: true)
     }
@@ -838,7 +838,7 @@ fn check_escaped_template(expr: &Syntax, env: &Environment) -> Vec<(Symbol, isiz
     }
 }
 
-impl Embeddable for Template {
+unsafe impl Embeddable for Template {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(ty: Template, name: "template", sealed: true, opaque: true)
     }

--- a/src/futures.rs
+++ b/src/futures.rs
@@ -16,14 +16,14 @@ use crate::{
     exceptions::Exception,
     ports::{BufferMode, Port},
     proc::{ContBarrier, Procedure},
-    records::{Record, RecordTypeDescriptor, SchemeCompatible, rtd},
+    records::{Embeddable, Embedded, RecordTypeDescriptor, rtd},
     strings::WideString,
     value::Value,
 };
 
 type Future = Shared<BoxFuture<'static, Result<Vec<Value>, Exception>>>;
 
-impl SchemeCompatible for Future {
+unsafe impl Embeddable for Future {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(
             ty: Future,
@@ -39,7 +39,7 @@ pub async fn make_future(proc: Procedure) -> Result<Vec<Value>, Exception> {
     let future: Future = async move { proc.call(&[], &mut ContBarrier::new()).await }
         .boxed()
         .shared();
-    let future = Value::from_rust_type(future);
+    let future = Value::from(future);
     Ok(vec![future])
 }
 
@@ -48,18 +48,19 @@ pub async fn spawn(task: &Value) -> Result<Vec<Value>, Exception> {
     let task: Procedure = task.clone().try_into()?;
     let task = tokio::task::spawn(async move { task.call(&[], &mut ContBarrier::new()).await });
     let future: Future = async move { task.await.unwrap() }.boxed().shared();
-    let future = Value::from(Record::from_rust_type(future));
+    let future = Value::from(future);
     Ok(vec![future])
 }
 
 #[bridge(name = "await", lib = "(async)")]
 pub async fn await_future(future: &Value) -> Result<Vec<Value>, Exception> {
-    future.try_to_rust_type::<Future>()?.as_ref().clone().await
+    future.try_to::<Embedded<Future>>()?.as_ref().clone().await
 }
 
-impl SchemeCompatible for Arc<TcpListener> {
+unsafe impl Embeddable for Arc<TcpListener> {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(
+            ty: Arc<TcpListener>,
             name: "tcp-listener",
             opaque: true,
             sealed: true,
@@ -73,13 +74,14 @@ pub async fn bind_tcp(addr: &Value) -> Result<Vec<Value>, Exception> {
     let listener = TcpListener::bind(&addr.to_string())
         .await
         .map_err(|e| Exception::error(format!("failed to bind to address: {e}")))?;
-    let listener = Value::from(Record::from_rust_type(Arc::new(listener)));
+    let listener = Value::from(Arc::new(listener));
     Ok(vec![listener])
 }
 
-impl SchemeCompatible for Arc<Mutex<TcpStream>> {
+unsafe impl Embeddable for Arc<Mutex<TcpStream>> {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(
+            ty: Arc<Mutex<TcpStream>>,
             name: "socket",
             opaque: true,
             sealed: true,
@@ -89,7 +91,12 @@ impl SchemeCompatible for Arc<Mutex<TcpStream>> {
 
 #[bridge(name = "accept", lib = "(async)")]
 pub async fn accept(listener: &Value) -> Result<Vec<Value>, Exception> {
-    let listener = { listener.try_to_rust_type::<Arc<TcpListener>>()?.clone() };
+    let listener = {
+        listener
+            .try_to::<Embedded<Arc<TcpListener>>>()?
+            .as_ref()
+            .clone()
+    };
     let (socket, addr) = listener
         .accept()
         .await

--- a/src/futures.rs
+++ b/src/futures.rs
@@ -26,6 +26,7 @@ type Future = Shared<BoxFuture<'static, Result<Vec<Value>, Exception>>>;
 impl SchemeCompatible for Future {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(
+            ty: Future,
             name: "future",
             opaque: true,
             sealed: true,

--- a/src/gc/collection.rs
+++ b/src/gc/collection.rs
@@ -28,9 +28,7 @@ pub(crate) struct GcHeader {
     crc: isize,
     /// VTable for the type
     vtable: &'static VTable,
-    /// Layout of the entire allocation (`GcInner<T>` plus any trailing
-    /// flexible-array/embedded data). Stored per-object rather than in the
-    /// VTable because records of the same type may have different sizes.
+    /// Layout of the type and header
     layout: Layout,
     /// Next item in the heap, or null. Lower 3 bits are the color
     next: *mut GcHeader,

--- a/src/gc/collection.rs
+++ b/src/gc/collection.rs
@@ -28,6 +28,10 @@ pub(crate) struct GcHeader {
     crc: isize,
     /// VTable for the type
     vtable: &'static VTable,
+    /// Layout of the entire allocation (`GcInner<T>` plus any trailing
+    /// flexible-array/embedded data). Stored per-object rather than in the
+    /// VTable because records of the same type may have different sizes.
+    layout: Layout,
     /// Next item in the heap, or null. Lower 3 bits are the color
     next: *mut GcHeader,
     /// Previous item in the heap, or null. Lower 1 bit is the buffered flag
@@ -46,6 +50,7 @@ impl GcHeader {
             epoch_rc: 1,
             crc: 1,
             vtable: &INVALID_VTABLE,
+            layout: Layout::new::<super::GcInner<T>>(),
             next: null_mut(),
             prev: null_mut::<GcHeader>().map_addr(|addr| addr | 1),
         }
@@ -84,14 +89,12 @@ impl GcHeader {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct VTable {
     /// Type-erased visitor function
     visit_children: unsafe fn(this: *const (), visitor: &mut dyn FnMut(HeapObject<()>)),
     /// Type-erased finalizer function
     finalize: unsafe fn(this: *mut ()),
-    /// Layout for the underlying data
-    layout: Layout,
 }
 
 impl VTable {
@@ -105,7 +108,6 @@ impl VTable {
                 let this = this as *mut T;
                 T::finalize_or_skip(this.as_mut().unwrap());
             },
-            layout: Layout::new::<super::GcInner<T>>(),
         }
     }
 }
@@ -113,7 +115,6 @@ impl VTable {
 static INVALID_VTABLE: VTable = VTable {
     visit_children: |_, _| unreachable!(),
     finalize: |_| unreachable!(),
-    layout: unsafe { Layout::from_size_align_unchecked(0, 1) },
 };
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -173,7 +174,7 @@ impl HeapObject<()> {
         let header = NonNull::new(ptr as *mut UnsafeCell<GcHeader>).unwrap();
 
         let (_, header_offset) = Layout::new::<GcHeader>()
-            .extend(unsafe { (*header.as_ref().get()).vtable.layout })
+            .extend(unsafe { (*header.as_ref().get()).layout })
             .unwrap();
 
         let data = unsafe { (ptr as *mut ()).byte_add(header_offset) };
@@ -252,7 +253,7 @@ impl HeapObject<()> {
     }
 
     unsafe fn layout(&self) -> Layout {
-        unsafe { (*self.header.as_ref().get()).vtable.layout }
+        unsafe { (*self.header.as_ref().get()).layout }
     }
 
     unsafe fn data(&self) -> *const () {
@@ -287,7 +288,8 @@ impl HeapObject<()> {
 unsafe impl Send for HeapObject<()> {}
 unsafe impl Sync for HeapObject<()> {}
 
-pub(super) unsafe fn unroot<T: super::GcOrTrace>(gc: &super::Gc<T>) {
+#[allow(private_bounds)]
+pub(crate) unsafe fn unroot<T: super::GcOrTrace>(gc: &super::Gc<T>, layout: Layout) {
     let new_gc_ptr = gc.ptr.as_ptr() as *mut GcHeader;
 
     let mut heap = HEAP.lock();
@@ -302,6 +304,7 @@ pub(super) unsafe fn unroot<T: super::GcOrTrace>(gc: &super::Gc<T>) {
             .or_insert_with(|| Box::leak(Box::new(VTable::new::<T>())));
 
         (*new_gc_ptr).vtable = vtable;
+        (*new_gc_ptr).layout = layout;
 
         if heap.head.is_null() {
             heap.tail = new_gc_ptr;

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -499,16 +499,16 @@ where
 {
     unsafe fn visit_children(&self, visitor: &mut dyn FnMut(OpaqueGcPtr)) {
         unsafe {
-            for i in 0..N {
-                self[i].visit_or_recurse(visitor);
+            for item in self {
+                item.visit_or_recurse(visitor);
             }
         }
     }
 
     unsafe fn finalize(&mut self) {
         unsafe {
-            for i in 0..N {
-                self[i].finalize_or_skip();
+            for item in self {
+                item.finalize_or_skip();
             }
         }
     }

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -18,6 +18,7 @@ pub use collection::{OpaqueGcPtr, collect_garbage, init_gc};
 pub use scheme_rs_macros::Trace;
 
 use std::{
+    alloc::Layout,
     any::Any,
     cell::UnsafeCell,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
@@ -29,10 +30,9 @@ use std::{
     ptr::{NonNull, drop_in_place},
 };
 
-use crate::{
-    Either,
-    gc::collection::{GcHeader, unroot},
-};
+pub(crate) use collection::unroot;
+
+use crate::{Either, gc::collection::GcHeader};
 
 /// A heap allocated garbage collected smart pointer. Gc requires that `T`
 /// implements the [`Trace`] trait to properly track references.
@@ -47,7 +47,7 @@ impl<T: Send + GcOrTrace + 'static> Gc<T> {
     pub fn new(data: T) -> Gc<T> {
         let new_gc = Self::rooted(data);
         unsafe {
-            unroot(&new_gc);
+            unroot(&new_gc, Layout::new::<GcInner<T>>());
         }
         new_gc
     }
@@ -89,7 +89,7 @@ impl<T: GcOrTrace> Gc<T> {
     /// an unrooted Gc object is undefined behavior.
     pub(crate) unsafe fn unroot(this: &Self) {
         unsafe {
-            unroot(this);
+            unroot(this, Layout::new::<GcInner<T>>());
         }
     }
 }
@@ -310,7 +310,26 @@ fn dec_rc<T: ?Sized>(ptr: NonNull<GcInner<T>>) {
 #[doc(hidden)]
 pub struct GcInner<T: ?Sized> {
     header: UnsafeCell<GcHeader>,
-    pub(crate) data: UnsafeCell<T>,
+    data: UnsafeCell<T>,
+}
+
+impl<T: Trace> GcInner<T> {
+    pub(crate) fn new(data: T) -> Self {
+        Self {
+            header: UnsafeCell::new(GcHeader::new::<T>()),
+            data: UnsafeCell::new(data),
+        }
+    }
+
+    pub(crate) fn data_mut(&mut self) -> &mut T {
+        self.data.get_mut()
+    }
+}
+
+impl<T> GcInner<T> {
+    pub(crate) const fn data_offset() -> usize {
+        std::mem::offset_of!(Self, data)
+    }
 }
 
 unsafe impl<T: ?Sized + Send> Send for GcInner<T> {}
@@ -470,6 +489,27 @@ where
             self.0.finalize_or_skip();
             self.1.finalize_or_skip();
             self.2.finalize_or_skip();
+        }
+    }
+}
+
+unsafe impl<T, const N: usize> Trace for [T; N]
+where
+    T: GcOrTrace,
+{
+    unsafe fn visit_children(&self, visitor: &mut dyn FnMut(OpaqueGcPtr)) {
+        unsafe {
+            for i in 0..N {
+                self[i].visit_or_recurse(visitor);
+            }
+        }
+    }
+
+    unsafe fn finalize(&mut self) {
+        unsafe {
+            for i in 0..N {
+                self[i].finalize_or_skip();
+            }
         }
     }
 }

--- a/src/hashtables.rs
+++ b/src/hashtables.rs
@@ -2,16 +2,19 @@
 
 use indexmap::IndexSet;
 use parking_lot::RwLock;
+use scheme_rs_macros::rtd;
 use std::{
     collections::HashSet,
     fmt,
     hash::{DefaultHasher, Hash, Hasher},
+    sync::Arc,
 };
 
 use crate::{
     exceptions::Exception,
-    gc::{Gc, Trace},
+    gc::Trace,
     proc::{ContBarrier, Procedure},
+    records::{Embeddable, Embedded, RecordTypeDescriptor},
     registry::bridge,
     strings::WideString,
     symbols::Symbol,
@@ -46,6 +49,15 @@ pub(crate) struct HashTableInner {
     hash: Procedure,
     /// Whether or not the hashtable is mutable
     mutable: bool,
+}
+
+unsafe impl Embeddable for HashTableInner {
+    fn rtd() -> Arc<RecordTypeDescriptor>
+    where
+        Self: Sized,
+    {
+        rtd!(ty: HashTableInner, name: "%hash-table", sealed: true, opaque: true)
+    }
 }
 
 impl HashTableInner {
@@ -233,8 +245,8 @@ impl HashTableInner {
     }
 }
 
-#[derive(Clone, Trace)]
-pub struct HashTable(pub(crate) Gc<HashTableInner>);
+#[derive(Clone, Trace, Debug)]
+pub struct HashTable(pub(crate) Embedded<HashTableInner>);
 
 impl HashTable {
     /*
@@ -252,7 +264,7 @@ impl HashTable {
     */
 
     pub fn new(hash: Procedure, eq: Procedure) -> Self {
-        Self(Gc::new(HashTableInner {
+        Self(Embedded::new(HashTableInner {
             table: RwLock::new(hashbrown::HashTable::new()),
             eq,
             hash,
@@ -261,7 +273,7 @@ impl HashTable {
     }
 
     pub fn with_capacity(hash: Procedure, eq: Procedure, cap: usize) -> Self {
-        Self(Gc::new(HashTableInner {
+        Self(Embedded::new(HashTableInner {
             table: RwLock::new(hashbrown::HashTable::with_capacity(cap)),
             eq,
             hash,
@@ -294,7 +306,7 @@ impl HashTable {
     }
 
     pub fn copy(&self, mutable: bool) -> Self {
-        Self(Gc::new(self.0.copy(mutable)))
+        Self(Embedded::new(self.0.copy(mutable)))
     }
 
     pub fn clear(&self) -> Result<(), Exception> {
@@ -310,10 +322,10 @@ impl HashTable {
     }
 }
 
-impl fmt::Debug for HashTable {
+impl fmt::Debug for HashTableInner {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "#hash(")?;
-        for (i, entry) in self.0.table.read().iter().enumerate() {
+        for (i, entry) in self.table.read().iter().enumerate() {
             if i > 0 {
                 write!(f, " ")?;
             }
@@ -361,6 +373,28 @@ impl Hash for EqualValue {
     }
 }
 
+impl From<HashTable> for Value {
+    fn from(value: HashTable) -> Self {
+        Value::from(value.0)
+    }
+}
+
+impl TryFrom<Value> for HashTable {
+    type Error = Exception;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        Ok(Self((&value).try_into()?))
+    }
+}
+
+impl TryFrom<&Value> for HashTable {
+    type Error = Exception;
+
+    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+        Ok(Self(value.try_into()?))
+    }
+}
+
 #[bridge(name = "make-hashtable", lib = "(rnrs hashtables builtins (6))")]
 pub fn make_hashtable(
     hash_function: &Value,
@@ -383,57 +417,51 @@ pub fn make_hashtable(
 }
 
 #[bridge(name = "hashtable?", lib = "(rnrs hashtables builtins (6))")]
-pub fn hashtable_pred(hashtable: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(
-        hashtable.type_of() == ValueType::HashTable,
-    )])
+pub fn hashtable_pred(obj: &Value) -> bool {
+    obj.is_a::<Embedded<HashTableInner>>()
 }
 
 #[bridge(name = "hashtable-size", lib = "(rnrs hashtables builtins (6))")]
-pub fn hashtable_size(hashtable: &Value) -> Result<Vec<Value>, Exception> {
-    let hashtable: HashTable = hashtable.clone().try_into()?;
-    Ok(vec![Value::from(hashtable.size())])
+pub fn hashtable_size(hashtable: HashTable) -> usize {
+    hashtable.size()
 }
 
 #[bridge(name = "hashtable-ref", lib = "(rnrs hashtables builtins (6))")]
 pub fn hashtable_ref(
-    hashtable: &Value,
+    hashtable: HashTable,
     key: &Value,
     default: &Value,
-) -> Result<Vec<Value>, Exception> {
-    let hashtable: HashTable = hashtable.clone().try_into()?;
-    Ok(vec![hashtable.get(key, default)?])
+) -> Result<Value, Exception> {
+    hashtable.get(key, default)
 }
 
 #[bridge(name = "hashtable-set!", lib = "(rnrs hashtables builtins (6))")]
 pub fn hashtable_set_bang(
-    hashtable: &Value,
+    hashtable: HashTable,
     key: &Value,
     obj: &Value,
-) -> Result<Vec<Value>, Exception> {
-    let hashtable: HashTable = hashtable.clone().try_into()?;
+) -> Result<(), Exception> {
     hashtable.set(key, obj)?;
-    Ok(Vec::new())
+    Ok(())
 }
 
 #[bridge(name = "hashtable-delete!", lib = "(rnrs hashtables builtins (6))")]
-pub fn hashtable_delete_bang(hashtable: &Value, key: &Value) -> Result<Vec<Value>, Exception> {
-    let hashtable: HashTable = hashtable.clone().try_into()?;
+pub fn hashtable_delete_bang(hashtable: HashTable, key: &Value) -> Result<(), Exception> {
     hashtable.delete(key)?;
-    Ok(Vec::new())
+    Ok(())
 }
 
 #[bridge(name = "hashtable-contains?", lib = "(rnrs hashtables builtins (6))")]
-pub fn hashtable_contains_pred(hashtable: &Value, key: &Value) -> Result<Vec<Value>, Exception> {
+pub fn hashtable_contains_pred(hashtable: HashTable, key: &Value) -> Result<bool, Exception> {
     let hashtable: HashTable = hashtable.clone().try_into()?;
-    Ok(vec![Value::from(hashtable.contains(key)?)])
+    Ok(hashtable.contains(key)?)
 }
 
 #[bridge(name = "hashtable-update!", lib = "(rnrs hashtables builtins (6))")]
 pub fn hashtable_update_bang(
-    hashtable: &Value,
+    hashtable: HashTable,
     key: &Value,
-    proc: &Value,
+    proc: Procedure,
     default: &Value,
 ) -> Result<Vec<Value>, Exception> {
     let hashtable: HashTable = hashtable.clone().try_into()?;
@@ -443,8 +471,7 @@ pub fn hashtable_update_bang(
 }
 
 #[bridge(name = "hashtable-copy", lib = "(rnrs hashtables builtins (6))")]
-pub fn hashtable_copy(hashtable: &Value, rest: &[Value]) -> Result<Vec<Value>, Exception> {
-    let hashtable: HashTable = hashtable.clone().try_into()?;
+pub fn hashtable_copy(hashtable: HashTable, rest: &[Value]) -> Result<Vec<Value>, Exception> {
     let mutable = match rest {
         [] => false,
         [mutable] => mutable.is_true(),
@@ -455,8 +482,7 @@ pub fn hashtable_copy(hashtable: &Value, rest: &[Value]) -> Result<Vec<Value>, E
 }
 
 #[bridge(name = "hashtable-clear!", lib = "(rnrs hashtables builtins (6))")]
-pub fn hashtable_clear_bang(hashtable: &Value, rest: &[Value]) -> Result<Vec<Value>, Exception> {
-    let hashtable: HashTable = hashtable.clone().try_into()?;
+pub fn hashtable_clear_bang(hashtable: HashTable, rest: &[Value]) -> Result<Vec<Value>, Exception> {
     let k = match rest {
         [] => None,
         [k] => Some(k.try_into()?),
@@ -478,15 +504,13 @@ pub fn hashtable_clear_bang(hashtable: &Value, rest: &[Value]) -> Result<Vec<Val
 }
 
 #[bridge(name = "hashtable-keys", lib = "(rnrs hashtables builtins (6))")]
-pub fn hashtable_keys(hashtable: &Value) -> Result<Vec<Value>, Exception> {
-    let hashtable: HashTable = hashtable.clone().try_into()?;
+pub fn hashtable_keys(hashtable: HashTable) -> Result<Vec<Value>, Exception> {
     let keys = Value::from(hashtable.keys());
     Ok(vec![keys])
 }
 
 #[bridge(name = "hashtable-entries", lib = "(rnrs hashtables builtins (6))")]
-pub fn hashtable_entries(hashtable: &Value) -> Result<Vec<Value>, Exception> {
-    let hashtable: HashTable = hashtable.clone().try_into()?;
+pub fn hashtable_entries(hashtable: HashTable) -> Result<Vec<Value>, Exception> {
     let (keys, values) = hashtable.entries();
     Ok(vec![Value::from(keys), Value::from(values)])
 }
@@ -495,8 +519,7 @@ pub fn hashtable_entries(hashtable: &Value) -> Result<Vec<Value>, Exception> {
     name = "hashtable-equivalence-function",
     lib = "(rnrs hashtables builtins (6))"
 )]
-pub fn hashtable_equivalence_function(hashtable: &Value) -> Result<Vec<Value>, Exception> {
-    let hashtable: HashTable = hashtable.clone().try_into()?;
+pub fn hashtable_equivalence_function(hashtable: HashTable) -> Result<Vec<Value>, Exception> {
     let eqv_func = Value::from(hashtable.0.eq.clone());
     Ok(vec![eqv_func])
 }
@@ -505,15 +528,13 @@ pub fn hashtable_equivalence_function(hashtable: &Value) -> Result<Vec<Value>, E
     name = "hashtable-hash-function",
     lib = "(rnrs hashtables builtins (6))"
 )]
-pub fn hashtable_hash_function(hashtable: &Value) -> Result<Vec<Value>, Exception> {
-    let hashtable: HashTable = hashtable.clone().try_into()?;
+pub fn hashtable_hash_function(hashtable: HashTable) -> Result<Vec<Value>, Exception> {
     let hash_func = Value::from(hashtable.0.hash.clone());
     Ok(vec![hash_func])
 }
 
 #[bridge(name = "hashtable-mutable?", lib = "(rnrs hashtables builtins (6))")]
-pub fn hashtable_mutable_pred(hashtable: &Value) -> Result<Vec<Value>, Exception> {
-    let hashtable: HashTable = hashtable.clone().try_into()?;
+pub fn hashtable_mutable_pred(hashtable: HashTable) -> Result<Vec<Value>, Exception> {
     let is_mutable = Value::from(hashtable.0.mutable);
     Ok(vec![is_mutable])
 }

--- a/src/hashtables.rs
+++ b/src/hashtables.rs
@@ -455,7 +455,6 @@ pub fn hashtable_delete_bang(hashtable: HashTable, key: &Value) -> Result<(), Ex
 
 #[bridge(name = "hashtable-contains?", lib = "(rnrs hashtables builtins (6))")]
 pub fn hashtable_contains_pred(hashtable: HashTable, key: &Value) -> Result<bool, Exception> {
-    let hashtable: HashTable = hashtable.clone().try_into()?;
     Ok(hashtable.contains(key)?)
 }
 
@@ -466,8 +465,6 @@ pub fn hashtable_update_bang(
     proc: Procedure,
     default: &Value,
 ) -> Result<Vec<Value>, Exception> {
-    let hashtable: HashTable = hashtable.clone().try_into()?;
-    let proc: Procedure = proc.clone().try_into()?;
     hashtable.update(key, &proc, default)?;
     Ok(Vec::new())
 }

--- a/src/hashtables.rs
+++ b/src/hashtables.rs
@@ -442,11 +442,7 @@ pub fn hashtable_ref(
 }
 
 #[bridge(name = "hashtable-set!", lib = "(rnrs hashtables builtins (6))")]
-pub fn hashtable_set_bang(
-    hashtable: HashTable,
-    key: &Value,
-    obj: &Value,
-) -> Result<(), Exception> {
+pub fn hashtable_set_bang(hashtable: HashTable, key: &Value, obj: &Value) -> Result<(), Exception> {
     hashtable.set(key, obj)?;
     Ok(())
 }

--- a/src/hashtables.rs
+++ b/src/hashtables.rs
@@ -389,7 +389,7 @@ impl TryFrom<Value> for HashTable {
 
 impl From<&Value> for Option<HashTable> {
     fn from(value: &Value) -> Self {
-        Some(HashTable(value.cast_to()?))
+        Some(HashTable(value.cast()?))
     }
 }
 

--- a/src/hashtables.rs
+++ b/src/hashtables.rs
@@ -18,7 +18,7 @@ use crate::{
     registry::bridge,
     strings::WideString,
     symbols::Symbol,
-    value::{Expect1, Value, ValueType},
+    value::{Expect1, Value},
 };
 
 #[derive(Clone, Trace)]
@@ -384,6 +384,12 @@ impl TryFrom<Value> for HashTable {
 
     fn try_from(value: Value) -> Result<Self, Self::Error> {
         Ok(Self((&value).try_into()?))
+    }
+}
+
+impl From<&Value> for Option<HashTable> {
+    fn from(value: &Value) -> Self {
+        Some(HashTable(value.cast_to()?))
     }
 }
 

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -37,9 +37,7 @@ unsafe impl Embeddable for Keyword {
 
 #[bridge(name = "keyword?", lib = "(srfi :88)")]
 pub fn keyword_pred(obj: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(
-        obj.cast::<Embedded<Keyword>>().is_some(),
-    )])
+    Ok(vec![Value::from(obj.cast::<Embedded<Keyword>>().is_some())])
 }
 
 #[bridge(name = "keyword->string", lib = "(srfi :88)")]

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -3,9 +3,10 @@ use std::sync::{Arc, LazyLock, Mutex};
 
 use scheme_rs_macros::{Trace, bridge};
 
+use crate::records::Embedded;
 use crate::{
     exceptions::Exception,
-    records::{RecordTypeDescriptor, SchemeCompatible, rtd},
+    records::{Embeddable, RecordTypeDescriptor, rtd},
     strings::WideString,
     symbols::Symbol,
     value::Value,
@@ -23,32 +24,30 @@ impl Keyword {
         let mut cache = INTERNED.lock().unwrap();
         cache
             .entry(sym)
-            .or_insert_with(|| Value::from_rust_type(Keyword(sym)))
+            .or_insert_with(|| Value::from(Keyword(sym)))
             .clone()
     }
 }
 
-impl SchemeCompatible for Keyword {
+impl Embeddable for Keyword {
     fn rtd() -> Arc<RecordTypeDescriptor> {
-        rtd!(name: "keyword", sealed: true, opaque: true)
+        rtd!(ty: Keyword, name: "keyword", sealed: true, opaque: true)
     }
 }
 
 #[bridge(name = "keyword?", lib = "(srfi :88)")]
 pub fn keyword_pred(obj: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
-        obj.cast_to_rust_type::<Keyword>().is_some(),
+        obj.cast_to::<Embedded<Keyword>>().is_some(),
     )])
 }
 
 #[bridge(name = "keyword->string", lib = "(srfi :88)")]
-pub fn keyword_to_string(obj: &Value) -> Result<Vec<Value>, Exception> {
-    let kw = obj.try_to_rust_type::<Keyword>()?;
+pub fn keyword_to_string(kw: Embedded<Keyword>) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(kw.0.to_str().to_string())])
 }
 
 #[bridge(name = "string->keyword", lib = "(srfi :88)")]
-pub fn string_to_keyword(s: &Value) -> Result<Vec<Value>, Exception> {
-    let s: WideString = s.clone().try_into()?;
+pub fn string_to_keyword(s: WideString) -> Result<Vec<Value>, Exception> {
     Ok(vec![Keyword::intern(&s.to_string())])
 }

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -38,7 +38,7 @@ unsafe impl Embeddable for Keyword {
 #[bridge(name = "keyword?", lib = "(srfi :88)")]
 pub fn keyword_pred(obj: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
-        obj.cast_to::<Embedded<Keyword>>().is_some(),
+        obj.cast::<Embedded<Keyword>>().is_some(),
     )])
 }
 

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -29,7 +29,7 @@ impl Keyword {
     }
 }
 
-impl Embeddable for Keyword {
+unsafe impl Embeddable for Keyword {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(ty: Keyword, name: "keyword", sealed: true, opaque: true)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@ pub mod threads;
 pub mod value;
 pub mod vectors;
 
+use std::hash::Hasher;
+
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 /// Internal `Either` type
@@ -42,6 +44,18 @@ enum Either<L, R> {
 impl<L, R> Either<L, R> {
     pub fn left_or(self, default: L) -> L {
         if let Self::Left(l) = self { l } else { default }
+    }
+}
+
+struct DynHasher<'a>(&'a mut dyn Hasher);
+
+impl Hasher for DynHasher<'_> {
+    fn finish(&self) -> u64 {
+        self.0.finish()
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        self.0.write(bytes)
     }
 }
 

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -214,7 +214,7 @@ impl From<&Value> for Option<List> {
             if !seen.insert(cdr.clone()) {
                 return None;
             }
-            let (car, new_cdr) = cdr.cast_to()?;
+            let (car, new_cdr) = cdr.cast()?;
             items.push(car);
             cdr = new_cdr;
         }
@@ -254,7 +254,7 @@ impl TryFrom<&Value> for List {
 
     fn try_from(value: &Value) -> Result<Self, Self::Error> {
         value
-            .cast_to::<List>()
+            .cast::<List>()
             .ok_or_else(|| Exception::error("value is not a proper list"))
     }
 }
@@ -299,7 +299,7 @@ pub fn is_list(curr: &Value, seen: &mut HashSet<Value>) -> bool {
         return false;
     }
 
-    let Some(curr) = curr.cast_to::<Pair>() else {
+    let Some(curr) = curr.cast::<Pair>() else {
         return false;
     };
 
@@ -487,7 +487,7 @@ unsafe extern "C" fn map_k(
                 return Box::into_raw(Box::new(app));
             }
 
-            let (car, cdr) = input.cast_to::<Pair>().unwrap().into();
+            let (car, cdr) = input.cast::<Pair>().unwrap().into();
             args.push(car);
             *input = cdr;
         }

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -214,7 +214,7 @@ impl From<&Value> for Option<List> {
             if !seen.insert(cdr.clone()) {
                 return None;
             }
-            let (car, new_cdr) = cdr.cast_to_scheme_type()?;
+            let (car, new_cdr) = cdr.cast_to()?;
             items.push(car);
             cdr = new_cdr;
         }
@@ -254,7 +254,7 @@ impl TryFrom<&Value> for List {
 
     fn try_from(value: &Value) -> Result<Self, Self::Error> {
         value
-            .cast_to_scheme_type::<List>()
+            .cast_to::<List>()
             .ok_or_else(|| Exception::error("value is not a proper list"))
     }
 }
@@ -299,7 +299,7 @@ pub fn is_list(curr: &Value, seen: &mut HashSet<Value>) -> bool {
         return false;
     }
 
-    let Some(curr) = curr.cast_to_scheme_type::<Pair>() else {
+    let Some(curr) = curr.cast_to::<Pair>() else {
         return false;
     };
 
@@ -328,12 +328,12 @@ pub fn cons(car: &Value, cdr: &Value) -> Result<Vec<Value>, Exception> {
 
 #[bridge(name = "car", lib = "(rnrs base builtins (6))")]
 pub fn car(val: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![val.try_to_scheme_type::<Pair>()?.car()])
+    Ok(vec![val.try_to::<Pair>()?.car()])
 }
 
 #[bridge(name = "cdr", lib = "(rnrs base builtins (6))")]
 pub fn cdr(val: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![val.try_to_scheme_type::<Pair>()?.cdr()])
+    Ok(vec![val.try_to::<Pair>()?.cdr()])
 }
 
 #[bridge(name = "set-car!", lib = "(rnrs mutable-pairs (6))")]
@@ -373,7 +373,7 @@ pub fn length(arg: &Value) -> Result<usize, Exception> {
 
 #[bridge(name = "list->vector", lib = "(rnrs base builtins (6))")]
 pub fn list_to_vector(list: &Value) -> Result<Vec<Value>, Exception> {
-    let List { items, .. } = list.try_to_scheme_type()?;
+    let List { items, .. } = list.try_to()?;
     Ok(vec![Value::from(items)])
 }
 
@@ -430,7 +430,7 @@ pub fn map(
             return Ok(Application::new(k, None, vec![Value::null()]));
         }
 
-        let (car, cdr) = input.try_to_scheme_type::<Pair>()?.into();
+        let (car, cdr) = input.try_to::<Pair>()?.into();
 
         args.push(car);
         *input = cdr;
@@ -487,7 +487,7 @@ unsafe extern "C" fn map_k(
                 return Box::into_raw(Box::new(app));
             }
 
-            let (car, cdr) = input.cast_to_scheme_type::<Pair>().unwrap().into();
+            let (car, cdr) = input.cast_to::<Pair>().unwrap().into();
             args.push(car);
             *input = cdr;
         }
@@ -514,7 +514,7 @@ unsafe extern "C" fn map_k(
 pub fn zip(list1: &Value, listn: &[Value]) -> Result<Vec<Value>, Exception> {
     let mut output: Option<Vec<Value>> = None;
     for list in Some(list1).into_iter().chain(listn.iter()).rev() {
-        let List { items, .. } = list.try_to_scheme_type()?;
+        let List { items, .. } = list.try_to()?;
         if let Some(output) = &output {
             if output.len() != items.len() {
                 return Err(Exception::error("lists do not have the same length"));

--- a/src/lsp/completion.rs
+++ b/src/lsp/completion.rs
@@ -95,7 +95,7 @@ fn var_completion_item(label: String, var: Var) -> CompletionItem {
     match var {
         Var::Global(global) => {
             let value = global.read();
-            if let Some(procedure) = value.cast_to_scheme_type::<Procedure>() {
+            if let Some(procedure) = value.cast::<Procedure>() {
                 procedure_completion_item(label, &procedure)
             } else {
                 CompletionItem {

--- a/src/lsp/hover.rs
+++ b/src/lsp/hover.rs
@@ -100,7 +100,7 @@ fn var_hover(var: Var) -> String {
             let name = global.name.to_string();
             let mut hover = format!("{name}\n\nglobal variable");
             let value = global.read();
-            if let Some(procedure) = value.cast_to_scheme_type::<Procedure>() {
+            if let Some(procedure) = value.cast::<Procedure>() {
                 hover = procedure_hover("global procedure", name, &procedure);
             } else if !value.is_undefined() {
                 hover.push_str(&format!("\n\ntype: {}", value.type_name()));

--- a/src/num.rs
+++ b/src/num.rs
@@ -225,6 +225,7 @@ impl Number {
     number_dispatch_method!(acos);
     number_dispatch_method!(atan);
 
+    #[allow(clippy::should_implement_trait)]
     pub fn eq(&self, rhs: &Number) -> bool {
         match (&self.0, &rhs.0) {
             (NumberRepr::Fixed(lhs), NumberRepr::Fixed(rhs)) => *lhs == *rhs,
@@ -237,7 +238,7 @@ impl Number {
         std::mem::discriminant(&self.0).hash(state);
         match &self.0 {
             NumberRepr::Fixed(fixed) => fixed.hash(state),
-            NumberRepr::Heap(heap) => Arc::as_ptr(&heap).hash(state),
+            NumberRepr::Heap(heap) => Arc::as_ptr(heap).hash(state),
         }
     }
 

--- a/src/num.rs
+++ b/src/num.rs
@@ -29,7 +29,7 @@ use crate::{
     registry::bridge,
     strings::WideString,
     syntax::{Span, lex::Lexer},
-    value::{Value, ValueType},
+    value::{FIXNUM_MAX, FIXNUM_MIN, Value, ValueType},
 };
 use core::f64;
 use malachite::{
@@ -46,28 +46,30 @@ use malachite::{
 use num::ToPrimitive;
 use scheme_rs_macros::{maybe_async, maybe_await};
 use std::{
-    cmp::Ordering,
-    fmt,
-    hash::Hash,
-    io::Cursor,
-    ops::{Add, Div, Mul, Neg, Rem, Sub},
-    sync::Arc,
+    borrow::Cow, cmp::Ordering, fmt, hash::{Hash, Hasher}, io::Cursor, ops::{Add, Div, Mul, Neg, Rem, Sub}, sync::Arc
 };
 
 #[repr(align(16))]
+#[derive(Clone)]
 pub(crate) enum NumberInner {
     Simple(SimpleNumber),
     Complex(ComplexNumber),
 }
 
+#[derive(Clone)]
+pub(crate) enum NumberRepr {
+    Fixed(i64),
+    Heap(Arc<NumberInner>),
+}
+
 /// Scheme numeric type.
 #[derive(Clone, Trace)]
-pub struct Number(pub(crate) Arc<NumberInner>);
+pub struct Number(#[trace(skip)] pub(crate) NumberRepr);
 
 macro_rules! number_dispatch_method {
     ( $func:ident ) => {
         pub fn $func(&self) -> Self {
-            match self.0.as_ref() {
+            match &*self.as_inner_ref() {
                 NumberInner::Simple(simple) => Number::from(simple.$func()),
                 NumberInner::Complex(complex) => Number::from(complex.$func()),
             }
@@ -76,29 +78,38 @@ macro_rules! number_dispatch_method {
 }
 
 impl Number {
-    pub fn as_simple(&self) -> Option<&SimpleNumber> {
-        match self.0.as_ref() {
-            NumberInner::Simple(simple) => Some(simple),
-            NumberInner::Complex(_) => None,
+    pub fn as_inner_ref(&self) -> Cow<'_, NumberInner> {
+        match &self.0 {
+            NumberRepr::Fixed(fixed) => Cow::Owned(NumberInner::Simple(SimpleNumber::FixedInteger(*fixed))),
+            NumberRepr::Heap(inner) => Cow::Borrowed(inner.as_ref()),
+        }
+    }
+    
+    pub fn as_simple(&self) -> Option<Cow<'_, SimpleNumber>> {
+        match &self.0 {
+            NumberRepr::Fixed(fixed) => Some(Cow::Owned(SimpleNumber::FixedInteger(*fixed))),
+            NumberRepr::Heap(inner) if let NumberInner::Simple(simple) = inner.as_ref() => Some(Cow::Borrowed(simple)),
+            NumberRepr::Heap(_) => None,
         }
     }
 
-    pub fn as_complex(&self) -> Option<&ComplexNumber> {
-        match self.0.as_ref() {
-            NumberInner::Complex(complex) => Some(complex),
-            NumberInner::Simple(_) => None,
+    pub fn as_complex(&self) -> Option<Cow<'_, ComplexNumber>> {
+        match &self.0 {
+            NumberRepr::Heap(inner) if let NumberInner::Complex(complex) = inner.as_ref() => Some(Cow::Borrowed(complex)),
+            _ => None,
+            // NumberInner::Simple(_) => None,
         }
     }
 
     pub fn is_zero(&self) -> bool {
-        match self.0.as_ref() {
+        match &*self.as_inner_ref() {
             NumberInner::Simple(simple) => simple.is_zero(),
             NumberInner::Complex(complex) => complex.re.is_zero() && complex.im.is_zero(),
         }
     }
 
     pub fn is_integer(&self) -> bool {
-        match self.0.as_ref() {
+        match &*self.as_inner_ref() {
             NumberInner::Simple(simple) => simple.is_integer(),
             NumberInner::Complex(complex) => {
                 complex.im.is_exact() && complex.im.is_zero() && complex.re.is_integer()
@@ -107,7 +118,7 @@ impl Number {
     }
 
     pub fn is_rational(&self) -> bool {
-        match self.0.as_ref() {
+        match &*self.as_inner_ref() {
             NumberInner::Simple(simple) => simple.is_rational(),
             NumberInner::Complex(complex) => {
                 complex.im.is_exact() && complex.im.is_zero() && complex.re.is_rational()
@@ -116,28 +127,28 @@ impl Number {
     }
 
     pub fn is_real(&self) -> bool {
-        match self.0.as_ref() {
+        match &*self.as_inner_ref() {
             NumberInner::Simple(_) => true,
             NumberInner::Complex(complex) => complex.im.is_exact() && complex.im.is_zero(),
         }
     }
 
     pub fn is_integer_valued(&self) -> bool {
-        match self.0.as_ref() {
+        match &*self.as_inner_ref() {
             NumberInner::Simple(simple) => simple.is_integer(),
             NumberInner::Complex(complex) => complex.im.is_zero() && complex.re.is_integer(),
         }
     }
 
     pub fn is_rational_valued(&self) -> bool {
-        match self.0.as_ref() {
+        match &*self.as_inner_ref() {
             NumberInner::Simple(simple) => simple.is_rational(),
             NumberInner::Complex(complex) => complex.im.is_zero() && complex.re.is_rational(),
         }
     }
 
     pub fn is_real_valued(&self) -> bool {
-        match self.0.as_ref() {
+        match &*self.as_inner_ref() {
             NumberInner::Simple(_) => true,
             NumberInner::Complex(complex) => complex.im.is_zero(),
         }
@@ -149,55 +160,35 @@ impl Number {
     }
 
     pub fn is_exact(&self) -> bool {
-        match self.0.as_ref() {
+        match &*self.as_inner_ref() {
             NumberInner::Simple(simple) => simple.is_exact(),
             NumberInner::Complex(complex) => complex.im.is_exact() && complex.re.is_exact(),
         }
     }
 
     pub fn is_inexact(&self) -> bool {
-        match self.0.as_ref() {
+        match &*self.as_inner_ref() {
             NumberInner::Simple(simple) => !simple.is_exact(),
             NumberInner::Complex(complex) => !complex.im.is_exact() || !complex.re.is_exact(),
         }
     }
 
     pub fn inexact(self) -> Number {
-        match self.0.as_ref() {
+        match &*self.as_inner_ref() {
             NumberInner::Simple(simple) => Number::from(simple.inexact()),
             NumberInner::Complex(complex) => Number::from(complex.inexact()),
         }
     }
 
     pub fn exact(self) -> Number {
-        match self.0.as_ref() {
+        match &*self.as_inner_ref() {
             NumberInner::Simple(simple) => Number::from(simple.exact()),
             NumberInner::Complex(complex) => Number::from(complex.exact()),
         }
     }
 
-    pub fn eqv(&self, rhs: &Self) -> bool {
-        match (self.0.as_ref(), rhs.0.as_ref()) {
-            (NumberInner::Simple(lhs), NumberInner::Simple(rhs)) => lhs.eqv(rhs),
-            (NumberInner::Complex(lhs), NumberInner::Simple(rhs))
-                if lhs.im.is_zero() && lhs.im.is_exact() == rhs.is_exact() =>
-            {
-                lhs.re.eqv(rhs)
-            }
-            (NumberInner::Simple(lhs), NumberInner::Complex(rhs))
-                if rhs.im.is_zero() && rhs.im.is_exact() == lhs.is_exact() =>
-            {
-                lhs.eqv(&rhs.re)
-            }
-            (NumberInner::Complex(lhs), NumberInner::Complex(rhs)) => {
-                lhs.re.eqv(&rhs.re) && lhs.im.eqv(&rhs.im)
-            }
-            _ => false,
-        }
-    }
-
     pub fn pow(&self, rhs: &Number) -> Number {
-        match (self.0.as_ref(), rhs.0.as_ref()) {
+        match (&*self.as_inner_ref(), &*rhs.as_inner_ref()) {
             (NumberInner::Simple(base), NumberInner::Simple(exp)) => Number::from(base.pow(exp)),
             (NumberInner::Simple(base), NumberInner::Complex(exp)) => {
                 Number::from(ComplexNumber::new(base.clone(), SimpleNumber::zero()).powc(exp))
@@ -221,11 +212,55 @@ impl Number {
     number_dispatch_method!(asin);
     number_dispatch_method!(acos);
     number_dispatch_method!(atan);
+
+    pub fn eq(&self, rhs: &Number) -> bool {
+        match (&self.0, &rhs.0) {
+            (NumberRepr::Fixed(lhs), NumberRepr::Fixed(rhs)) => *lhs == *rhs,
+            (NumberRepr::Heap(_), NumberRepr::Heap(_)) => self == rhs,
+            _ => false,
+        }
+    }
+
+    pub fn eq_hash<H: Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(&self.0).hash(state);
+        match &self.0 {
+            NumberRepr::Fixed(fixed) => fixed.hash(state),
+            NumberRepr::Heap(heap) => Arc::as_ptr(&heap).hash(state),
+        }
+    }
+
+    pub fn eqv(&self, rhs: &Self) -> bool {
+        match (&*self.as_inner_ref(), &*rhs.as_inner_ref()) {
+            (NumberInner::Simple(lhs), NumberInner::Simple(rhs)) => lhs.eqv(rhs),
+            (NumberInner::Complex(lhs), NumberInner::Simple(rhs))
+                if lhs.im.is_zero() && lhs.im.is_exact() == rhs.is_exact() =>
+            {
+                lhs.re.eqv(rhs)
+            }
+            (NumberInner::Simple(lhs), NumberInner::Complex(rhs))
+                if rhs.im.is_zero() && rhs.im.is_exact() == lhs.is_exact() =>
+            {
+                lhs.eqv(&rhs.re)
+            }
+            (NumberInner::Complex(lhs), NumberInner::Complex(rhs)) => {
+                lhs.re.eqv(&rhs.re) && lhs.im.eqv(&rhs.im)
+            }
+            _ => false,
+        }
+    }
+
+    pub fn eqv_hash<H: Hasher>(&self, state: &mut H) {
+        self.hash(state)
+    }
 }
 
 impl From<NumberInner> for Number {
     fn from(value: NumberInner) -> Self {
-        Self(Arc::new(value))
+        if let NumberInner::Simple(SimpleNumber::FixedInteger(fixed)) = value {
+            Self(NumberRepr::Fixed(fixed))
+        } else {
+            Self(NumberRepr::Heap(Arc::new(value)))
+        }
     }
 }
 
@@ -233,8 +268,11 @@ impl<T> From<T> for Number
 where
     SimpleNumber: From<T>,
 {
-    fn from(value: T) -> Self {
-        Self(Arc::new(NumberInner::Simple(SimpleNumber::from(value))))
+    fn from(simple_number: T) -> Self {
+        match SimpleNumber::from(simple_number) {
+            SimpleNumber::FixedInteger(fixed) if (FIXNUM_MIN..FIXNUM_MAX).contains(&fixed) => Self(NumberRepr::Fixed(fixed)),
+            simple_number => Self(NumberRepr::Heap(Arc::new(NumberInner::Simple(simple_number)))),
+        }
     }
 }
 
@@ -244,7 +282,7 @@ macro_rules! impl_simple_number_int_conversion_for_num {
             type Error = Exception;
 
             fn try_from(num: &Number) -> Result<$ty, Self::Error> {
-                match num.0.as_ref() {
+                match &*num.as_inner_ref() {
                     NumberInner::Simple(simple) => simple.try_into(),
                     NumberInner::Complex(complex)
                         if complex.im.is_exact() && complex.im.is_zero() =>
@@ -266,7 +304,7 @@ macro_rules! impl_simple_number_int_conversion_for_num {
 
         impl From<&Number> for Option<$ty> {
             fn from(num: &Number) -> Option<$ty> {
-                match num.0.as_ref() {
+                match &*num.as_inner_ref() {
                     NumberInner::Simple(simple) => simple.into(),
                     NumberInner::Complex(complex)
                         if complex.im.is_exact() && complex.im.is_zero() =>
@@ -696,7 +734,7 @@ impl SimpleNumber {
 
 impl From<&Number> for Option<SimpleNumber> {
     fn from(value: &Number) -> Self {
-        match value.0.as_ref() {
+        match &*value.as_inner_ref() {
             NumberInner::Simple(simple) => Some(simple.clone()),
             NumberInner::Complex(complex) if complex.im.is_exact() && complex.im.is_zero() => {
                 Some(complex.re.clone())
@@ -787,7 +825,7 @@ impl From<f64> for SimpleNumber {
 
 impl From<ComplexNumber> for Number {
     fn from(complex: ComplexNumber) -> Self {
-        Self(Arc::new(NumberInner::Complex(complex)))
+        Self(NumberRepr::Heap(Arc::new(NumberInner::Complex(complex))))
     }
 }
 
@@ -979,7 +1017,7 @@ impl TryFrom<&Number> for f64 {
     type Error = Exception;
 
     fn try_from(num: &Number) -> Result<f64, Self::Error> {
-        match num.0.as_ref() {
+        match &*num.as_inner_ref() {
             NumberInner::Simple(simple) => f64::try_from(simple),
             NumberInner::Complex(complex) if !complex.im.is_exact() && complex.im.is_zero() => {
                 f64::try_from(&complex.re)
@@ -999,7 +1037,7 @@ impl TryFrom<Number> for f64 {
 
 impl From<&Number> for Option<f64> {
     fn from(num: &Number) -> Option<f64> {
-        match num.0.as_ref() {
+        match &*num.as_inner_ref() {
             NumberInner::Simple(simple) => Self::from(simple),
             NumberInner::Complex(complex) if !complex.im.is_exact() && complex.im.is_zero() => {
                 Self::from(&complex.re)
@@ -1581,7 +1619,7 @@ impl ComplexNumber {
 
 impl From<&Number> for Option<ComplexNumber> {
     fn from(value: &Number) -> Self {
-        match value.0.as_ref() {
+        match &*value.as_inner_ref() {
             NumberInner::Simple(simple) => {
                 Some(ComplexNumber::new(simple.clone(), SimpleNumber::zero()))
             }
@@ -1600,7 +1638,7 @@ impl TryFrom<&Number> for ComplexNumber {
     type Error = Exception;
 
     fn try_from(value: &Number) -> Result<Self, Self::Error> {
-        match value.0.as_ref() {
+        match &*value.as_inner_ref() {
             NumberInner::Simple(simple) => {
                 Ok(ComplexNumber::new(simple.clone(), SimpleNumber::zero()))
             }
@@ -1760,7 +1798,7 @@ impl fmt::Debug for ComplexNumber {
 
 impl fmt::Display for Number {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.0.as_ref() {
+        match &*self.as_inner_ref() {
             NumberInner::Simple(simple) => write!(f, "{simple}"),
             NumberInner::Complex(complex) => write!(f, "{complex}"),
         }
@@ -1769,7 +1807,7 @@ impl fmt::Display for Number {
 
 impl fmt::Debug for Number {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.0.as_ref() {
+        match &*self.as_inner_ref() {
             NumberInner::Simple(simple) => write!(f, "{simple:?}"),
             NumberInner::Complex(complex) => write!(f, "{complex:?}"),
         }
@@ -1778,8 +1816,9 @@ impl fmt::Debug for Number {
 
 impl Hash for Number {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        std::mem::discriminant(self.0.as_ref()).hash(state);
-        match self.0.as_ref() {
+        let inner = self.as_inner_ref();
+        std::mem::discriminant(inner.as_ref()).hash(state);
+        match &*inner {
             NumberInner::Simple(simple) => simple.hash(state),
             NumberInner::Complex(complex) => {
                 complex.re.hash(state);
@@ -1791,7 +1830,7 @@ impl Hash for Number {
 
 impl PartialEq for Number {
     fn eq(&self, rhs: &Self) -> bool {
-        match (self.0.as_ref(), rhs.0.as_ref()) {
+        match (&*self.as_inner_ref(), &*rhs.as_inner_ref()) {
             (NumberInner::Simple(lhs), NumberInner::Simple(rhs)) => lhs.eq(rhs),
             (NumberInner::Complex(lhs), NumberInner::Simple(rhs)) if lhs.im.is_zero() => {
                 lhs.re.eq(rhs)
@@ -1807,7 +1846,7 @@ impl PartialEq for Number {
 
 impl PartialOrd for Number {
     fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
-        match (self.0.as_ref(), rhs.0.as_ref()) {
+        match (&*self.as_inner_ref(), &*rhs.as_inner_ref()) {
             (NumberInner::Simple(lhs), NumberInner::Simple(rhs)) => lhs.partial_cmp(rhs),
             (NumberInner::Complex(lhs), NumberInner::Simple(rhs)) if lhs.im.is_zero() => {
                 lhs.re.partial_cmp(rhs)
@@ -1829,7 +1868,7 @@ impl Neg for Number {
     type Output = Number;
 
     fn neg(self) -> Self {
-        match self.0.as_ref() {
+        match &*self.as_inner_ref() {
             NumberInner::Simple(this) => Number::from(-this),
             NumberInner::Complex(this) => Number::from(-this),
         }
@@ -1840,7 +1879,7 @@ impl Neg for &'_ Number {
     type Output = Number;
 
     fn neg(self) -> Number {
-        match self.0.as_ref() {
+        match &*self.as_inner_ref() {
             NumberInner::Simple(this) => Number::from(-this),
             NumberInner::Complex(this) => Number::from(-this),
         }
@@ -1853,7 +1892,7 @@ macro_rules! impl_op_for_number {
             type Output = Number;
 
             fn $op(self, rhs: &Number) -> Self::Output {
-                match (self.0.as_ref(), rhs.0.as_ref()) {
+                match (&*self.as_inner_ref(), &*rhs.as_inner_ref()) {
                     (NumberInner::Simple(lhs), NumberInner::Simple(rhs)) => {
                         Number::from(lhs.$op(rhs))
                     }
@@ -1896,7 +1935,7 @@ pub fn is_number(arg: &Value) -> Result<Vec<Value>, Exception> {
 #[bridge(name = "complex?", lib = "(rnrs base builtins (6))")]
 pub fn is_complex(arg: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
-        arg.cast_to::<Number>()
+        arg.cast::<Number>()
             .as_ref()
             .is_some_and(Number::is_complex),
     )])
@@ -1905,7 +1944,7 @@ pub fn is_complex(arg: &Value) -> Result<Vec<Value>, Exception> {
 #[bridge(name = "real?", lib = "(rnrs base builtins (6))")]
 pub fn is_real(arg: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
-        arg.cast_to::<Number>()
+        arg.cast::<Number>()
             .as_ref()
             .is_some_and(Number::is_real),
     )])
@@ -1914,7 +1953,7 @@ pub fn is_real(arg: &Value) -> Result<Vec<Value>, Exception> {
 #[bridge(name = "rational?", lib = "(rnrs base builtins (6))")]
 pub fn is_rational(arg: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
-        arg.cast_to::<Number>()
+        arg.cast::<Number>()
             .as_ref()
             .is_some_and(Number::is_rational),
     )])
@@ -1923,7 +1962,7 @@ pub fn is_rational(arg: &Value) -> Result<Vec<Value>, Exception> {
 #[bridge(name = "integer?", lib = "(rnrs base builtins (6))")]
 pub fn is_integer(arg: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
-        arg.cast_to::<Number>()
+        arg.cast::<Number>()
             .as_ref()
             .is_some_and(Number::is_integer),
     )])
@@ -1932,7 +1971,7 @@ pub fn is_integer(arg: &Value) -> Result<Vec<Value>, Exception> {
 #[bridge(name = "real-valued?", lib = "(rnrs base builtins (6))")]
 pub fn real_valued_pred(arg: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
-        arg.cast_to::<Number>()
+        arg.cast::<Number>()
             .as_ref()
             .is_some_and(Number::is_real_valued),
     )])
@@ -1941,7 +1980,7 @@ pub fn real_valued_pred(arg: &Value) -> Result<Vec<Value>, Exception> {
 #[bridge(name = "rational-valued?", lib = "(rnrs base builtins (6))")]
 pub fn rational_valued_pred(arg: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
-        arg.cast_to::<Number>()
+        arg.cast::<Number>()
             .as_ref()
             .is_some_and(Number::is_rational_valued),
     )])
@@ -1950,7 +1989,7 @@ pub fn rational_valued_pred(arg: &Value) -> Result<Vec<Value>, Exception> {
 #[bridge(name = "integer-valued?", lib = "(rnrs base builtins (6))")]
 pub fn integer_valued_pred(arg: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
-        arg.cast_to::<Number>()
+        arg.cast::<Number>()
             .as_ref()
             .is_some_and(Number::is_integer_valued),
     )])
@@ -2504,8 +2543,8 @@ pub struct Fixnum(pub i64);
 
 impl From<&Value> for Option<Fixnum> {
     fn from(value: &Value) -> Option<Fixnum> {
-        if let Some(num) = value.cast_to::<Number>()
-            && let NumberInner::Simple(simple) = &*num.0
+        if let Some(num) = value.cast::<Number>()
+            && let NumberInner::Simple(simple) = &*num.as_inner_ref()
             && let SimpleNumber::FixedInteger(fixnum) = simple
         {
             Some(Fixnum(*fixnum))
@@ -2519,8 +2558,8 @@ impl TryFrom<&Value> for Fixnum {
     type Error = Exception;
 
     fn try_from(value: &Value) -> Result<Self, Self::Error> {
-        if let Some(num) = value.cast_to::<Number>()
-            && let NumberInner::Simple(simple) = &*num.0
+        if let Some(num) = value.cast::<Number>()
+            && let NumberInner::Simple(simple) = &*num.as_inner_ref()
             && let SimpleNumber::FixedInteger(fixnum) = simple
         {
             Ok(Fixnum(*fixnum))
@@ -2532,7 +2571,7 @@ impl TryFrom<&Value> for Fixnum {
 
 #[bridge(name = "fixnum?", lib = "(rnrs arithmetic fixnums (6))")]
 pub fn fixnum_pred(obj: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(obj.cast_to::<Fixnum>().is_some())])
+    Ok(vec![Value::from(obj.cast::<Fixnum>().is_some())])
 }
 
 #[bridge(name = "fixnum-width", lib = "(rnrs arithmetic fixnums (6))")]
@@ -2555,8 +2594,8 @@ pub struct Flonum(pub f64);
 
 impl From<&Value> for Option<Flonum> {
     fn from(value: &Value) -> Option<Flonum> {
-        if let Some(num) = value.cast_to::<Number>()
-            && let NumberInner::Simple(simple) = &*num.0
+        if let Some(num) = value.cast::<Number>()
+            && let NumberInner::Simple(simple) = &*num.as_inner_ref()
             && let SimpleNumber::Real(flonum) = simple
         {
             Some(Flonum(*flonum))
@@ -2570,8 +2609,8 @@ impl TryFrom<&Value> for Flonum {
     type Error = Exception;
 
     fn try_from(value: &Value) -> Result<Self, Self::Error> {
-        if let Some(num) = value.cast_to::<Number>()
-            && let NumberInner::Simple(simple) = &*num.0
+        if let Some(num) = value.cast::<Number>()
+            && let NumberInner::Simple(simple) = &*num.as_inner_ref()
             && let SimpleNumber::Real(flonum) = simple
         {
             Ok(Flonum(*flonum))
@@ -2583,5 +2622,5 @@ impl TryFrom<&Value> for Flonum {
 
 #[bridge(name = "flonum?", lib = "(rnrs arithmetic flonums (6))")]
 pub fn flonum_pred(obj: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(obj.cast_to::<Flonum>().is_some())])
+    Ok(vec![Value::from(obj.cast::<Flonum>().is_some())])
 }

--- a/src/num.rs
+++ b/src/num.rs
@@ -46,12 +46,18 @@ use malachite::{
 use num::ToPrimitive;
 use scheme_rs_macros::{maybe_async, maybe_await};
 use std::{
-    borrow::Cow, cmp::Ordering, fmt, hash::{Hash, Hasher}, io::Cursor, ops::{Add, Div, Mul, Neg, Rem, Sub}, sync::Arc
+    borrow::Cow,
+    cmp::Ordering,
+    fmt,
+    hash::{Hash, Hasher},
+    io::Cursor,
+    ops::{Add, Div, Mul, Neg, Rem, Sub},
+    sync::Arc,
 };
 
 #[repr(align(16))]
 #[derive(Clone)]
-pub(crate) enum NumberInner {
+pub enum NumberInner {
     Simple(SimpleNumber),
     Complex(ComplexNumber),
 }
@@ -80,22 +86,28 @@ macro_rules! number_dispatch_method {
 impl Number {
     pub fn as_inner_ref(&self) -> Cow<'_, NumberInner> {
         match &self.0 {
-            NumberRepr::Fixed(fixed) => Cow::Owned(NumberInner::Simple(SimpleNumber::FixedInteger(*fixed))),
+            NumberRepr::Fixed(fixed) => {
+                Cow::Owned(NumberInner::Simple(SimpleNumber::FixedInteger(*fixed)))
+            }
             NumberRepr::Heap(inner) => Cow::Borrowed(inner.as_ref()),
         }
     }
-    
+
     pub fn as_simple(&self) -> Option<Cow<'_, SimpleNumber>> {
         match &self.0 {
             NumberRepr::Fixed(fixed) => Some(Cow::Owned(SimpleNumber::FixedInteger(*fixed))),
-            NumberRepr::Heap(inner) if let NumberInner::Simple(simple) = inner.as_ref() => Some(Cow::Borrowed(simple)),
+            NumberRepr::Heap(inner) if let NumberInner::Simple(simple) = inner.as_ref() => {
+                Some(Cow::Borrowed(simple))
+            }
             NumberRepr::Heap(_) => None,
         }
     }
 
     pub fn as_complex(&self) -> Option<Cow<'_, ComplexNumber>> {
         match &self.0 {
-            NumberRepr::Heap(inner) if let NumberInner::Complex(complex) = inner.as_ref() => Some(Cow::Borrowed(complex)),
+            NumberRepr::Heap(inner) if let NumberInner::Complex(complex) = inner.as_ref() => {
+                Some(Cow::Borrowed(complex))
+            }
             _ => None,
             // NumberInner::Simple(_) => None,
         }
@@ -216,7 +228,7 @@ impl Number {
     pub fn eq(&self, rhs: &Number) -> bool {
         match (&self.0, &rhs.0) {
             (NumberRepr::Fixed(lhs), NumberRepr::Fixed(rhs)) => *lhs == *rhs,
-            (NumberRepr::Heap(_), NumberRepr::Heap(_)) => self == rhs,
+            (NumberRepr::Heap(lhs), NumberRepr::Heap(rhs)) => Arc::ptr_eq(lhs, rhs),
             _ => false,
         }
     }
@@ -256,7 +268,9 @@ impl Number {
 
 impl From<NumberInner> for Number {
     fn from(value: NumberInner) -> Self {
-        if let NumberInner::Simple(SimpleNumber::FixedInteger(fixed)) = value {
+        if let NumberInner::Simple(SimpleNumber::FixedInteger(fixed)) = value
+            && (FIXNUM_MIN..=FIXNUM_MAX).contains(&fixed)
+        {
             Self(NumberRepr::Fixed(fixed))
         } else {
             Self(NumberRepr::Heap(Arc::new(value)))
@@ -270,8 +284,12 @@ where
 {
     fn from(simple_number: T) -> Self {
         match SimpleNumber::from(simple_number) {
-            SimpleNumber::FixedInteger(fixed) if (FIXNUM_MIN..FIXNUM_MAX).contains(&fixed) => Self(NumberRepr::Fixed(fixed)),
-            simple_number => Self(NumberRepr::Heap(Arc::new(NumberInner::Simple(simple_number)))),
+            SimpleNumber::FixedInteger(fixed) if (FIXNUM_MIN..=FIXNUM_MAX).contains(&fixed) => {
+                Self(NumberRepr::Fixed(fixed))
+            }
+            simple_number => Self(NumberRepr::Heap(Arc::new(NumberInner::Simple(
+                simple_number,
+            )))),
         }
     }
 }
@@ -1944,9 +1962,7 @@ pub fn is_complex(arg: &Value) -> Result<Vec<Value>, Exception> {
 #[bridge(name = "real?", lib = "(rnrs base builtins (6))")]
 pub fn is_real(arg: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
-        arg.cast::<Number>()
-            .as_ref()
-            .is_some_and(Number::is_real),
+        arg.cast::<Number>().as_ref().is_some_and(Number::is_real),
     )])
 }
 
@@ -2576,17 +2592,17 @@ pub fn fixnum_pred(obj: &Value) -> Result<Vec<Value>, Exception> {
 
 #[bridge(name = "fixnum-width", lib = "(rnrs arithmetic fixnums (6))")]
 pub fn fixnum_width() -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(64)])
+    Ok(vec![Value::from(63)])
 }
 
 #[bridge(name = "least-fixnum", lib = "(rnrs arithmetic fixnums (6))")]
 pub fn least_fixnum() -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(i64::MIN)])
+    Ok(vec![Value::from(FIXNUM_MIN)])
 }
 
 #[bridge(name = "greatest-fixnum", lib = "(rnrs arithmetic fixnums (6))")]
 pub fn greatest_fixnum() -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(i64::MAX)])
+    Ok(vec![Value::from(FIXNUM_MAX)])
 }
 
 /// R6RS Flonums

--- a/src/num.rs
+++ b/src/num.rs
@@ -1896,7 +1896,7 @@ pub fn is_number(arg: &Value) -> Result<Vec<Value>, Exception> {
 #[bridge(name = "complex?", lib = "(rnrs base builtins (6))")]
 pub fn is_complex(arg: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
-        arg.cast_to_scheme_type::<Number>()
+        arg.cast_to::<Number>()
             .as_ref()
             .is_some_and(Number::is_complex),
     )])
@@ -1905,7 +1905,7 @@ pub fn is_complex(arg: &Value) -> Result<Vec<Value>, Exception> {
 #[bridge(name = "real?", lib = "(rnrs base builtins (6))")]
 pub fn is_real(arg: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
-        arg.cast_to_scheme_type::<Number>()
+        arg.cast_to::<Number>()
             .as_ref()
             .is_some_and(Number::is_real),
     )])
@@ -1914,7 +1914,7 @@ pub fn is_real(arg: &Value) -> Result<Vec<Value>, Exception> {
 #[bridge(name = "rational?", lib = "(rnrs base builtins (6))")]
 pub fn is_rational(arg: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
-        arg.cast_to_scheme_type::<Number>()
+        arg.cast_to::<Number>()
             .as_ref()
             .is_some_and(Number::is_rational),
     )])
@@ -1923,7 +1923,7 @@ pub fn is_rational(arg: &Value) -> Result<Vec<Value>, Exception> {
 #[bridge(name = "integer?", lib = "(rnrs base builtins (6))")]
 pub fn is_integer(arg: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
-        arg.cast_to_scheme_type::<Number>()
+        arg.cast_to::<Number>()
             .as_ref()
             .is_some_and(Number::is_integer),
     )])
@@ -1932,7 +1932,7 @@ pub fn is_integer(arg: &Value) -> Result<Vec<Value>, Exception> {
 #[bridge(name = "real-valued?", lib = "(rnrs base builtins (6))")]
 pub fn real_valued_pred(arg: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
-        arg.cast_to_scheme_type::<Number>()
+        arg.cast_to::<Number>()
             .as_ref()
             .is_some_and(Number::is_real_valued),
     )])
@@ -1941,7 +1941,7 @@ pub fn real_valued_pred(arg: &Value) -> Result<Vec<Value>, Exception> {
 #[bridge(name = "rational-valued?", lib = "(rnrs base builtins (6))")]
 pub fn rational_valued_pred(arg: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
-        arg.cast_to_scheme_type::<Number>()
+        arg.cast_to::<Number>()
             .as_ref()
             .is_some_and(Number::is_rational_valued),
     )])
@@ -1950,7 +1950,7 @@ pub fn rational_valued_pred(arg: &Value) -> Result<Vec<Value>, Exception> {
 #[bridge(name = "integer-valued?", lib = "(rnrs base builtins (6))")]
 pub fn integer_valued_pred(arg: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
-        arg.cast_to_scheme_type::<Number>()
+        arg.cast_to::<Number>()
             .as_ref()
             .is_some_and(Number::is_integer_valued),
     )])
@@ -1983,9 +1983,9 @@ pub fn equal(args: &[Value]) -> Result<Vec<Value>, Exception> {
 
 pub(crate) fn equal_prim(vals: &[Value]) -> Result<bool, Exception> {
     if let Some((first, rest)) = vals.split_first() {
-        let first: Number = first.try_to_scheme_type()?;
+        let first: Number = first.try_to()?;
         for next in rest {
-            let next: Number = next.try_to_scheme_type()?;
+            let next: Number = next.try_to()?;
             if !(first == next) {
                 return Ok(false);
             }
@@ -2003,8 +2003,8 @@ pub(crate) fn lesser_prim(vals: &[Value]) -> Result<bool, Exception> {
     if let Some((head, rest)) = vals.split_first() {
         let mut prev = head.clone();
         for next in rest {
-            let prev_num: Number = prev.try_to_scheme_type()?;
-            let next_num: Number = next.try_to_scheme_type()?;
+            let prev_num: Number = prev.try_to()?;
+            let next_num: Number = next.try_to()?;
             if !prev_num.is_real() {
                 return Err(Exception::type_error("real", "complex"));
             }
@@ -2029,8 +2029,8 @@ pub(crate) fn greater_prim(vals: &[Value]) -> Result<bool, Exception> {
     if let Some((head, rest)) = vals.split_first() {
         let mut prev = head.clone();
         for next in rest {
-            let prev_num: Number = prev.try_to_scheme_type()?;
-            let next_num: Number = next.try_to_scheme_type()?;
+            let prev_num: Number = prev.try_to()?;
+            let next_num: Number = next.try_to()?;
             // This is somewhat less efficient for small numbers but avoids
             // cloning big ones
             if !prev_num.is_real() {
@@ -2057,8 +2057,8 @@ pub(crate) fn lesser_equal_prim(vals: &[Value]) -> Result<bool, Exception> {
     if let Some((head, rest)) = vals.split_first() {
         let mut prev = head.clone();
         for next in rest {
-            let prev_num: Number = prev.try_to_scheme_type()?;
-            let next_num: Number = next.try_to_scheme_type()?;
+            let prev_num: Number = prev.try_to()?;
+            let next_num: Number = next.try_to()?;
             if !prev_num.is_real() {
                 return Err(Exception::type_error("real", "complex"));
             }
@@ -2086,8 +2086,8 @@ pub(crate) fn greater_equal_prim(vals: &[Value]) -> Result<bool, Exception> {
     if let Some((head, rest)) = vals.split_first() {
         let mut prev = head.clone();
         for next in rest {
-            let prev_num: Number = prev.try_to_scheme_type()?;
-            let next_num: Number = next.try_to_scheme_type()?;
+            let prev_num: Number = prev.try_to()?;
+            let next_num: Number = next.try_to()?;
             if !prev_num.is_real() {
                 return Err(Exception::type_error("real", "complex"));
             }
@@ -2108,41 +2108,39 @@ pub(crate) fn greater_equal_prim(vals: &[Value]) -> Result<bool, Exception> {
 
 #[bridge(name = "zero?", lib = "(rnrs base builtins (6))")]
 pub fn zero(arg: &Value) -> Result<Vec<Value>, Exception> {
-    let num: Number = arg.try_to_scheme_type()?;
+    let num: Number = arg.try_to()?;
     Ok(vec![Value::from(num.is_zero())])
 }
 
 #[bridge(name = "odd?", lib = "(rnrs base builtins (6))")]
 pub fn odd(arg: &Value) -> Result<Vec<Value>, Exception> {
-    let int: Integer = arg.try_to_scheme_type()?;
+    let int: Integer = arg.try_to()?;
     Ok(vec![Value::from(int.odd())])
 }
 
 #[bridge(name = "even?", lib = "(rnrs base builtins (6))")]
 pub fn even(arg: &Value) -> Result<Vec<Value>, Exception> {
-    let int: Integer = arg.try_to_scheme_type()?;
+    let int: Integer = arg.try_to()?;
     Ok(vec![Value::from(int.even())])
 }
 
 #[bridge(name = "finite?", lib = "(rnrs base builtins (6))")]
 pub fn is_finite(arg: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
-        !arg.try_to_scheme_type::<SimpleNumber>()?.is_infinite(),
+        !arg.try_to::<SimpleNumber>()?.is_infinite(),
     )])
 }
 
 #[bridge(name = "infinite?", lib = "(rnrs base builtins (6))")]
 pub fn is_infinite(arg: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
-        arg.try_to_scheme_type::<SimpleNumber>()?.is_infinite(),
+        arg.try_to::<SimpleNumber>()?.is_infinite(),
     )])
 }
 
 #[bridge(name = "nan?", lib = "(rnrs base builtins (6))")]
 pub fn is_nan(arg: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(
-        arg.try_to_scheme_type::<SimpleNumber>()?.is_nan(),
-    )])
+    Ok(vec![Value::from(arg.try_to::<SimpleNumber>()?.is_nan())])
 }
 
 #[bridge(name = "+", lib = "(rnrs base builtins (6))")]
@@ -2153,7 +2151,7 @@ pub fn add(args: &[Value]) -> Result<Vec<Value>, Exception> {
 pub(crate) fn add_prim(vals: &[Value]) -> Result<Number, Exception> {
     let mut result = Number::from(0i64);
     for val in vals {
-        let num: Number = val.try_to_scheme_type()?;
+        let num: Number = val.try_to()?;
         result = result + num;
     }
     Ok(result)
@@ -2167,7 +2165,7 @@ pub fn mul(args: &[Value]) -> Result<Vec<Value>, Exception> {
 pub(crate) fn mul_prim(vals: &[Value]) -> Result<Number, Exception> {
     let mut result = Number::from(1i64);
     for val in vals {
-        let num: Number = val.try_to_scheme_type()?;
+        let num: Number = val.try_to()?;
         result = result * num;
     }
     Ok(result)
@@ -2179,13 +2177,13 @@ pub fn sub(arg1: &Value, args: &[Value]) -> Result<Vec<Value>, Exception> {
 }
 
 pub(crate) fn sub_prim(val1: &Value, vals: &[Value]) -> Result<Number, Exception> {
-    let val1: Number = val1.try_to_scheme_type()?;
+    let val1: Number = val1.try_to()?;
     let mut val1 = val1.clone();
     if vals.is_empty() {
         Ok(-val1)
     } else {
         for val in vals {
-            let num: Number = val.try_to_scheme_type()?;
+            let num: Number = val.try_to()?;
             val1 = val1 - num;
         }
         Ok(val1)
@@ -2198,7 +2196,7 @@ pub fn div(arg1: &Value, args: &[Value]) -> Result<Vec<Value>, Exception> {
 }
 
 pub(crate) fn div_prim(val1: &Value, vals: &[Value]) -> Result<Number, Exception> {
-    let val1: Number = val1.try_to_scheme_type()?;
+    let val1: Number = val1.try_to()?;
     if vals.is_empty() {
         if val1.is_zero() && val1.is_exact() {
             return Err(Exception::error("division by zero"));
@@ -2207,7 +2205,7 @@ pub(crate) fn div_prim(val1: &Value, vals: &[Value]) -> Result<Number, Exception
     }
     let mut result = val1.clone();
     for val in vals {
-        let num: Number = val.try_to_scheme_type()?;
+        let num: Number = val.try_to()?;
         if num.is_zero() && num.is_exact() {
             return Err(Exception::error("division by zero"));
         }
@@ -2252,7 +2250,7 @@ pub fn modulo(x1: SimpleNumber, x2: SimpleNumber) -> Result<Vec<Value>, Exceptio
 
 #[bridge(name = "numerator", lib = "(rnrs base builtins (6))")]
 pub fn numerator(obj: &Value) -> Result<Vec<Value>, Exception> {
-    match obj.try_to_scheme_type::<SimpleNumber>()? {
+    match obj.try_to::<SimpleNumber>()? {
         SimpleNumber::Rational(r) => Ok(vec![Value::from(Integer::from_sign_and_abs(
             r >= 0i64,
             r.into_numerator(),
@@ -2263,7 +2261,7 @@ pub fn numerator(obj: &Value) -> Result<Vec<Value>, Exception> {
 
 #[bridge(name = "denominator", lib = "(rnrs base builtins (6))")]
 pub fn denominator(obj: &Value) -> Result<Vec<Value>, Exception> {
-    match obj.try_to_scheme_type::<SimpleNumber>()? {
+    match obj.try_to::<SimpleNumber>()? {
         SimpleNumber::Rational(r) => Ok(vec![Value::from(Integer::from(r.into_denominator()))]),
         SimpleNumber::Real(r) => Ok(vec![Value::from(
             f64::rounding_from(
@@ -2280,7 +2278,7 @@ pub fn denominator(obj: &Value) -> Result<Vec<Value>, Exception> {
 
 #[bridge(name = "floor", lib = "(rnrs base builtins (6))")]
 pub fn floor(obj: &Value) -> Result<Vec<Value>, Exception> {
-    match obj.try_to_scheme_type::<SimpleNumber>()? {
+    match obj.try_to::<SimpleNumber>()? {
         SimpleNumber::Rational(r) => Ok(vec![Value::from(
             Integer::rounding_from(r, RoundingMode::Floor).0,
         )]),
@@ -2291,7 +2289,7 @@ pub fn floor(obj: &Value) -> Result<Vec<Value>, Exception> {
 
 #[bridge(name = "ceiling", lib = "(rnrs base builtins (6))")]
 pub fn ceiling(obj: &Value) -> Result<Vec<Value>, Exception> {
-    match obj.try_to_scheme_type::<SimpleNumber>()? {
+    match obj.try_to::<SimpleNumber>()? {
         SimpleNumber::Rational(r) => Ok(vec![Value::from(
             Integer::rounding_from(r, RoundingMode::Ceiling).0,
         )]),
@@ -2302,7 +2300,7 @@ pub fn ceiling(obj: &Value) -> Result<Vec<Value>, Exception> {
 
 #[bridge(name = "truncate", lib = "(rnrs base builtins (6))")]
 pub fn truncate(obj: &Value) -> Result<Vec<Value>, Exception> {
-    match obj.try_to_scheme_type::<SimpleNumber>()? {
+    match obj.try_to::<SimpleNumber>()? {
         SimpleNumber::Rational(r) => Ok(vec![Value::from(
             Integer::rounding_from(r, RoundingMode::Down).0,
         )]),
@@ -2313,7 +2311,7 @@ pub fn truncate(obj: &Value) -> Result<Vec<Value>, Exception> {
 
 #[bridge(name = "round", lib = "(rnrs base builtins (6))")]
 pub fn round(obj: &Value) -> Result<Vec<Value>, Exception> {
-    match obj.try_to_scheme_type::<SimpleNumber>()? {
+    match obj.try_to::<SimpleNumber>()? {
         SimpleNumber::Rational(r) => Ok(vec![Value::from(
             Integer::rounding_from(r, RoundingMode::Nearest).0,
         )]),
@@ -2324,17 +2322,17 @@ pub fn round(obj: &Value) -> Result<Vec<Value>, Exception> {
 
 #[bridge(name = "exp", lib = "(rnrs base builtins (6))")]
 pub fn exp(z: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(z.try_to_scheme_type::<Number>()?.exp())])
+    Ok(vec![Value::from(z.try_to::<Number>()?.exp())])
 }
 
 #[bridge(name = "log", lib = "(rnrs base builtins (6))")]
 pub fn log(z: &Value, base: &[Value]) -> Result<Vec<Value>, Exception> {
     let base = match base {
         [] => None,
-        [base] => Some(base.try_to_scheme_type::<f64>()?),
+        [base] => Some(base.try_to::<f64>()?),
         _ => return Err(Exception::error("too many arguments")),
     };
-    let num = match z.try_to_scheme_type::<SimpleNumber>()? {
+    let num = match z.try_to::<SimpleNumber>()? {
         SimpleNumber::FixedInteger(i) => i as f64,
         SimpleNumber::BigInteger(i) => f64::rounding_from(&i, RoundingMode::Nearest).0,
         SimpleNumber::Rational(r) => f64::rounding_from(&r, RoundingMode::Nearest).0,
@@ -2379,7 +2377,7 @@ pub fn atan(z: Number) -> Result<Vec<Value>, Exception> {
 
 #[bridge(name = "sqrt", lib = "(rnrs base builtins (6))")]
 pub fn sqrt(z: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(z.try_to_scheme_type::<Number>()?.sqrt())])
+    Ok(vec![Value::from(z.try_to::<Number>()?.sqrt())])
 }
 
 #[bridge(name = "exact-integer-sqrt", lib = "(rnrs base builtins (6))")]
@@ -2391,8 +2389,8 @@ pub fn exact_integer_sqrt(arg: Integer) -> Result<Vec<Value>, Exception> {
 
 #[bridge(name = "expt", lib = "(rnrs base builtins (6))")]
 pub fn expt(z1: &Value, z2: &Value) -> Result<Vec<Value>, Exception> {
-    let z1 = z1.try_to_scheme_type::<Number>()?;
-    let z2 = z2.try_to_scheme_type::<Number>()?;
+    let z1 = z1.try_to::<Number>()?;
+    let z2 = z2.try_to::<Number>()?;
     Ok(vec![Value::from(z1.pow(&z2))])
 }
 
@@ -2408,7 +2406,7 @@ pub fn make_polar(x1: SimpleNumber, x2: SimpleNumber) -> Result<Vec<Value>, Exce
 
 #[bridge(name = "real-part", lib = "(rnrs base builtins (6))")]
 pub fn real_part(arg: &Value) -> Result<Vec<Value>, Exception> {
-    let num: Number = arg.try_to_scheme_type()?;
+    let num: Number = arg.try_to()?;
     if let Some(complex) = num.as_complex() {
         Ok(vec![Value::from(complex.re.clone())])
     } else {
@@ -2418,7 +2416,7 @@ pub fn real_part(arg: &Value) -> Result<Vec<Value>, Exception> {
 
 #[bridge(name = "imag-part", lib = "(rnrs base builtins (6))")]
 pub fn imag_part(arg: &Value) -> Result<Vec<Value>, Exception> {
-    let num: Number = arg.try_to_scheme_type()?;
+    let num: Number = arg.try_to()?;
     if let Some(complex) = num.as_complex() {
         Ok(vec![Value::from(complex.im.clone())])
     } else {
@@ -2428,7 +2426,7 @@ pub fn imag_part(arg: &Value) -> Result<Vec<Value>, Exception> {
 
 #[bridge(name = "magnitude", lib = "(rnrs base builtins (6))")]
 pub fn magnitude(arg: &Value) -> Result<Vec<Value>, Exception> {
-    let num: Number = arg.try_to_scheme_type()?;
+    let num: Number = arg.try_to()?;
     if let Some(complex) = num.as_complex() {
         Ok(vec![Value::from(complex.magnitude())])
     } else {
@@ -2446,11 +2444,8 @@ pub fn angle(z: ComplexNumber) -> Result<Vec<Value>, Exception> {
 pub fn number_to_string(z: ComplexNumber, rest_args: &[Value]) -> Result<Vec<Value>, Exception> {
     let (radix, precision) = match rest_args {
         [] => (10, None),
-        [radix] => (radix.try_to_scheme_type::<u32>()?, None),
-        [radix, precision] => (
-            radix.try_to_scheme_type::<u32>()?,
-            Some(precision.try_to_scheme_type::<usize>()?),
-        ),
+        [radix] => (radix.try_to::<u32>()?, None),
+        [radix, precision] => (radix.try_to::<u32>()?, Some(precision.try_to::<usize>()?)),
         _ => return Err(Exception::wrong_num_of_var_args(2..3, 1 + rest_args.len())),
     };
     if !matches!(radix, 2 | 8 | 10 | 16) {
@@ -2469,7 +2464,7 @@ pub fn number_to_string(z: ComplexNumber, rest_args: &[Value]) -> Result<Vec<Val
 pub fn string_to_number(s: WideString, rest_args: &[Value]) -> Result<Vec<Value>, Exception> {
     let radix = match rest_args {
         [] => 10,
-        [radix] => match radix.try_to_scheme_type::<u32>()? {
+        [radix] => match radix.try_to::<u32>()? {
             radix @ (2 | 8 | 10 | 16) => radix,
             radix => {
                 return Err(Exception::error(format!(
@@ -2509,7 +2504,7 @@ pub struct Fixnum(pub i64);
 
 impl From<&Value> for Option<Fixnum> {
     fn from(value: &Value) -> Option<Fixnum> {
-        if let Some(num) = value.cast_to_scheme_type::<Number>()
+        if let Some(num) = value.cast_to::<Number>()
             && let NumberInner::Simple(simple) = &*num.0
             && let SimpleNumber::FixedInteger(fixnum) = simple
         {
@@ -2524,7 +2519,7 @@ impl TryFrom<&Value> for Fixnum {
     type Error = Exception;
 
     fn try_from(value: &Value) -> Result<Self, Self::Error> {
-        if let Some(num) = value.cast_to_scheme_type::<Number>()
+        if let Some(num) = value.cast_to::<Number>()
             && let NumberInner::Simple(simple) = &*num.0
             && let SimpleNumber::FixedInteger(fixnum) = simple
         {
@@ -2537,9 +2532,7 @@ impl TryFrom<&Value> for Fixnum {
 
 #[bridge(name = "fixnum?", lib = "(rnrs arithmetic fixnums (6))")]
 pub fn fixnum_pred(obj: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(
-        obj.cast_to_scheme_type::<Fixnum>().is_some(),
-    )])
+    Ok(vec![Value::from(obj.cast_to::<Fixnum>().is_some())])
 }
 
 #[bridge(name = "fixnum-width", lib = "(rnrs arithmetic fixnums (6))")]
@@ -2562,7 +2555,7 @@ pub struct Flonum(pub f64);
 
 impl From<&Value> for Option<Flonum> {
     fn from(value: &Value) -> Option<Flonum> {
-        if let Some(num) = value.cast_to_scheme_type::<Number>()
+        if let Some(num) = value.cast_to::<Number>()
             && let NumberInner::Simple(simple) = &*num.0
             && let SimpleNumber::Real(flonum) = simple
         {
@@ -2577,7 +2570,7 @@ impl TryFrom<&Value> for Flonum {
     type Error = Exception;
 
     fn try_from(value: &Value) -> Result<Self, Self::Error> {
-        if let Some(num) = value.cast_to_scheme_type::<Number>()
+        if let Some(num) = value.cast_to::<Number>()
             && let NumberInner::Simple(simple) = &*num.0
             && let SimpleNumber::Real(flonum) = simple
         {
@@ -2590,7 +2583,5 @@ impl TryFrom<&Value> for Flonum {
 
 #[bridge(name = "flonum?", lib = "(rnrs arithmetic flonums (6))")]
 pub fn flonum_pred(obj: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(
-        obj.cast_to_scheme_type::<Flonum>().is_some(),
-    )])
+    Ok(vec![Value::from(obj.cast_to::<Flonum>().is_some())])
 }

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -33,7 +33,7 @@ use crate::{
         Span, Syntax,
         parse::{ParseSyntaxError, Parser},
     },
-    value::{Expect1, Value, ValueType},
+    value::{Expect1, Value},
     vectors::{ByteVector, Vector},
 };
 
@@ -1096,8 +1096,11 @@ mod __impl {
 
 pub use __impl::*;
 
+#[derive(Trace)]
 pub(crate) struct PortInner {
+    #[trace(skip)]
     pub(crate) info: PortInfo,
+    #[trace(skip)]
     pub(crate) data: Mutex<PortData>,
 }
 
@@ -1228,6 +1231,20 @@ impl PortInner {
                 output_buffer: buffer_mode.new_output_char_buffer(is_write),
             })),
         }
+    }
+}
+
+unsafe impl Embeddable for PortInner {
+    fn rtd() -> Arc<RecordTypeDescriptor>
+    where
+        Self: Sized {
+        rtd!(ty: PortInner, name: "port", sealed: true, opaque: true)
+    }
+}
+
+impl fmt::Debug for PortInner {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Ok(())
     }
 }
 
@@ -2270,7 +2287,7 @@ impl IntoPort for Cursor<Vec<u8>> {
 ///
 /// For more information, see [the module documentation](scheme_rs::ports).
 #[derive(Trace, Clone)]
-pub struct Port(pub(crate) Arc<PortInner>);
+pub struct Port(pub(crate) Embedded<PortInner>);
 
 impl Port {
     /// Create a new Port from a Rust source.
@@ -2315,7 +2332,7 @@ impl Port {
         D: fmt::Display,
         P: IntoPort,
     {
-        Self(Arc::new(PortInner::new(
+        Self(Embedded::new(PortInner::new(
             id,
             port,
             has_read,
@@ -2339,7 +2356,7 @@ impl Port {
         buffer_mode: BufferMode,
         transcoder: Option<Transcoder>,
     ) -> Self {
-        Self(Arc::new(PortInner::new_custom(
+        Self(Embedded::new(PortInner::new_custom(
             id,
             read,
             write,
@@ -2363,7 +2380,7 @@ impl Port {
         close: Option<Procedure>,
         buffer_mode: BufferMode,
     ) -> Self {
-        Self(Arc::new(PortInner::new_custom_textual(
+        Self(Embedded::new(PortInner::new_custom_textual(
             id,
             read,
             write,
@@ -2701,7 +2718,35 @@ impl fmt::Debug for Port {
 
 impl PartialEq for Port {
     fn eq(&self, rhs: &Self) -> bool {
-        Arc::ptr_eq(&self.0, &rhs.0)
+        Embedded::ptr_eq(&self.0, &rhs.0)
+    }
+}
+
+impl From<Port> for Value {
+    fn from(value: Port) -> Self {
+        Value::from(value.0)
+    }
+}
+
+impl TryFrom<Value> for Port {
+    type Error = Exception;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        Ok(Self((&value).try_into()?))
+    }
+}
+
+impl From<&Value> for Option<Port> {
+    fn from(value: &Value) -> Self {
+        Some(Port(value.cast_to()?))
+    }
+}
+
+impl TryFrom<&Value> for Port {
+    type Error = Exception;
+
+    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+        Ok(Self(value.try_into()?))
     }
 }
 
@@ -3326,8 +3371,8 @@ pub fn eof_object_pred(val: &Value) -> Result<Vec<Value>, Exception> {
 }
 
 #[bridge(name = "port?", lib = "(rnrs io builtins (6))")]
-pub fn port_pred(obj: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(obj.type_of() == ValueType::Port)])
+pub fn port_pred(obj: &Value,) -> bool {
+    obj.is_a::<Embedded<PortInner>>()
 }
 
 #[bridge(name = "port-transcoder", lib = "(rnrs io builtins (6))")]
@@ -3395,7 +3440,7 @@ pub fn transcoded_port(
         ..port_info.clone()
     };
 
-    let new_port = Port(Arc::new(PortInner {
+    let new_port = Port(Embedded::new(PortInner {
         info: PortInfo::BinaryPort(new_info),
         data: Mutex::new(PortData::BinaryPort(new_data)),
     }));

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -25,7 +25,7 @@ use crate::{
     exceptions::{Assertion, Error, Exception, raise},
     gc::{Gc, GcInner, Trace},
     proc::{Application, ContBarrier, DynStackElem, FuncPtr, Procedure, pop_dyn_stack},
-    records::{Record, RecordTypeDescriptor, SchemeCompatible},
+    records::{Embeddable, Embedded, RecordTypeDescriptor},
     runtime::{Runtime, RuntimeInner},
     strings::WideString,
     symbols::Symbol,
@@ -292,22 +292,22 @@ impl Transcoder {
     }
 }
 
-impl SchemeCompatible for Transcoder {
+impl Embeddable for Transcoder {
     fn rtd() -> Arc<RecordTypeDescriptor> {
-        rtd!(name: "transcoder", opaque: true, sealed: true)
+        rtd!(ty: Transcoder, name: "transcoder", opaque: true, sealed: true)
     }
 }
 
 #[bridge(name = "native-transcoder", lib = "(rnrs io builtins (6))")]
 pub fn native_transcoder() -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(Record::from_rust_type(
-        Transcoder::native(),
-    ))])
+    Ok(vec![Value::from(Transcoder::native())])
 }
 
 #[bridge(name = "make-transcoder", lib = "(rnrs io builtins (6))")]
-pub fn make_transcoder(codec: &Value, remaining: &[Value]) -> Result<Vec<Value>, Exception> {
-    let codec = *codec.try_to_rust_type::<Codec>()?;
+pub fn make_transcoder(
+    codec: Embedded<Codec>,
+    remaining: &[Value],
+) -> Result<Vec<Value>, Exception> {
     let (eol_type, error_handling_mode) = match remaining {
         [] => (EolStyle::None, ErrorHandlingMode::Replace),
         [eol_style] => (
@@ -320,44 +320,31 @@ pub fn make_transcoder(codec: &Value, remaining: &[Value]) -> Result<Vec<Value>,
         ),
         _ => return Err(Exception::wrong_num_of_var_args(1..3, 1 + remaining.len())),
     };
-    Ok(vec![Value::from_rust_type(Transcoder {
-        codec,
+    Ok(vec![Value::from(Transcoder {
+        codec: *codec,
         eol_type,
         error_handling_mode,
     })])
 }
 
 #[bridge(name = "transcoder-codec", lib = "(rnrs io builtins (6))")]
-pub fn transcoder_codec(transcoder: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![
-        transcoder
-            .try_to_rust_type::<Transcoder>()?
-            .codec
-            .to_value(),
-    ])
+pub fn transcoder_codec(transcoder: Embedded<Transcoder>) -> Result<Vec<Value>, Exception> {
+    Ok(vec![transcoder.codec.to_value()])
 }
 
 #[bridge(name = "transcoder-eol-style", lib = "(rnrs io builtins (6))")]
-pub fn transcoder_eol_style(transcoder: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(
-        transcoder
-            .try_to_rust_type::<Transcoder>()?
-            .eol_type
-            .to_sym(),
-    )])
+pub fn transcoder_eol_style(transcoder: Embedded<Transcoder>) -> Result<Vec<Value>, Exception> {
+    Ok(vec![Value::from(transcoder.eol_type.to_sym())])
 }
 
 #[bridge(
     name = "transcoder-error-handling-mode",
     lib = "(rnrs io builtins (6))"
 )]
-pub fn transcoder_error_handling_mode(transcoder: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(
-        transcoder
-            .try_to_rust_type::<Transcoder>()?
-            .error_handling_mode
-            .to_sym(),
-    )])
+pub fn transcoder_error_handling_mode(
+    transcoder: Embedded<Transcoder>,
+) -> Result<Vec<Value>, Exception> {
+    Ok(vec![Value::from(transcoder.error_handling_mode.to_sym())])
 }
 
 #[derive(Copy, Clone, Trace)]
@@ -367,35 +354,29 @@ pub enum Codec {
     Utf16,
 }
 
-impl SchemeCompatible for Codec {
+impl Embeddable for Codec {
     fn rtd() -> Arc<RecordTypeDescriptor> {
-        rtd!(name: "codec", opaque: true, sealed: true)
+        rtd!(ty: Codec, name: "codec", opaque: true, sealed: true)
     }
 }
 
-static LATIN_1_CODEC: LazyLock<Gc<Codec>> = LazyLock::new(|| Gc::new(Codec::Latin1));
-static UTF_8_CODEC: LazyLock<Gc<Codec>> = LazyLock::new(|| Gc::new(Codec::Utf8));
-static UTF_16_CODEC: LazyLock<Gc<Codec>> = LazyLock::new(|| Gc::new(Codec::Utf16));
+static LATIN_1_CODEC: LazyLock<Embedded<Codec>> = LazyLock::new(|| Embedded::new(Codec::Latin1));
+static UTF_8_CODEC: LazyLock<Embedded<Codec>> = LazyLock::new(|| Embedded::new(Codec::Utf8));
+static UTF_16_CODEC: LazyLock<Embedded<Codec>> = LazyLock::new(|| Embedded::new(Codec::Utf16));
 
 #[bridge(name = "latin-1-codec", lib = "(rnrs io builtins (6))")]
 pub fn latin_1_codec() -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(Record::from_rust_gc_type(
-        LATIN_1_CODEC.clone(),
-    ))])
+    Ok(vec![Value::from(LATIN_1_CODEC.clone())])
 }
 
 #[bridge(name = "utf-8-codec", lib = "(rnrs io builtins (6))")]
 pub fn utf_8_codec() -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(Record::from_rust_gc_type(
-        UTF_8_CODEC.clone(),
-    ))])
+    Ok(vec![Value::from(UTF_8_CODEC.clone())])
 }
 
 #[bridge(name = "utf-16-codec", lib = "(rnrs io builtins (6))")]
 pub fn utf_16_codec() -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(Record::from_rust_gc_type(
-        UTF_16_CODEC.clone(),
-    ))])
+    Ok(vec![Value::from(UTF_16_CODEC.clone())])
 }
 
 impl fmt::Debug for Codec {
@@ -431,9 +412,9 @@ impl Codec {
 
     fn to_value(self) -> Value {
         match self {
-            Self::Latin1 => Value::from(Record::from_rust_gc_type(LATIN_1_CODEC.clone())),
-            Self::Utf8 => Value::from(Record::from_rust_gc_type(UTF_8_CODEC.clone())),
-            Self::Utf16 => Value::from(Record::from_rust_gc_type(UTF_16_CODEC.clone())),
+            Self::Latin1 => Value::from(LATIN_1_CODEC.clone()),
+            Self::Utf8 => Value::from(UTF_8_CODEC.clone()),
+            Self::Utf16 => Value::from(UTF_16_CODEC.clone()),
         }
     }
 }
@@ -2942,7 +2923,7 @@ define_condition_type!(
 impl IoError {
     pub fn new() -> Self {
         Self {
-            parent: Gc::new(Error::new()),
+            parent: Error::new(),
         }
     }
 }
@@ -2963,7 +2944,7 @@ define_condition_type!(
 impl IoReadError {
     pub fn new() -> Self {
         Self {
-            parent: Gc::new(IoError::new()),
+            parent: IoError::new(),
         }
     }
 }
@@ -2984,7 +2965,7 @@ define_condition_type!(
 impl IoWriteError {
     pub fn new() -> Self {
         Self {
-            parent: Gc::new(IoError::new()),
+            parent: IoError::new(),
         }
     }
 }
@@ -3005,7 +2986,7 @@ define_condition_type!(
     },
     constructor: |position| {
         Ok(IoInvalidPositionError {
-            parent: Gc::new(IoError::new()),
+            parent: IoError::new(),
             position: position.try_into()?,
         })
     },
@@ -3024,7 +3005,7 @@ define_condition_type!(
     },
     constructor: |filename| {
         Ok(IoFilenameError {
-            parent: Gc::new(IoError::new()),
+            parent: IoError::new(),
             filename: filename.to_string(),
         })
     },
@@ -3036,7 +3017,7 @@ define_condition_type!(
 impl IoFilenameError {
     pub fn new(filename: String) -> Self {
         Self {
-            parent: Gc::new(IoError::new()),
+            parent: IoError::new(),
             filename: filename.to_string(),
         }
     }
@@ -3049,7 +3030,7 @@ define_condition_type!(
     parent: IoFilenameError,
     constructor: |filename| {
         Ok(IoFileProtectionError {
-            parent: Gc::new(IoFilenameError::new(filename.to_string()))
+            parent: IoFilenameError::new(filename.to_string())
         })
     },
     debug: |this, f| {
@@ -3060,7 +3041,7 @@ define_condition_type!(
 impl IoFileProtectionError {
     pub fn new(filename: impl fmt::Display) -> Self {
         Self {
-            parent: Gc::new(IoFilenameError::new(filename.to_string())),
+            parent: IoFilenameError::new(filename.to_string()),
         }
     }
 }
@@ -3072,7 +3053,7 @@ define_condition_type!(
     parent: IoFileProtectionError,
     constructor: |filename| {
         Ok(IoFileIsReadOnlyError {
-            parent: Gc::new(IoFileProtectionError::new(filename.to_string()))
+            parent: IoFileProtectionError::new(filename.to_string())
         })
     },
     debug: |this, f| {
@@ -3087,7 +3068,7 @@ define_condition_type!(
     parent: IoFilenameError,
     constructor: |filename| {
         Ok(IoFileAlreadyExistsError {
-            parent: Gc::new(IoFilenameError::new(filename.to_string()))
+            parent: IoFilenameError::new(filename.to_string())
         })
     },
     debug: |this, f| {
@@ -3098,7 +3079,7 @@ define_condition_type!(
 impl IoFileAlreadyExistsError {
     pub fn new(filename: impl fmt::Display) -> Self {
         Self {
-            parent: Gc::new(IoFilenameError::new(filename.to_string())),
+            parent: IoFilenameError::new(filename.to_string()),
         }
     }
 }
@@ -3110,7 +3091,7 @@ define_condition_type!(
     parent: IoFilenameError,
     constructor: |filename| {
         Ok(IoFileDoesNotExistError {
-            parent: Gc::new(IoFilenameError::new(filename.to_string()))
+            parent: IoFilenameError::new(filename.to_string())
         })
     },
     debug: |this, f| {
@@ -3121,7 +3102,7 @@ define_condition_type!(
 impl IoFileDoesNotExistError {
     pub fn new(filename: impl fmt::Display) -> Self {
         Self {
-            parent: Gc::new(IoFilenameError::new(filename.to_string())),
+            parent: IoFilenameError::new(filename.to_string()),
         }
     }
 }
@@ -3136,7 +3117,7 @@ define_condition_type!(
     },
     constructor: |port| {
         Ok(IoPortError {
-            parent: Gc::new(IoError::new()),
+            parent: IoError::new(),
             port,
         })
     },
@@ -3145,7 +3126,7 @@ define_condition_type!(
 impl IoPortError {
     pub fn new(port: Value) -> Self {
         Self {
-            parent: Gc::new(IoError::new()),
+            parent: IoError::new(),
             port,
         }
     }
@@ -3158,7 +3139,7 @@ define_condition_type!(
     parent: IoPortError,
     constructor: |port| {
         Ok(IoDecodingError {
-            parent: Gc::new(IoPortError::new(port)),
+            parent: IoPortError::new(port),
         })
     },
 );
@@ -3166,7 +3147,7 @@ define_condition_type!(
 impl IoDecodingError {
     pub fn new(port: Value) -> Self {
         Self {
-            parent: Gc::new(IoPortError::new(port)),
+            parent: IoPortError::new(port),
         }
     }
 }
@@ -3181,7 +3162,7 @@ define_condition_type!(
     },
     constructor: |port, chr| {
         Ok(IoEncodingError {
-            parent: Gc::new(IoPortError::new(port)),
+            parent: IoPortError::new(port),
             chr: chr.try_into()?,
         })
     },
@@ -3190,7 +3171,7 @@ define_condition_type!(
 impl IoEncodingError {
     pub fn new(port: Value, chr: char) -> Self {
         Self {
-            parent: Gc::new(IoPortError::new(port)),
+            parent: IoPortError::new(port),
             chr,
         }
     }
@@ -3199,9 +3180,9 @@ impl IoEncodingError {
 #[derive(Copy, Clone, Trace)]
 pub struct EofObject;
 
-impl SchemeCompatible for EofObject {
+impl Embeddable for EofObject {
     fn rtd() -> Arc<RecordTypeDescriptor> {
-        rtd!(name: "!eof", opaque: true, sealed: true)
+        rtd!(ty: EofObject, name: "!eof", opaque: true, sealed: true)
     }
 }
 
@@ -3211,11 +3192,10 @@ impl fmt::Debug for EofObject {
     }
 }
 
-static EOF_OBJECT: LazyLock<Value> =
-    LazyLock::new(|| Value::from(Record::from_rust_type(EofObject)));
+static EOF_OBJECT: LazyLock<Value> = LazyLock::new(|| Value::from(EofObject));
 
-static FILE_OPTIONS: LazyLock<Gc<EnumerationType>> = LazyLock::new(|| {
-    Gc::new(EnumerationType::new([
+static FILE_OPTIONS: LazyLock<Embedded<EnumerationType>> = LazyLock::new(|| {
+    Embedded::new(EnumerationType::new([
         Symbol::intern("append"),
         Symbol::intern("no-create"),
         Symbol::intern("no-fail"),
@@ -3223,8 +3203,8 @@ static FILE_OPTIONS: LazyLock<Gc<EnumerationType>> = LazyLock::new(|| {
     ]))
 });
 
-fn default_file_options() -> EnumerationSet {
-    EnumerationSet::new(&FILE_OPTIONS, [])
+fn default_file_options() -> Embedded<EnumerationSet> {
+    Embedded::new(EnumerationSet::new(&FILE_OPTIONS, []))
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -3262,16 +3242,15 @@ fn open_file_port(
 
     // We don't actually use file options for anything in the input case.
     let (file_options, rest_args) = if let [file_options, rest @ ..] = rest_args {
-        let file_options = file_options.clone().try_to_rust_type::<EnumerationSet>()?;
+        let file_options = file_options.clone().try_to::<Embedded<EnumerationSet>>()?;
         file_options.type_check(&FILE_OPTIONS)?;
         (file_options, rest)
     } else {
-        (Gc::new(default_file_options()), &[] as &[Value])
+        (default_file_options(), &[] as &[Value])
     };
 
     let (buffer_mode, rest_args) = if let [buffer_mode, rest @ ..] = rest_args {
-        let buffer_mode =
-            BufferMode::from_sym(buffer_mode.clone().try_to_scheme_type::<Symbol>()?)?;
+        let buffer_mode = BufferMode::from_sym(buffer_mode.clone().try_to::<Symbol>()?)?;
         (buffer_mode, rest)
     } else {
         (BufferMode::Block, &[] as &[Value])
@@ -3279,7 +3258,7 @@ fn open_file_port(
 
     let transcoder = if let [transcoder] = rest_args {
         if transcoder.is_true() {
-            let transcoder = transcoder.clone().try_to_rust_type::<Transcoder>()?;
+            let transcoder = transcoder.clone().try_to::<Embedded<Transcoder>>()?;
             Some(*transcoder)
         } else {
             None
@@ -3331,20 +3310,18 @@ fn map_io_error_to_condition(filename: &str, err: std::io::Error) -> Exception {
 
 #[bridge(name = "default-file-options", lib = "(rnrs io builtins (6))")]
 pub fn default_file_options_scm() -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(Record::from_rust_type(
-        default_file_options(),
-    ))])
+    Ok(vec![Value::from(default_file_options())])
 }
 
 #[bridge(name = "eof-object", lib = "(rnrs io builtins (6))")]
 pub fn eof_object() -> Result<Vec<Value>, Exception> {
-    Ok(vec![EOF_OBJECT.clone()])
+    Ok(vec![Value::from(EOF_OBJECT.clone())])
 }
 
 #[bridge(name = "eof-object?", lib = "(rnrs io builtins (6))")]
 pub fn eof_object_pred(val: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
-        val.cast_to_rust_type::<EofObject>().is_some(),
+        val.cast_to::<Embedded<EofObject>>().is_some(),
     )])
 }
 
@@ -3357,7 +3334,7 @@ pub fn port_pred(obj: &Value) -> Result<Vec<Value>, Exception> {
 pub fn port_transcoder(port: &Value) -> Result<Vec<Value>, Exception> {
     let port: Port = port.clone().try_into()?;
     if let Some(transcoder) = port.transcoder() {
-        let transcoder = Value::from(Record::from_rust_type(transcoder));
+        let transcoder = Value::from(transcoder);
         Ok(vec![transcoder])
     } else {
         Ok(vec![Value::from(false)])
@@ -3378,8 +3355,10 @@ pub fn binary_port_pred(port: &Value) -> Result<Vec<Value>, Exception> {
 
 #[maybe_async]
 #[bridge(name = "transcoded-port", lib = "(rnrs io builtins (6))")]
-pub fn transcoded_port(port: Port, transcoder: &Value) -> Result<Vec<Value>, Exception> {
-    let transcoder = transcoder.try_to_rust_type::<Transcoder>()?;
+pub fn transcoded_port(
+    port: Port,
+    transcoder: Embedded<Transcoder>,
+) -> Result<Vec<Value>, Exception> {
     if port.is_textual_port() {
         return Err(Exception::error("not a binary port"));
     }
@@ -3682,7 +3661,7 @@ pub fn get_u8(binary_input_port: &Value) -> Result<Vec<Value>, Exception> {
     if let Some(byte) = maybe_await!(port.get_u8())? {
         Ok(vec![Value::from(byte)])
     } else {
-        Ok(vec![EOF_OBJECT.clone()])
+        Ok(vec![Value::from(EOF_OBJECT.clone())])
     }
 }
 
@@ -3693,7 +3672,7 @@ pub fn lookahead_u8(binary_input_port: &Value) -> Result<Vec<Value>, Exception> 
     if let Some(byte) = maybe_await!(port.lookahead_u8())? {
         Ok(vec![Value::from(byte)])
     } else {
-        Ok(vec![EOF_OBJECT.clone()])
+        Ok(vec![Value::from(EOF_OBJECT.clone())])
     }
 }
 
@@ -3706,7 +3685,7 @@ pub fn get_char(textual_input_port: &Value) -> Result<Vec<Value>, Exception> {
     if let Some(chr) = maybe_await!(port.get_char())? {
         Ok(vec![Value::from(chr)])
     } else {
-        Ok(vec![EOF_OBJECT.clone()])
+        Ok(vec![Value::from(EOF_OBJECT.clone())])
     }
 }
 
@@ -3717,7 +3696,7 @@ pub fn lookahead_char(textual_input_port: &Value) -> Result<Vec<Value>, Exceptio
     if let Some(chr) = maybe_await!(port.lookahead_char())? {
         Ok(vec![Value::from(chr)])
     } else {
-        Ok(vec![EOF_OBJECT.clone()])
+        Ok(vec![Value::from(EOF_OBJECT.clone())])
     }
 }
 
@@ -3729,7 +3708,7 @@ pub fn get_string_n(textual_input_port: &Value, n: &Value) -> Result<Vec<Value>,
     if let Some(s) = maybe_await!(port.get_string_n(n))? {
         Ok(vec![Value::from(s)])
     } else {
-        Ok(vec![EOF_OBJECT.clone()])
+        Ok(vec![Value::from(EOF_OBJECT.clone())])
     }
 }
 
@@ -3740,7 +3719,7 @@ pub fn get_line(textual_input_port: &Value) -> Result<Vec<Value>, Exception> {
     if let Some(line) = maybe_await!(port.get_line())? {
         Ok(vec![Value::from(line)])
     } else {
-        Ok(vec![EOF_OBJECT.clone()])
+        Ok(vec![Value::from(EOF_OBJECT.clone())])
     }
 }
 
@@ -3750,7 +3729,7 @@ pub fn get_string_all(textual_input_port: Port) -> Result<Vec<Value>, Exception>
     if let Some(s) = maybe_await!(textual_input_port.get_string_all())? {
         Ok(vec![Value::from(s)])
     } else {
-        Ok(vec![EOF_OBJECT.clone()])
+        Ok(vec![Value::from(EOF_OBJECT.clone())])
     }
 }
 
@@ -3761,7 +3740,7 @@ pub fn get_datum(textual_input_port: &Value) -> Result<Vec<Value>, Exception> {
     if let Some((syntax, _)) = maybe_await!(port.get_sexpr(Span::default()))? {
         Ok(vec![Value::datum_from_syntax(&syntax)])
     } else {
-        Ok(vec![EOF_OBJECT.clone()])
+        Ok(vec![Value::from(EOF_OBJECT.clone())])
     }
 }
 
@@ -3936,15 +3915,15 @@ pub fn put_bytevector(
     let slice = match start_count {
         [] => &bytevector[..],
         [start] => {
-            let start: usize = start.try_to_scheme_type()?;
+            let start: usize = start.try_to()?;
             if start >= bytevector.len() {
                 return Err(Exception::invalid_index(start, bytevector.len()));
             }
             &bytevector[start..]
         }
         [start, count] => {
-            let start: usize = start.try_to_scheme_type()?;
-            let count: usize = count.try_to_scheme_type()?;
+            let start: usize = start.try_to()?;
+            let count: usize = count.try_to()?;
             if (start + count) >= bytevector.len() {
                 return Err(Exception::invalid_index(start + count, bytevector.len()));
             }
@@ -4022,15 +4001,15 @@ pub fn put_string(
     let slice = match start_count {
         [] => &string[..],
         [start] => {
-            let start: usize = start.try_to_scheme_type()?;
+            let start: usize = start.try_to()?;
             if start >= string.len() {
                 return Err(Exception::invalid_index(start, string.len()));
             }
             &string[start..]
         }
         [start, count] => {
-            let start: usize = start.try_to_scheme_type()?;
-            let count: usize = count.try_to_scheme_type()?;
+            let start: usize = start.try_to()?;
+            let count: usize = count.try_to()?;
             if (start + count) >= string.len() {
                 return Err(Exception::invalid_index(start + count, string.len()));
             }
@@ -4351,7 +4330,7 @@ unsafe extern "C" fn close_port_and_call_k(
         let k = env.add(1).as_ref().unwrap().clone();
 
         // Collect necessary arguments
-        let k_proc = k.cast_to_scheme_type::<Procedure>().unwrap();
+        let k_proc = k.cast_to::<Procedure>().unwrap();
         let args = k_proc.collect_args(args);
 
         let k = Procedure::new_cont(
@@ -4385,7 +4364,7 @@ unsafe extern "C" fn call_k_with_env(
             .add(1)
             .as_ref()
             .unwrap()
-            .cast_to_scheme_type::<Vector>()
+            .cast_to::<Vector>()
             .unwrap()
             .clone_inner_vec();
 
@@ -4591,7 +4570,7 @@ pub fn read_char(
     let result = if let Some(byte) = maybe_await!(input_port.get_char())? {
         Value::from(byte)
     } else {
-        EOF_OBJECT.clone()
+        Value::from(EOF_OBJECT.clone())
     };
 
     Ok(Application::new(k, None, vec![result]))

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -3356,15 +3356,13 @@ pub fn default_file_options_scm() -> Result<Vec<Value>, Exception> {
 }
 
 #[bridge(name = "eof-object", lib = "(rnrs io builtins (6))")]
-pub fn eof_object() -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(EOF_OBJECT.clone())])
+pub fn eof_object() -> Value {
+    EOF_OBJECT.clone()
 }
 
 #[bridge(name = "eof-object?", lib = "(rnrs io builtins (6))")]
-pub fn eof_object_pred(val: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(
-        val.cast::<Embedded<EofObject>>().is_some(),
-    )])
+pub fn eof_object_pred(val: &Value) -> bool {
+    val.is_a::<Embedded<EofObject>>()
 }
 
 #[bridge(name = "port?", lib = "(rnrs io builtins (6))")]
@@ -3703,7 +3701,7 @@ pub fn get_u8(binary_input_port: &Value) -> Result<Vec<Value>, Exception> {
     if let Some(byte) = maybe_await!(port.get_u8())? {
         Ok(vec![Value::from(byte)])
     } else {
-        Ok(vec![Value::from(EOF_OBJECT.clone())])
+        Ok(vec![EOF_OBJECT.clone()])
     }
 }
 
@@ -3714,7 +3712,7 @@ pub fn lookahead_u8(binary_input_port: &Value) -> Result<Vec<Value>, Exception> 
     if let Some(byte) = maybe_await!(port.lookahead_u8())? {
         Ok(vec![Value::from(byte)])
     } else {
-        Ok(vec![Value::from(EOF_OBJECT.clone())])
+        Ok(vec![EOF_OBJECT.clone()])
     }
 }
 
@@ -3722,46 +3720,41 @@ pub fn lookahead_u8(binary_input_port: &Value) -> Result<Vec<Value>, Exception> 
 
 #[maybe_async]
 #[bridge(name = "get-char", lib = "(rnrs io builtins (6))")]
-pub fn get_char(textual_input_port: &Value) -> Result<Vec<Value>, Exception> {
-    let port: Port = textual_input_port.clone().try_into()?;
-    if let Some(chr) = maybe_await!(port.get_char())? {
+pub fn get_char(textual_input_port: Port) -> Result<Vec<Value>, Exception> {
+    if let Some(chr) = maybe_await!(textual_input_port.get_char())? {
         Ok(vec![Value::from(chr)])
     } else {
-        Ok(vec![Value::from(EOF_OBJECT.clone())])
+        Ok(vec![EOF_OBJECT.clone()])
     }
 }
 
 #[maybe_async]
 #[bridge(name = "lookahead-char", lib = "(rnrs io builtins (6))")]
-pub fn lookahead_char(textual_input_port: &Value) -> Result<Vec<Value>, Exception> {
-    let port: Port = textual_input_port.clone().try_into()?;
-    if let Some(chr) = maybe_await!(port.lookahead_char())? {
+pub fn lookahead_char(textual_input_port: Port) -> Result<Vec<Value>, Exception> {
+    if let Some(chr) = maybe_await!(textual_input_port.lookahead_char())? {
         Ok(vec![Value::from(chr)])
     } else {
-        Ok(vec![Value::from(EOF_OBJECT.clone())])
+        Ok(vec![EOF_OBJECT.clone()])
     }
 }
 
 #[maybe_async]
 #[bridge(name = "get-string-n", lib = "(rnrs io builtins (6))")]
-pub fn get_string_n(textual_input_port: &Value, n: &Value) -> Result<Vec<Value>, Exception> {
-    let port: Port = textual_input_port.clone().try_into()?;
-    let n: usize = n.clone().try_into()?;
-    if let Some(s) = maybe_await!(port.get_string_n(n))? {
+pub fn get_string_n(textual_input_port: Port, n: usize) -> Result<Vec<Value>, Exception> {
+    if let Some(s) = maybe_await!(textual_input_port.get_string_n(n))? {
         Ok(vec![Value::from(s)])
     } else {
-        Ok(vec![Value::from(EOF_OBJECT.clone())])
+        Ok(vec![EOF_OBJECT.clone()])
     }
 }
 
 #[maybe_async]
 #[bridge(name = "get-line", lib = "(rnrs io builtins (6))")]
-pub fn get_line(textual_input_port: &Value) -> Result<Vec<Value>, Exception> {
-    let port: Port = textual_input_port.clone().try_into()?;
-    if let Some(line) = maybe_await!(port.get_line())? {
+pub fn get_line(textual_input_port: Port) -> Result<Vec<Value>, Exception> {
+    if let Some(line) = maybe_await!(textual_input_port.get_line())? {
         Ok(vec![Value::from(line)])
     } else {
-        Ok(vec![Value::from(EOF_OBJECT.clone())])
+        Ok(vec![EOF_OBJECT.clone()])
     }
 }
 
@@ -3771,18 +3764,17 @@ pub fn get_string_all(textual_input_port: Port) -> Result<Vec<Value>, Exception>
     if let Some(s) = maybe_await!(textual_input_port.get_string_all())? {
         Ok(vec![Value::from(s)])
     } else {
-        Ok(vec![Value::from(EOF_OBJECT.clone())])
+        Ok(vec![EOF_OBJECT.clone()])
     }
 }
 
 #[maybe_async]
 #[bridge(name = "get-datum", lib = "(rnrs io builtins (6))")]
-pub fn get_datum(textual_input_port: &Value) -> Result<Vec<Value>, Exception> {
-    let port: Port = textual_input_port.clone().try_into()?;
-    if let Some((syntax, _)) = maybe_await!(port.get_sexpr(Span::default()))? {
+pub fn get_datum(textual_input_port: Port) -> Result<Vec<Value>, Exception> {
+    if let Some((syntax, _)) = maybe_await!(textual_input_port.get_sexpr(Span::default()))? {
         Ok(vec![Value::datum_from_syntax(&syntax)])
     } else {
-        Ok(vec![Value::from(EOF_OBJECT.clone())])
+        Ok(vec![EOF_OBJECT.clone()])
     }
 }
 
@@ -3995,15 +3987,15 @@ pub async fn put_bytevector(
         match start_count {
             [] => bytevector[..].to_vec(),
             [start] => {
-                let start: usize = start.try_to_scheme_type()?;
+                let start: usize = start.try_to()?;
                 if start >= bytevector.len() {
                     return Err(Exception::invalid_index(start, bytevector.len()));
                 }
                 bytevector[start..].to_vec()
             }
             [start, count] => {
-                let start: usize = start.try_to_scheme_type()?;
-                let count: usize = count.try_to_scheme_type()?;
+                let start: usize = start.try_to()?;
+                let count: usize = count.try_to()?;
                 if (start + count) >= bytevector.len() {
                     return Err(Exception::invalid_index(start + count, bytevector.len()));
                 }
@@ -4080,15 +4072,15 @@ pub async fn put_string(
         match start_count {
             [] => string[..].to_vec(),
             [start] => {
-                let start: usize = start.try_to_scheme_type()?;
+                let start: usize = start.try_to()?;
                 if start >= string.len() {
                     return Err(Exception::invalid_index(start, string.len()));
                 }
                 string[start..].to_vec()
             }
             [start, count] => {
-                let start: usize = start.try_to_scheme_type()?;
-                let count: usize = count.try_to_scheme_type()?;
+                let start: usize = start.try_to()?;
+                let count: usize = count.try_to()?;
                 if (start + count) >= string.len() {
                     return Err(Exception::invalid_index(start + count, string.len()));
                 }
@@ -4612,7 +4604,7 @@ pub fn read_char(
     let result = if let Some(byte) = maybe_await!(input_port.get_char())? {
         Value::from(byte)
     } else {
-        Value::from(EOF_OBJECT.clone())
+        EOF_OBJECT.clone()
     };
 
     Ok(Application::new(k, None, vec![result]))

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -292,7 +292,7 @@ impl Transcoder {
     }
 }
 
-impl Embeddable for Transcoder {
+unsafe impl Embeddable for Transcoder {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(ty: Transcoder, name: "transcoder", opaque: true, sealed: true)
     }
@@ -354,7 +354,7 @@ pub enum Codec {
     Utf16,
 }
 
-impl Embeddable for Codec {
+unsafe impl Embeddable for Codec {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(ty: Codec, name: "codec", opaque: true, sealed: true)
     }
@@ -3180,7 +3180,7 @@ impl IoEncodingError {
 #[derive(Copy, Clone, Trace)]
 pub struct EofObject;
 
-impl Embeddable for EofObject {
+unsafe impl Embeddable for EofObject {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(ty: EofObject, name: "!eof", opaque: true, sealed: true)
     }

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -1237,7 +1237,8 @@ impl PortInner {
 unsafe impl Embeddable for PortInner {
     fn rtd() -> Arc<RecordTypeDescriptor>
     where
-        Self: Sized {
+        Self: Sized,
+    {
         rtd!(ty: PortInner, name: "port", sealed: true, opaque: true)
     }
 }
@@ -3371,7 +3372,7 @@ pub fn eof_object_pred(val: &Value) -> Result<Vec<Value>, Exception> {
 }
 
 #[bridge(name = "port?", lib = "(rnrs io builtins (6))")]
-pub fn port_pred(obj: &Value,) -> bool {
+pub fn port_pred(obj: &Value) -> bool {
     obj.is_a::<Embedded<PortInner>>()
 }
 

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -2739,7 +2739,7 @@ impl TryFrom<Value> for Port {
 
 impl From<&Value> for Option<Port> {
     fn from(value: &Value) -> Self {
-        Some(Port(value.cast_to()?))
+        Some(Port(value.cast()?))
     }
 }
 
@@ -3367,7 +3367,7 @@ pub fn eof_object() -> Result<Vec<Value>, Exception> {
 #[bridge(name = "eof-object?", lib = "(rnrs io builtins (6))")]
 pub fn eof_object_pred(val: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(
-        val.cast_to::<Embedded<EofObject>>().is_some(),
+        val.cast::<Embedded<EofObject>>().is_some(),
     )])
 }
 
@@ -4376,7 +4376,7 @@ unsafe extern "C" fn close_port_and_call_k(
         let k = env.add(1).as_ref().unwrap().clone();
 
         // Collect necessary arguments
-        let k_proc = k.cast_to::<Procedure>().unwrap();
+        let k_proc = k.cast::<Procedure>().unwrap();
         let args = k_proc.collect_args(args);
 
         let k = Procedure::new_cont(
@@ -4410,7 +4410,7 @@ unsafe extern "C" fn call_k_with_env(
             .add(1)
             .as_ref()
             .unwrap()
-            .cast_to::<Vector>()
+            .cast::<Vector>()
             .unwrap()
             .clone_inner_vec();
 

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -61,7 +61,7 @@
 //!     _barrier: &mut ContBarrier,
 //! ) -> Result<Application, Exception> {
 //!     // Fetch the cell from the environment:
-//!     let cell: Cell = env[0].try_to_scheme_type()?;
+//!     let cell: Cell = env[0].try_to()?;
 //!     let curr: Number = cell.get().try_into()?;
 //!
 //!     // Increment the cell
@@ -98,7 +98,7 @@ use crate::{
     gc::{Gc, GcInner, Trace},
     lists::{self, Pair, list_to_vec},
     ports::{BufferMode, Port, Transcoder},
-    records::{Record, RecordTypeDescriptor, SchemeCompatible, rtd},
+    records::{Embeddable, Embedded, RecordTypeDescriptor, rtd},
     registry::BridgeFnDebugInfo,
     runtime::{Runtime, RuntimeInner},
     symbols::Symbol,
@@ -1197,9 +1197,9 @@ impl From<SavedDynamicState> for ContBarrier<'_> {
     }
 }
 
-impl SchemeCompatible for SavedDynamicState {
+impl Embeddable for SavedDynamicState {
     fn rtd() -> Arc<RecordTypeDescriptor> {
-        rtd!(name: "$dynamic-state", sealed: true, opaque: true)
+        rtd!(ty: SavedDynamicState, name: "%dynamic-state", sealed: true, opaque: true)
     }
 }
 
@@ -1270,7 +1270,7 @@ pub fn call_with_current_continuation(
 
     let (req_args, variadic) = k.get_formals();
 
-    let barrier = Value::from_rust_type(barrier.save());
+    let barrier = Value::from(barrier.save());
 
     let escape_procedure = Procedure::new(
         runtime.clone(),
@@ -1302,7 +1302,7 @@ fn escape_procedure(
     // env[1] is the dyn stack of the continuation
     let saved_barrier_val = env[1].clone();
     let saved_barrier = saved_barrier_val
-        .try_to_rust_type::<SavedDynamicState>()
+        .try_to::<Embedded<SavedDynamicState>>()
         .unwrap();
     let saved_barrier_read = saved_barrier.as_ref();
 
@@ -1353,7 +1353,7 @@ unsafe extern "C" fn unwind(
         let dest_stack_val = env.add(2).as_ref().unwrap().clone();
         let dest_stack = dest_stack_val
             .clone()
-            .try_to_rust_type::<SavedDynamicState>()
+            .try_to::<Embedded<SavedDynamicState>>()
             .unwrap();
         let dest_stack_read = dest_stack.as_ref();
 
@@ -1422,7 +1422,7 @@ unsafe extern "C" fn wind(
         // env[2] is the stack we are trying to reach
         let dest_stack_val = env.add(2).as_ref().unwrap().clone();
         let dest_stack = dest_stack_val
-            .try_to_rust_type::<SavedDynamicState>()
+            .try_to::<Embedded<SavedDynamicState>>()
             .unwrap();
         let dest_stack_read = dest_stack.as_ref();
 
@@ -1431,7 +1431,7 @@ unsafe extern "C" fn wind(
         // env[3] is potentially a winder that we should push onto the dyn stack
         let winder = env.add(3).as_ref().unwrap().clone();
         if winder.is_true() {
-            let winder = winder.try_to_rust_type::<Winder>().unwrap();
+            let winder = winder.try_to::<Embedded<Winder>>().unwrap();
             barrier.push_dyn_stack(DynStackElem::Winder(winder.as_ref().clone()));
         }
 
@@ -1449,12 +1449,7 @@ unsafe extern "C" fn wind(
                         winder.in_thunk.clone(),
                         Some(Procedure::new_cont(
                             Runtime::from_raw_inc_rc(runtime),
-                            vec![
-                                k,
-                                args,
-                                dest_stack_val,
-                                Value::from(Record::from_rust_type(winder)),
-                            ],
+                            vec![k, args, dest_stack_val, Value::from(winder)],
                             wind,
                             0,
                             false,
@@ -1524,7 +1519,7 @@ unsafe extern "C" fn call_consumer_with_values(
 
         Box::into_raw(Box::new(Application::new(
             consumer.clone(),
-            k.cast_to_scheme_type(),
+            k.cast_to(),
             collected_args,
         )))
     }
@@ -1579,9 +1574,9 @@ pub(crate) struct Winder {
     pub(crate) out_thunk: Procedure,
 }
 
-impl SchemeCompatible for Winder {
+impl Embeddable for Winder {
     fn rtd() -> Arc<RecordTypeDescriptor> {
-        rtd!(name: "$winder", sealed: true, opaque: true)
+        rtd!(ty: Winder, name: "%winder", sealed: true, opaque: true)
     }
 }
 
@@ -1799,7 +1794,7 @@ pub fn abort_to_prompt(
             Value::from(k),
             Value::from(rest_args.to_vec()),
             tag.clone(),
-            Value::from_rust_type(barrier.save()),
+            Value::from(barrier.save()),
         ],
         unwind_to_prompt,
         0,
@@ -1843,7 +1838,7 @@ unsafe extern "C" fn unwind_to_prompt(
                     handler_k,
                 })) if prompt_tag == tag => {
                     let saved_barrier = saved_barrier
-                        .try_to_rust_type::<SavedDynamicState>()
+                        .try_to::<Embedded<SavedDynamicState>>()
                         .unwrap();
                     let prompt_delimited_barrier = SavedDynamicState {
                         id: saved_barrier.id,
@@ -1862,13 +1857,13 @@ unsafe extern "C" fn unwind_to_prompt(
                         vec![
                             k,
                             Value::from(barrier_id),
-                            Value::from_rust_type(prompt_delimited_barrier),
+                            Value::from(prompt_delimited_barrier),
                         ],
                         FuncPtr::Bridge(delimited_continuation),
                         req_args,
                         var,
                     ))];
-                    handler_args.extend(args.cast_to_scheme_type::<Vector>().unwrap().iter());
+                    handler_args.extend(args.cast_to::<Vector>().unwrap().iter());
                     Application::new(handler, Some(handler_k), handler_args)
                 }
                 Some(DynStackElem::Winder(winder)) => {
@@ -1906,12 +1901,12 @@ fn delimited_continuation(
     let dk = env[0].clone();
 
     // env[1] is the barrier Id
-    let barrier_id: usize = env[1].try_to_scheme_type()?;
+    let barrier_id: usize = env[1].try_to()?;
 
     // env[2] is the dyn stack of the continuation
     let saved_barrier_val = env[2].clone();
     let saved_barrier = saved_barrier_val
-        .try_to_rust_type::<SavedDynamicState>()
+        .try_to::<Embedded<SavedDynamicState>>()
         .unwrap();
     let saved_barrier_read = saved_barrier.as_ref();
     // Restore continuation marks
@@ -1964,19 +1959,19 @@ unsafe extern "C" fn wind_delim(
         // env[2] is the stack we are trying to reach
         let dest_stack_val = env.add(2).as_ref().unwrap().clone();
         let dest_stack = dest_stack_val
-            .try_to_rust_type::<SavedDynamicState>()
+            .try_to::<Embedded<SavedDynamicState>>()
             .unwrap();
         let dest_stack_read = dest_stack.as_ref();
 
         // env[3] is the index into the dest stack we're at
-        let mut idx: usize = env.add(3).as_ref().unwrap().cast_to_scheme_type().unwrap();
+        let mut idx: usize = env.add(3).as_ref().unwrap().cast_to().unwrap();
 
         let barrier = barrier.as_mut().unwrap_unchecked();
 
         // env[4] is potentially a winder that we should push onto the dyn stack
         let winder = env.add(4).as_ref().unwrap().clone();
         if winder.is_true() {
-            let winder = winder.try_to_rust_type::<Winder>().unwrap();
+            let winder = winder.try_to::<Embedded<Winder>>().unwrap();
             barrier.push_dyn_stack(DynStackElem::Winder(winder.as_ref().clone()));
         }
 
@@ -1989,12 +1984,7 @@ unsafe extern "C" fn wind_delim(
                     winder.in_thunk.clone(),
                     Some(Procedure::new_cont(
                         Runtime::from_raw_inc_rc(runtime),
-                        vec![
-                            k,
-                            args,
-                            dest_stack_val,
-                            Value::from(Record::from_rust_type(winder.clone())),
-                        ],
+                        vec![k, args, dest_stack_val, Value::from(winder.clone())],
                         wind,
                         0,
                         false,

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -1197,7 +1197,7 @@ impl From<SavedDynamicState> for ContBarrier<'_> {
     }
 }
 
-impl Embeddable for SavedDynamicState {
+unsafe impl Embeddable for SavedDynamicState {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(ty: SavedDynamicState, name: "%dynamic-state", sealed: true, opaque: true)
     }
@@ -1574,7 +1574,7 @@ pub(crate) struct Winder {
     pub(crate) out_thunk: Procedure,
 }
 
-impl Embeddable for Winder {
+unsafe impl Embeddable for Winder {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(ty: Winder, name: "%winder", sealed: true, opaque: true)
     }

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -1519,7 +1519,7 @@ unsafe extern "C" fn call_consumer_with_values(
 
         Box::into_raw(Box::new(Application::new(
             consumer.clone(),
-            k.cast_to(),
+            k.cast(),
             collected_args,
         )))
     }
@@ -1863,7 +1863,7 @@ unsafe extern "C" fn unwind_to_prompt(
                         req_args,
                         var,
                     ))];
-                    handler_args.extend(args.cast_to::<Vector>().unwrap().iter());
+                    handler_args.extend(args.cast::<Vector>().unwrap().iter());
                     Application::new(handler, Some(handler_k), handler_args)
                 }
                 Some(DynStackElem::Winder(winder)) => {
@@ -1964,7 +1964,7 @@ unsafe extern "C" fn wind_delim(
         let dest_stack_read = dest_stack.as_ref();
 
         // env[3] is the index into the dest stack we're at
-        let mut idx: usize = env.add(3).as_ref().unwrap().cast_to().unwrap();
+        let mut idx: usize = env.add(3).as_ref().unwrap().cast().unwrap();
 
         let barrier = barrier.as_mut().unwrap_unchecked();
 

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -1490,7 +1490,7 @@ unsafe extern "C" fn call_consumer_with_values(
             _ => {
                 let raised = raise(
                     Runtime::from_raw_inc_rc(runtime),
-                    Exception::invalid_operator(type_name).into(),
+                    Exception::invalid_operator(&type_name).into(),
                     barrier.as_mut().unwrap_unchecked(),
                 );
                 return Box::into_raw(Box::new(raised));

--- a/src/records.rs
+++ b/src/records.rs
@@ -538,6 +538,12 @@ impl Record {
     }
 }
 
+impl fmt::Display for Record {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 impl fmt::Debug for Record {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
@@ -638,15 +644,23 @@ unsafe impl Trace for RecordInner {
     }
 }
 
+impl fmt::Display for RecordInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(vtable) = self.rtd.embedded_vtable {
+            (vtable.display_fmt)(self.embedded_ptr().unwrap(), f)
+        } else {
+            Ok(())
+        }
+    }
+}
+
 impl fmt::Debug for RecordInner {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "#<{}", self.rtd.name)?;
-        let skipped_fields = if let Some(vtable) = self.rtd.embedded_vtable {
+        if let Some(vtable) = self.rtd.embedded_vtable {
             (vtable.debug_fmt)(self.embedded_ptr().unwrap(), f)?;
-            vtable.embedded_fields
-        } else {
-            0
-        };
+        }
+
+        write!(f, "#<{}", self.rtd.name)?;
         for (Field::Mutable(name) | Field::Immutable(name), field) in self
             .rtd
             .inherits
@@ -654,7 +668,6 @@ impl fmt::Debug for RecordInner {
             .cloned()
             .chain(Some(ByAddress(self.rtd.clone())))
             .flat_map(|rtd| rtd.fields.clone())
-            .skip(skipped_fields)
             .zip(self.fields())
         {
             write!(f, " {name}: {field:?}")?;
@@ -673,7 +686,7 @@ impl fmt::Debug for RecordInner {
 ///
 /// scheme-rs uses the layout of the type to compactly allocate types within
 /// scheme records. Those layouts are stored in the RTD.
-pub unsafe trait Embeddable: fmt::Debug + Trace + Any + Send + Sync {
+pub unsafe trait Embeddable: Trace + Any + Send + Sync {
     /// The Record Type Descriptor of the value. Can be constructed at runtime,
     /// but cannot change.
     fn rtd() -> Arc<RecordTypeDescriptor>
@@ -693,6 +706,14 @@ pub unsafe trait Embeddable: fmt::Debug + Trace + Any + Send + Sync {
     /// Set the kth field of the record.
     fn set_field(&self, k: usize, _val: Value) -> Result<(), Exception> {
         Err(Exception::error(format!("invalid record field: {k}")))
+    }
+
+    fn display_fmt(&self, _fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Ok(())
+    }
+
+    fn debug_fmt(&self, _fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Ok(())
     }
 
     fn eq(&self, rhs: &Record) -> bool
@@ -775,6 +796,8 @@ pub struct EmbeddableVTable {
     #[trace(skip)]
     pub set_field: fn(*const (), usize, Value) -> Result<(), Exception>,
     #[trace(skip)]
+    pub display_fmt: fn(*const (), &mut fmt::Formatter<'_>) -> fmt::Result,
+    #[trace(skip)]
     pub debug_fmt: fn(*const (), &mut fmt::Formatter<'_>) -> fmt::Result,
     #[trace(skip)]
     pub eq: for<'a> fn(*const (), &'a Record) -> bool,
@@ -810,7 +833,10 @@ impl EmbeddableVTable {
             set_field: |this, k, val| {
                 E::set_field(unsafe { this.cast::<E>().as_ref().unwrap() }, k, val)
             },
-            debug_fmt: |this, fmt| E::fmt(unsafe { this.cast::<E>().as_ref().unwrap() }, fmt),
+            display_fmt: |this, fmt| {
+                E::display_fmt(unsafe { this.cast::<E>().as_ref().unwrap() }, fmt)
+            },
+            debug_fmt: |this, fmt| E::debug_fmt(unsafe { this.cast::<E>().as_ref().unwrap() }, fmt),
             eq: |lhs, rhs| E::eq(unsafe { lhs.cast::<E>().as_ref().unwrap() }, rhs),
             eqv: |lhs, rhs| E::eqv(unsafe { lhs.cast::<E>().as_ref().unwrap() }, rhs),
             equal: |lhs, rhs| E::equal(unsafe { lhs.cast::<E>().as_ref().unwrap() }, rhs),

--- a/src/records.rs
+++ b/src/records.rs
@@ -748,26 +748,14 @@ pub unsafe trait Embeddable: Trace + Any + Send + Sync {
     where
         Self: Sized,
     {
-        let Some(rhs) = rhs.cast::<Self>() else {
-            return false;
-        };
-        std::ptr::eq(
-            self as *const Self as *const (),
-            rhs.embedded_ptr.as_ptr().cast::<()>(),
-        )
+        self.eq(rhs)
     }
 
     fn equal(&self, rhs: &Record) -> bool
     where
         Self: Sized,
     {
-        let Some(rhs) = rhs.cast::<Self>() else {
-            return false;
-        };
-        std::ptr::eq(
-            self as *const Self as *const (),
-            rhs.embedded_ptr.as_ptr().cast::<()>(),
-        )
+        self.eqv(rhs)
     }
 
     fn eq_hash(&self, hasher: &mut dyn Hasher)
@@ -781,14 +769,14 @@ pub unsafe trait Embeddable: Trace + Any + Send + Sync {
     where
         Self: Sized,
     {
-        hasher.write_usize(self as *const Self as usize)
+        self.eq_hash(hasher)
     }
 
     fn equal_hash(&self, _recursive: &mut IndexSet<Value>, hasher: &mut dyn Hasher)
     where
         Self: Sized,
     {
-        hasher.write_usize(self as *const Self as usize)
+        self.eqv_hash(hasher)
     }
 }
 

--- a/src/records.rs
+++ b/src/records.rs
@@ -1267,7 +1267,7 @@ pub(crate) unsafe extern "C" fn chain_protocols(
         if remaining_protocols.is_empty() {
             return Box::into_raw(Box::new(Application::new(
                 curr_protocol,
-                k.cast_to(),
+                k.cast(),
                 vec![args.as_ref().unwrap().clone()],
             )));
         }
@@ -1492,7 +1492,7 @@ pub(crate) unsafe extern "C" fn call_constructor_continuation(
         // Call the constructor
         Box::into_raw(Box::new(Application::new(
             constructor,
-            cont.cast_to(),
+            cont.cast(),
             args,
         )))
     }
@@ -1576,7 +1576,7 @@ fn record_accessor_fn(
         }
     } else {
         let k = abs_idx - record.0.num_embedded_fields();
-        if let Some(cell) = record.0.fields()[k].cast_to::<Cell>() {
+        if let Some(cell) = record.0.fields()[k].cast::<Cell>() {
             cell.get()
         } else {
             record.0.fields()[k].clone()

--- a/src/records.rs
+++ b/src/records.rs
@@ -1490,11 +1490,7 @@ pub(crate) unsafe extern "C" fn call_constructor_continuation(
         let cont = env.add(1).as_ref().unwrap();
 
         // Call the constructor
-        Box::into_raw(Box::new(Application::new(
-            constructor,
-            cont.cast(),
-            args,
-        )))
+        Box::into_raw(Box::new(Application::new(constructor, cont.cast(), args)))
     }
 }
 

--- a/src/records.rs
+++ b/src/records.rs
@@ -215,6 +215,7 @@ use std::{
     any::{Any, TypeId},
     collections::HashMap,
     fmt,
+    hash::{Hash, Hasher},
     marker::PhantomData,
     mem::align_of,
     ops::Deref,
@@ -487,6 +488,54 @@ impl Record {
         todo!()
     }
      */
+
+    pub fn eq(&self, rhs: &Record) -> bool {
+        if let Some(vtable) = self.0.rtd.embedded_vtable {
+            (vtable.eq)(self.0.embedded_ptr().unwrap(), rhs)
+        } else {
+            Gc::ptr_eq(&self.0, &rhs.0)
+        }
+    }
+
+    pub fn eqv(&self, rhs: &Record) -> bool {
+        if let Some(vtable) = self.0.rtd.embedded_vtable {
+            (vtable.eqv)(self.0.embedded_ptr().unwrap(), rhs)
+        } else {
+            Gc::ptr_eq(&self.0, &rhs.0)
+        }
+    }
+
+    pub fn equal(&self, rhs: &Record) -> bool {
+        if let Some(vtable) = self.0.rtd.embedded_vtable {
+            (vtable.equal)(self.0.embedded_ptr().unwrap(), rhs)
+        } else {
+            Gc::ptr_eq(&self.0, &rhs.0)
+        }
+    }
+
+    pub fn eq_hash<H: Hasher>(&self, hasher: &mut H) {
+        if let Some(vtable) = self.0.rtd.embedded_vtable {
+            (vtable.eq_hash)(self.0.embedded_ptr().unwrap(), hasher)
+        } else {
+            Gc::as_ptr(&self.0).hash(hasher)
+        }
+    }
+
+    pub fn eqv_hash<H: Hasher>(&self, hasher: &mut H) {
+        if let Some(vtable) = self.0.rtd.embedded_vtable {
+            (vtable.eqv_hash)(self.0.embedded_ptr().unwrap(), hasher)
+        } else {
+            Gc::as_ptr(&self.0).hash(hasher)
+        }
+    }
+
+    pub fn equal_hash<H: Hasher>(&self, hasher: &mut H) {
+        if let Some(vtable) = self.0.rtd.embedded_vtable {
+            (vtable.equal_hash)(self.0.embedded_ptr().unwrap(), hasher)
+        } else {
+            Gc::as_ptr(&self.0).hash(hasher)
+        }
+    }
 }
 
 impl fmt::Debug for Record {
@@ -571,6 +620,9 @@ unsafe impl Trace for RecordInner {
     }
 
     unsafe fn finalize(&mut self) {
+        unsafe {
+            self.rtd.finalize();
+        }
         let num_fields = self.num_unembedded_fields();
         let fields_ptr = self.fields_ptr_mut();
         for i in 0..num_fields {
@@ -621,7 +673,7 @@ impl fmt::Debug for RecordInner {
 ///
 /// scheme-rs uses the layout of the type to compactly allocate types within
 /// scheme records. Those layouts are stored in the RTD.
-pub unsafe trait Embeddable: fmt::Debug + Trace + Any + Send + Sync  {
+pub unsafe trait Embeddable: fmt::Debug + Trace + Any + Send + Sync {
     /// The Record Type Descriptor of the value. Can be constructed at runtime,
     /// but cannot change.
     fn rtd() -> Arc<RecordTypeDescriptor>
@@ -641,6 +693,66 @@ pub unsafe trait Embeddable: fmt::Debug + Trace + Any + Send + Sync  {
     /// Set the kth field of the record.
     fn set_field(&self, k: usize, _val: Value) -> Result<(), Exception> {
         Err(Exception::error(format!("invalid record field: {k}")))
+    }
+
+    fn eq(&self, rhs: &Record) -> bool
+    where
+        Self: Sized,
+    {
+        let Some(rhs) = rhs.cast::<Self>() else {
+            return false;
+        };
+        std::ptr::eq(
+            self as *const Self as *const (),
+            rhs.embedded_ptr.as_ptr().cast::<()>(),
+        )
+    }
+
+    fn eqv(&self, rhs: &Record) -> bool
+    where
+        Self: Sized,
+    {
+        let Some(rhs) = rhs.cast::<Self>() else {
+            return false;
+        };
+        std::ptr::eq(
+            self as *const Self as *const (),
+            rhs.embedded_ptr.as_ptr().cast::<()>(),
+        )
+    }
+
+    fn equal(&self, rhs: &Record) -> bool
+    where
+        Self: Sized,
+    {
+        let Some(rhs) = rhs.cast::<Self>() else {
+            return false;
+        };
+        std::ptr::eq(
+            self as *const Self as *const (),
+            rhs.embedded_ptr.as_ptr().cast::<()>(),
+        )
+    }
+
+    fn eq_hash(&self, hasher: &mut dyn Hasher)
+    where
+        Self: Sized,
+    {
+        hasher.write_usize(self as *const Self as usize)
+    }
+
+    fn eqv_hash(&self, hasher: &mut dyn Hasher)
+    where
+        Self: Sized,
+    {
+        hasher.write_usize(self as *const Self as usize)
+    }
+
+    fn equal_hash(&self, hasher: &mut dyn Hasher)
+    where
+        Self: Sized,
+    {
+        hasher.write_usize(self as *const Self as usize)
     }
 }
 
@@ -664,6 +776,18 @@ pub struct EmbeddableVTable {
     pub set_field: fn(*const (), usize, Value) -> Result<(), Exception>,
     #[trace(skip)]
     pub debug_fmt: fn(*const (), &mut fmt::Formatter<'_>) -> fmt::Result,
+    #[trace(skip)]
+    pub eq: for<'a> fn(*const (), &'a Record) -> bool,
+    #[trace(skip)]
+    pub eqv: for<'a> fn(*const (), &'a Record) -> bool,
+    #[trace(skip)]
+    pub equal: for<'a> fn(*const (), &'a Record) -> bool,
+    #[trace(skip)]
+    pub eq_hash: for<'a> fn(*const (), &'a mut dyn Hasher),
+    #[trace(skip)]
+    pub eqv_hash: for<'a> fn(*const (), &'a mut dyn Hasher),
+    #[trace(skip)]
+    pub equal_hash: for<'a> fn(*const (), &'a mut dyn Hasher),
 }
 
 impl EmbeddableVTable {
@@ -687,6 +811,18 @@ impl EmbeddableVTable {
                 E::set_field(unsafe { this.cast::<E>().as_ref().unwrap() }, k, val)
             },
             debug_fmt: |this, fmt| E::fmt(unsafe { this.cast::<E>().as_ref().unwrap() }, fmt),
+            eq: |lhs, rhs| E::eq(unsafe { lhs.cast::<E>().as_ref().unwrap() }, rhs),
+            eqv: |lhs, rhs| E::eqv(unsafe { lhs.cast::<E>().as_ref().unwrap() }, rhs),
+            equal: |lhs, rhs| E::equal(unsafe { lhs.cast::<E>().as_ref().unwrap() }, rhs),
+            eq_hash: |this, hasher| {
+                E::eq_hash(unsafe { this.cast::<E>().as_ref().unwrap() }, hasher)
+            },
+            eqv_hash: |this, hasher| {
+                E::eqv_hash(unsafe { this.cast::<E>().as_ref().unwrap() }, hasher)
+            },
+            equal_hash: |this, hasher| {
+                E::equal_hash(unsafe { this.cast::<E>().as_ref().unwrap() }, hasher)
+            },
         }
     }
 
@@ -783,7 +919,7 @@ where
     fn try_from(value: &Value) -> Result<Self, Self::Error> {
         let type_name = T::rtd().name.to_str();
         let UnpackedValue::Record(record) = value.clone().unpack() else {
-            return Err(Exception::type_error(&type_name, value.type_name()));
+            return Err(Exception::type_error(&type_name, &value.type_name()));
         };
         let record_name = record.rtd().name.to_str();
         record

--- a/src/records.rs
+++ b/src/records.rs
@@ -588,32 +588,26 @@ unsafe impl Trace for RecordInner {
 
 impl fmt::Debug for RecordInner {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        /*
         write!(f, "#<{}", self.rtd.name)?;
-        // Inline slots hold only the fields *not* covered by the embed, so skip
-        // the embed-covered names to keep names aligned with the slots.
-        let mut field_names = self
+        let skipped_fields = if let Some(vtable) = self.rtd.embedded_vtable {
+            (vtable.debug_fmt)(self.embedded_ptr().unwrap(), f)?;
+            vtable.embedded_fields
+        } else {
+            0
+        };
+        for (Field::Mutable(name) | Field::Immutable(name), field) in self
             .rtd
             .inherits
             .iter()
             .cloned()
             .chain(Some(ByAddress(self.rtd.clone())))
             .flat_map(|rtd| rtd.fields.clone())
-            .skip(self.embed_field_count());
-        for field in self.fields() {
-            let field = if let Some(cell) = field.cast_to::<Cell>() {
-                cell.get()
-            } else {
-                field.clone()
-            };
-            match field_names.next() {
-                Some(name) => write!(f, " {}: {field:?}", name.name())?,
-                None => write!(f, " {field:?}")?,
-            }
+            .skip(skipped_fields)
+            .zip(self.fields())
+        {
+            write!(f, " {name}: {field:?}")?;
         }
         write!(f, ">")
-         */
-        todo!()
     }
 }
 
@@ -659,6 +653,8 @@ pub struct EmbeddableVTable {
     pub get_field: fn(*const (), usize) -> Result<Value, Exception>,
     #[trace(skip)]
     pub set_field: fn(*const (), usize, Value) -> Result<(), Exception>,
+    #[trace(skip)]
+    pub debug_fmt: fn(*const (), &mut fmt::Formatter<'_>) -> fmt::Result,
 }
 
 impl EmbeddableVTable {
@@ -681,6 +677,7 @@ impl EmbeddableVTable {
             set_field: |this, k, val| {
                 E::set_field(unsafe { this.cast::<E>().as_ref().unwrap() }, k, val)
             },
+            debug_fmt: |this, fmt| E::fmt(unsafe { this.cast::<E>().as_ref().unwrap() }, fmt),
         }
     }
 

--- a/src/records.rs
+++ b/src/records.rs
@@ -612,7 +612,16 @@ impl fmt::Debug for RecordInner {
 }
 
 /// A Rust type that can be embedded safely in a Scheme record.
-pub trait Embeddable: fmt::Debug + Trace + Any + Send + Sync {
+///
+/// # Safety:
+///
+/// The [rtd] function cannot return a RecordTypeDescriptor created for a
+/// different type than the type implementing that function. Doing so is
+/// undefined behavior.
+///
+/// scheme-rs uses the layout of the type to compactly allocate types within
+/// scheme records. Those layouts are stored in the RTD.
+pub unsafe trait Embeddable: fmt::Debug + Trace + Any + Send + Sync  {
     /// The Record Type Descriptor of the value. Can be constructed at runtime,
     /// but cannot change.
     fn rtd() -> Arc<RecordTypeDescriptor>
@@ -741,6 +750,15 @@ impl<T> Deref for Embedded<T> {
 impl<T> AsRef<T> for Embedded<T> {
     fn as_ref(&self) -> &T {
         unsafe { self.embedded_ptr.as_ref() }
+    }
+}
+
+impl<T> fmt::Debug for Embedded<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_ref().fmt(f)
     }
 }
 
@@ -907,7 +925,7 @@ pub struct RecordConstructorDescriptor {
     protocol: Procedure,
 }
 
-impl Embeddable for RecordConstructorDescriptor {
+unsafe impl Embeddable for RecordConstructorDescriptor {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(
             ty: RecordConstructorDescriptor,

--- a/src/records.rs
+++ b/src/records.rs
@@ -7,11 +7,13 @@
 //! Each records is described by its [`RecordTypeDescriptor`], which includes
 //! the names of its name and fields among other properties.
 //!
-//! # Implementing [`SchemeCompatible`]
+//! # Implementing [`Embeddable`]
 //!
 //! Any type that implements [`Trace`] and [`Debug`](std::fmt::Debug) is
-//! eligible to implement `SchemeCompatible`. Once this criteria is fulfilled,
-//! we first need to use the [`rtd`] proc macro to fill in the type descriptor.
+//! eligible to implement `Embeddable`, which allows a value of that type to be
+//! embedded directly inside the record's allocation. Once this criteria is
+//! fulfilled, we first need to use the [`rtd`] proc macro to fill in the type
+//! descriptor.
 //!
 //! For example, let's say that we have `Enemy` struct that we want to have two
 //! immutable fields and one mutable field:
@@ -29,11 +31,12 @@
 //! }
 //! ```
 //!
-//! We can now fill in the `rtd` for the type:
+//! We can now fill in the `rtd` for the type. Note that the `ty` field tells the
+//! macro which Rust type is being embedded:
 //!
 //! ```rust
 //! # use std::sync::{Arc, Mutex};
-//! # use scheme_rs::{gc::Trace, records::{rtd, SchemeCompatible, RecordTypeDescriptor},
+//! # use scheme_rs::{gc::Trace, records::{rtd, Embeddable, RecordTypeDescriptor},
 //! # exceptions::Exception };
 //! # #[derive(Debug, Trace)]
 //! # struct Enemy {
@@ -41,16 +44,17 @@
 //! #   pos_y: f64,
 //! #   health: Mutex<f64>,
 //! # }
-//! impl SchemeCompatible for Enemy {
+//! impl Embeddable for Enemy {
 //!     fn rtd() -> Arc<RecordTypeDescriptor> {
 //!         rtd!(
+//!             ty: Enemy,
 //!             name: "enemy",
 //!             fields: [ "pos-x", "pos-y", mutable("health") ],
 //!             constructor: |pos_x, pos_y, health| {
 //!                 Ok(Enemy {
-//!                     pos_x: pos_x.try_to_scheme_type()?,
-//!                     pos_y: pos_y.try_to_scheme_type()?,
-//!                     health: Mutex::new(health.try_to_scheme_type()?),
+//!                     pos_x: pos_x.try_to()?,
+//!                     pos_y: pos_y.try_to()?,
+//!                     health: Mutex::new(health.try_to()?),
 //!                 })
 //!             }
 //!         )
@@ -63,11 +67,11 @@
 //! however, this does not preclude you from omitting fields that are present in
 //! your data type from the `fields` list.
 //!
-//! Technically, [`rtd`](SchemeCompatible::rtd) is the only required method to
-//! implement `SchemeCompatible`, but since we populated `fields` it will be
-//! possible for the [`get_field`](SchemeCompatible::get_field) and
-//! [`set_field`](SchemeCompatible::set_field) functions to be called, which by
-//! default panic.
+//! Technically, [`rtd`](Embeddable::rtd) is the only required method to
+//! implement `Embeddable`, but since we populated `fields` it will be
+//! possible for the [`get_field`](Embeddable::get_field) and
+//! [`set_field`](Embeddable::set_field) functions to be called, which by
+//! default error.
 //!
 //! Thus, we need to provide getters and setters for each field. We only need to
 //! provide setters for the mutable fields. Fields are indexed by their position
@@ -75,16 +79,16 @@
 //!
 //! ```rust
 //! # use std::sync::{Arc, Mutex};
-//! # use scheme_rs::{gc::Trace, value::Value, records::{rtd, SchemeCompatible, RecordTypeDescriptor}, exceptions::Exception};
+//! # use scheme_rs::{gc::Trace, value::Value, records::{rtd, Embeddable, RecordTypeDescriptor}, exceptions::Exception};
 //! # #[derive(Debug, Trace)]
 //! # struct Enemy {
 //! #   pos_x: f64,
 //! #   pos_y: f64,
 //! #   health: Mutex<f64>,
 //! # }
-//! impl SchemeCompatible for Enemy {
+//! impl Embeddable for Enemy {
 //! #    fn rtd() -> Arc<RecordTypeDescriptor> {
-//! #        rtd!(name: "enemy", sealed: true)
+//! #        rtd!(ty: Enemy, name: "enemy", sealed: true)
 //! #    }
 //!     fn get_field(&self, k: usize) -> Result<Value, Exception> {
 //!         match k {
@@ -107,33 +111,33 @@
 //! ## Expressing subtyping relationships
 //!
 //! It is possible to express the classic child/parent relationship in structs
-//! by embedding the parent in the child and implementing the
-//! [`extract_embedded_record`](SchemeCompatible::extract_embedded_record)
-//! function with the [`into_scheme_compatible`] function:
+//! by embedding the parent in the child by value and implementing the
+//! [`parent_record`](Embeddable::parent_record) function:
 //!
 //! ```rust
 //! # use std::sync::Arc;
-//! # use scheme_rs::{gc::{Trace, Gc}, value::Value, records::{rtd, SchemeCompatible, RecordTypeDescriptor, into_scheme_compatible}, exceptions::Exception};
+//! # use scheme_rs::{gc::Trace, value::Value, records::{rtd, Embeddable, RecordTypeDescriptor}, exceptions::Exception};
 //! # #[derive(Debug, Trace)]
 //! # struct Enemy {
 //! #   pos_x: f64,
 //! #   pos_y: f64,
 //! #   health: f64,
 //! # }
-//! # impl SchemeCompatible for Enemy {
+//! # impl Embeddable for Enemy {
 //! #    fn rtd() -> Arc<RecordTypeDescriptor> {
-//! #        rtd!(name: "enemy", sealed: true)
+//! #        rtd!(ty: Enemy, name: "enemy", sealed: true)
 //! #    }
 //! # }
 //! #[derive(Debug, Trace)]
 //! struct SpecialEnemy {
-//!     parent: Gc<Enemy>,
+//!     parent: Enemy,
 //!     special: u64,
 //! }
 //!
-//! impl SchemeCompatible for SpecialEnemy {
+//! impl Embeddable for SpecialEnemy {
 //!     fn rtd() -> Arc<RecordTypeDescriptor> {
 //!         rtd!(
+//!             ty: SpecialEnemy,
 //!             name: "enemy",
 //!             parent: Enemy,
 //!             fields: ["special"],
@@ -141,12 +145,12 @@
 //!             // required by all of the parent objects, in order.
 //!             constructor: |pos_x, pos_y, health, special| {
 //!                 Ok(SpecialEnemy {
-//!                     parent: Gc::new(Enemy {
-//!                         pos_x: pos_x.try_to_scheme_type()?,
-//!                         pos_y: pos_y.try_to_scheme_type()?,
-//!                         health: health.try_to_scheme_type()?,
-//!                     }),
-//!                     special: special.try_to_scheme_type()?,
+//!                     parent: Enemy {
+//!                         pos_x: pos_x.try_to()?,
+//!                         pos_y: pos_y.try_to()?,
+//!                         health: health.try_to()?,
+//!                     },
+//!                     special: special.try_to()?,
 //!                 })
 //!             }
 //!         )
@@ -156,13 +160,13 @@
 //!         Ok(Value::from(self.special))
 //!     }
 //!
-//!     fn extract_embedded_record(
+//!     fn parent_record(
 //!         &self,
 //!         rtd: &Arc<RecordTypeDescriptor>
-//!     ) -> Option<Gc<dyn SchemeCompatible>> {
+//!     ) -> Option<&dyn Embeddable> {
 //!         Enemy::rtd()
 //!             .is_subtype_of(rtd)
-//!             .then(|| into_scheme_compatible(self.parent.clone()))
+//!             .then(|| &self.parent as &dyn Embeddable)
 //!     }
 //! }
 //! ```
@@ -176,13 +180,14 @@
 //!
 //! ```rust
 //! # use std::sync::Arc;
-//! # use scheme_rs::{gc::Trace, records::{rtd, SchemeCompatible, RecordTypeDescriptor},
+//! # use scheme_rs::{gc::Trace, records::{rtd, Embeddable, RecordTypeDescriptor},
 //! # exceptions::Exception };
 //! # #[derive(Debug, Trace)]
 //! # struct Enemy {}
-//! impl SchemeCompatible for Enemy {
+//! impl Embeddable for Enemy {
 //!     fn rtd() -> Arc<RecordTypeDescriptor> {
 //!         rtd!(
+//!             ty: Enemy,
 //!             lib: "(enemies (1))",
 //!             // ...
 //! #           name: "enemy",
@@ -206,11 +211,15 @@
 //! ```
 
 use std::{
-    any::Any,
+    alloc::{self, Layout},
+    any::{Any, TypeId},
     collections::HashMap,
     fmt,
-    mem::ManuallyDrop,
-    ptr::NonNull,
+    marker::PhantomData,
+    mem::align_of,
+    ops::Deref,
+    ptr::{self, NonNull},
+    slice,
     sync::{Arc, LazyLock, Mutex},
 };
 
@@ -219,12 +228,12 @@ use parking_lot::RwLock;
 
 use crate::{
     exceptions::Exception,
-    gc::{Gc, GcInner, Trace},
+    gc::{Gc, GcInner, OpaqueGcPtr, Trace},
     proc::{Application, ContBarrier, FuncPtr, Procedure},
     registry::{bridge, cps_bridge},
     runtime::{Runtime, RuntimeInner},
     symbols::Symbol,
-    value::{UnpackedValue, Value, ValueType},
+    value::{Cell, UnpackedValue, Value, ValueType},
     vectors::Vector,
 };
 
@@ -246,21 +255,28 @@ pub struct RecordTypeDescriptor {
     /// from being "generative," i.e. unique upon each call to
     /// `define-record-type`.
     pub uid: Option<Symbol>,
-    /// Whether or not the type being described is a Rust type.
-    pub rust_type: bool,
-    /// The Rust parent of the record type, if it exists.
-    pub rust_parent_constructor: Option<RustParentConstructor>,
+    /// Embedded type's VTable. Some if the record contains an embedded type.
+    /// Child RTDs inherit the `embedded_vtable` of their Parent.
+    pub embedded_vtable: Option<EmbeddableVTable>,
+    /// The Rust constructor of the embedded type, if it exists. Child RTDs
+    /// inherit the `embedded_constructor` of their
+    pub embedded_constructor: Option<RustParentConstructor>,
     /// Parent is most recently inserted record type, if one exists.
     pub inherits: indexmap::IndexSet<ByAddress<Arc<RecordTypeDescriptor>>>,
-    /// The index into `fields` where this record's fields proper begin. All of
-    /// the previous fields belong to a parent.
-    pub field_index_offset: usize,
+    /// The number of fields inherited by this record.
+    pub num_inherited_fields: usize,
     /// The fields of the record, not including any of the ones inherited from
     /// parents.
     pub fields: Vec<Field>,
 }
 
 impl RecordTypeDescriptor {
+    // TODO: Add a constructor that sets everything up from a parent.
+
+    pub fn is_rust_type(&self) -> bool {
+        self.embedded_vtable.is_some()
+    }
+
     pub fn is_base_record_type(&self) -> bool {
         self.inherits.is_empty()
     }
@@ -270,12 +286,7 @@ impl RecordTypeDescriptor {
     }
 
     pub fn num_fields(&self) -> usize {
-        self.fields.len()
-            + self
-                .inherits
-                .iter()
-                .map(|parent| parent.fields.len())
-                .sum::<usize>()
+        self.fields.len() + self.num_inherited_fields
     }
 }
 
@@ -283,8 +294,8 @@ impl fmt::Debug for RecordTypeDescriptor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "#<rtd name: {} sealed: {} opaque: {} rust: {} ",
-            self.name, self.sealed, self.opaque, self.rust_type,
+            "#<rtd name: {} sealed: {} opaque: {} ", // rust: {} ",
+            self.name, self.sealed, self.opaque,
         )?;
         if !self.inherits.is_empty() {
             let parent = self.inherits.last().unwrap();
@@ -334,6 +345,10 @@ impl Field {
             Self::Immutable(sym) | Self::Mutable(sym) => *sym,
         }
     }
+
+    fn is_mutable(&self) -> bool {
+        matches!(self, Self::Mutable(_))
+    }
 }
 
 impl fmt::Debug for Field {
@@ -343,6 +358,464 @@ impl fmt::Debug for Field {
             Self::Mutable(sym) => write!(f, "(mutable {sym})"),
         }
     }
+}
+
+/// A Scheme record type. Effectively a tuple of a fixed size array and some type
+/// information.
+#[derive(Trace, Clone)]
+pub struct Record(pub(crate) Gc<RecordInner>);
+
+impl Record {
+    pub fn rtd(&self) -> Arc<RecordTypeDescriptor> {
+        self.0.rtd.clone()
+    }
+
+    /// Embed a rust value into a record.
+    pub fn embed<E: Embeddable>(e: E) -> Self {
+        let (layout, embed_offset) = Layout::from_size_align(
+            RecordInner::fields_offset(),
+            align_of::<GcInner<RecordInner>>(),
+        )
+        .unwrap()
+        .extend(Layout::new::<E>())
+        .unwrap();
+        let layout = layout.pad_to_align();
+
+        let ptr = unsafe {
+            let record = alloc::alloc(layout) as *mut GcInner<RecordInner>;
+            ptr::write(
+                record,
+                GcInner::new(RecordInner {
+                    rtd: E::rtd(),
+                    fields: [],
+                }),
+            );
+            ptr::write(record.byte_add(embed_offset) as *mut E, e);
+            record
+        };
+
+        let inner = Gc {
+            ptr: NonNull::new(ptr).unwrap(),
+            marker: PhantomData,
+        };
+
+        unsafe {
+            crate::gc::unroot(&inner, layout);
+        }
+
+        Self(inner)
+    }
+
+    pub fn cast<E: Embeddable>(&self) -> Option<Embedded<E>> {
+        let embedded_ptr = self.0.embedded_ptr()?;
+        let embedded_vtable = self.0.rtd.embedded_vtable.as_ref()?;
+
+        if TypeId::of::<E>() == embedded_vtable.type_id {
+            return Some(Embedded::from_raw_parts(
+                NonNull::new(embedded_ptr as *mut E).unwrap(),
+                self.clone(),
+            ));
+        }
+
+        let rtd = E::rtd();
+        let mut embedded = embedded_vtable.ptr_to_parent(embedded_ptr, &rtd)?;
+        while let Some(parent) = embedded.parent_record(&rtd) {
+            embedded = parent;
+        }
+
+        let downcast_embedded = (embedded as &dyn Any).downcast_ref::<E>()?;
+
+        Some(Embedded {
+            embedded_ptr: NonNull::from_ref(downcast_embedded),
+            record: self.clone(),
+        })
+    }
+
+    /*
+
+    /// Get the kth field of the Record
+    pub fn get_field(&self, k: usize) -> Result<Value, Exception> {
+        self.get_parent_field(&self.rtd(), k)
+    }
+
+    /// Get the kth field of a parent Record
+    pub fn get_parent_field(
+        &self,
+        rtd: &Arc<RecordTypeDescriptor>,
+        k: usize,
+    ) -> Result<Value, Exception> {
+        /*
+        if !self.0.rtd.is_subtype_of(rtd) {
+            Err(Exception::error(format!("not a subtype of {}", rtd.name)))
+        } else if let Some(mut t) = self.0.rust_parent.clone() {
+            while let Some(embedded) = { t.extract_embedded_record(rtd) } {
+                t = embedded;
+            }
+            t.get_field(rtd.field_index_offset + k)
+        } else {
+            Ok(self.0.fields[rtd.field_index_offset + k].read().clone())
+        }
+         */
+        todo!()
+    }
+
+    /// Set the kth field of the Record
+    pub fn set_field(&self, k: usize, new_value: Value) -> Result<(), Exception> {
+        self.set_parent_field(&self.rtd(), k, new_value)
+    }
+
+    /// Set the kth field of a parent Record
+    pub fn set_parent_field(
+        &self,
+        rtd: &Arc<RecordTypeDescriptor>,
+        k: usize,
+        new_value: Value,
+    ) -> Result<(), Exception> {
+        /*
+        if !self.0.rtd.is_subtype_of(rtd) {
+            Err(Exception::error(format!("not a subtype of {}", rtd.name)))
+        } else if let Some(mut t) = self.0.rust_parent.clone() {
+            while let Some(embedded) = { t.extract_embedded_record(rtd) } {
+                t = embedded;
+            }
+            t.set_field(rtd.field_index_offset + k, new_value)
+        } else {
+            *self.0.fields[rtd.field_index_offset + k].write() = new_value;
+            Ok(())
+        }
+         */
+        todo!()
+    }
+     */
+}
+
+impl fmt::Debug for Record {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+// #[derive(Trace)]
+#[repr(C, align(16))]
+pub(crate) struct RecordInner {
+    // pub(crate) rust_parent: Option<Gc<dyn SchemeCompatible>>,
+    rtd: Arc<RecordTypeDescriptor>,
+    /// Pointer to the first field. If the record contains an embedded value it
+    /// will be stored after the last field.
+    fields: [Value; 0],
+}
+
+impl RecordInner {
+    pub(crate) fn num_embedded_fields(&self) -> usize {
+        self.rtd
+            .embedded_vtable
+            .as_ref()
+            .map_or(0, |vtable| vtable.embedded_fields)
+    }
+
+    pub(crate) fn num_unembedded_fields(&self) -> usize {
+        self.rtd.num_fields() - self.num_embedded_fields()
+    }
+
+    pub(crate) fn fields(&self) -> &[Value] {
+        unsafe { slice::from_raw_parts(self.fields_ptr(), self.num_unembedded_fields()) }
+    }
+
+    pub(crate) const fn fields_offset() -> usize {
+        GcInner::<RecordInner>::data_offset() + std::mem::offset_of!(RecordInner, fields)
+    }
+
+    pub(crate) fn fields_ptr(&self) -> *const Value {
+        &self.fields as *const Value
+    }
+
+    pub(crate) fn fields_ptr_mut(&mut self) -> *mut Value {
+        &mut self.fields as *mut Value
+    }
+
+    pub(crate) fn embedded_ptr(&self) -> Option<*const ()> {
+        let vtable = self.rtd.embedded_vtable?;
+        unsafe {
+            let fields_end = self
+                .fields_ptr()
+                .add(self.rtd.num_fields() - vtable.embedded_fields);
+            Some(fields_end.add(fields_end.align_offset(vtable.layout.align())) as *const ())
+        }
+    }
+
+    pub(crate) fn embedded_ptr_mut(&mut self) -> Option<*mut ()> {
+        let vtable = self.rtd.embedded_vtable?;
+        unsafe {
+            let fields_end = self
+                .fields_ptr_mut()
+                .add(self.rtd.num_fields() - vtable.embedded_fields);
+            Some(fields_end.add(fields_end.align_offset(vtable.layout.align())) as *mut ())
+        }
+    }
+}
+
+unsafe impl Trace for RecordInner {
+    unsafe fn visit_children(&self, visitor: &mut dyn FnMut(crate::gc::OpaqueGcPtr)) {
+        let num_fields = self.num_unembedded_fields();
+        let fields_ptr = self.fields_ptr();
+        for i in 0..num_fields {
+            unsafe {
+                fields_ptr.add(i).as_ref().unwrap().visit_children(visitor);
+            }
+        }
+        if let Some(embedded_vtable) = self.rtd.embedded_vtable {
+            unsafe {
+                (embedded_vtable.visit_children)(self.embedded_ptr().unwrap(), visitor);
+            }
+        }
+    }
+
+    unsafe fn finalize(&mut self) {
+        let num_fields = self.num_unembedded_fields();
+        let fields_ptr = self.fields_ptr_mut();
+        for i in 0..num_fields {
+            unsafe {
+                fields_ptr.add(i).as_mut().unwrap().finalize();
+            }
+        }
+        if let Some(embedded_vtable) = self.rtd.embedded_vtable {
+            unsafe {
+                (embedded_vtable.finalize)(self.embedded_ptr_mut().unwrap());
+            }
+        }
+    }
+}
+
+impl fmt::Debug for RecordInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        /*
+        write!(f, "#<{}", self.rtd.name)?;
+        // Inline slots hold only the fields *not* covered by the embed, so skip
+        // the embed-covered names to keep names aligned with the slots.
+        let mut field_names = self
+            .rtd
+            .inherits
+            .iter()
+            .cloned()
+            .chain(Some(ByAddress(self.rtd.clone())))
+            .flat_map(|rtd| rtd.fields.clone())
+            .skip(self.embed_field_count());
+        for field in self.fields() {
+            let field = if let Some(cell) = field.cast_to::<Cell>() {
+                cell.get()
+            } else {
+                field.clone()
+            };
+            match field_names.next() {
+                Some(name) => write!(f, " {}: {field:?}", name.name())?,
+                None => write!(f, " {field:?}")?,
+            }
+        }
+        write!(f, ">")
+         */
+        todo!()
+    }
+}
+
+/// A Rust type that can be embedded safely in a Scheme record.
+pub trait Embeddable: fmt::Debug + Trace + Any + Send + Sync {
+    /// The Record Type Descriptor of the value. Can be constructed at runtime,
+    /// but cannot change.
+    fn rtd() -> Arc<RecordTypeDescriptor>
+    where
+        Self: Sized;
+
+    /// Returns any parent records embedded in the Rust type.
+    fn parent_record(&self, _rtd: &Arc<RecordTypeDescriptor>) -> Option<&dyn Embeddable> {
+        None
+    }
+
+    /// Fetch the kth field of the record.
+    fn get_field(&self, k: usize) -> Result<Value, Exception> {
+        Err(Exception::error(format!("invalid record field: {k}")))
+    }
+
+    /// Set the kth field of the record.
+    fn set_field(&self, k: usize, _val: Value) -> Result<(), Exception> {
+        Err(Exception::error(format!("invalid record field: {k}")))
+    }
+}
+
+// TODO: add trace(skip_all) attribute
+#[derive(Copy, Clone, Trace)]
+pub struct EmbeddableVTable {
+    #[trace(skip)]
+    pub type_id: TypeId,
+    #[trace(skip)]
+    layout: Layout,
+    pub embedded_fields: usize,
+    #[trace(skip)]
+    pub visit_children: unsafe fn(*const (), &mut dyn FnMut(OpaqueGcPtr)),
+    #[trace(skip)]
+    pub finalize: unsafe fn(*mut ()),
+    #[trace(skip)]
+    pub parent_record: fn(*const (), &Arc<RecordTypeDescriptor>) -> Option<*const dyn Embeddable>,
+    #[trace(skip)]
+    pub get_field: fn(*const (), usize) -> Result<Value, Exception>,
+    #[trace(skip)]
+    pub set_field: fn(*const (), usize, Value) -> Result<(), Exception>,
+}
+
+impl EmbeddableVTable {
+    pub const fn new<E: Embeddable>(embedded_fields: usize) -> Self {
+        Self {
+            type_id: TypeId::of::<E>(),
+            layout: Layout::new::<E>(),
+            embedded_fields,
+            visit_children: |this, visitor| unsafe {
+                E::visit_children(this.cast::<E>().as_ref().unwrap(), visitor);
+            },
+            finalize: |this| unsafe {
+                E::finalize(this.cast::<E>().as_mut().unwrap());
+            },
+            parent_record: |this, rtd| {
+                E::parent_record(unsafe { this.cast::<E>().as_ref().unwrap() }, rtd)
+                    .map(|r| r as *const dyn Embeddable)
+            },
+            get_field: |this, k| E::get_field(unsafe { this.cast::<E>().as_ref().unwrap() }, k),
+            set_field: |this, k, val| {
+                E::set_field(unsafe { this.cast::<E>().as_ref().unwrap() }, k, val)
+            },
+        }
+    }
+
+    fn ptr_to_parent(
+        &self,
+        ptr: *const (),
+        rtd: &Arc<RecordTypeDescriptor>,
+    ) -> Option<&dyn Embeddable> {
+        (self.parent_record)(ptr, rtd).and_then(|ptr| unsafe { ptr.as_ref() })
+    }
+}
+
+#[derive(Trace)]
+pub struct Embedded<T> {
+    #[trace(skip)]
+    embedded_ptr: NonNull<T>,
+    record: Record,
+}
+
+unsafe impl<T> Send for Embedded<T> {}
+unsafe impl<T> Sync for Embedded<T> {}
+
+impl<T> Clone for Embedded<T> {
+    fn clone(&self) -> Self {
+        Self {
+            embedded_ptr: self.embedded_ptr,
+            record: self.record.clone(),
+        }
+    }
+}
+
+impl<T: Embeddable> Embedded<T> {
+    pub fn new(embeddable: T) -> Self {
+        Record::embed(embeddable)
+            .cast::<T>()
+            .expect("freshly embedded value must cast back to its own type")
+    }
+}
+
+impl<T> Embedded<T> {
+    pub fn ptr_eq(lhs: &Self, rhs: &Self) -> bool {
+        lhs.embedded_ptr == rhs.embedded_ptr
+    }
+
+    pub(crate) fn from_raw_parts(embedded_ptr: NonNull<T>, record: Record) -> Self {
+        Self {
+            embedded_ptr,
+            record,
+        }
+    }
+}
+
+impl<T> Deref for Embedded<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { self.embedded_ptr.as_ref() }
+    }
+}
+
+impl<T> AsRef<T> for Embedded<T> {
+    fn as_ref(&self) -> &T {
+        unsafe { self.embedded_ptr.as_ref() }
+    }
+}
+
+impl<T> From<&Value> for Option<Embedded<T>>
+where
+    T: Embeddable,
+{
+    fn from(value: &Value) -> Self {
+        let UnpackedValue::Record(record) = value.clone().unpack() else {
+            return None;
+        };
+        record.cast::<T>()
+    }
+}
+
+impl<T> TryFrom<&Value> for Embedded<T>
+where
+    T: Embeddable,
+{
+    type Error = Exception;
+
+    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+        let type_name = T::rtd().name.to_str();
+        let UnpackedValue::Record(record) = value.clone().unpack() else {
+            return Err(Exception::type_error(&type_name, value.type_name()));
+        };
+        let record_name = record.rtd().name.to_str();
+        record
+            .cast::<T>()
+            .ok_or_else(|| Exception::type_error(&type_name, &record_name))
+    }
+}
+
+impl<T> From<T> for Value
+where
+    T: Embeddable,
+{
+    fn from(value: T) -> Self {
+        Value::from(Record::embed(value))
+    }
+}
+
+impl<T> From<Embedded<T>> for Value
+where
+    T: Embeddable,
+{
+    fn from(value: Embedded<T>) -> Self {
+        Value::from(value.record)
+    }
+}
+
+#[derive(Copy, Clone, Debug, Trace)]
+pub struct RustParentConstructor {
+    #[trace(skip)]
+    constructor: ParentConstructor,
+}
+
+impl RustParentConstructor {
+    pub fn new(constructor: ParentConstructor) -> Self {
+        Self { constructor }
+    }
+}
+
+type ParentConstructor = fn(&[Value]) -> Result<ParentWriter, Exception>;
+
+type ParentWriter = Box<dyn FnOnce(*mut ())>;
+
+pub(crate) fn is_subtype_of(val: &Value, rt: Arc<RecordTypeDescriptor>) -> Result<bool, Exception> {
+    let UnpackedValue::Record(rec) = val.clone().unpack() else {
+        return Ok(false);
+    };
+    Ok(Arc::ptr_eq(&rec.0.rtd, &rt) || rec.0.rtd.inherits.contains(&ByAddress::from(rt)))
 }
 
 type NonGenerativeStore = LazyLock<Arc<Mutex<HashMap<Symbol, Arc<RecordTypeDescriptor>>>>>;
@@ -387,22 +860,29 @@ pub fn make_record_type_descriptor(
     } else {
         indexmap::IndexSet::new()
     };
-    let field_index_offset = inherits.last().map_or(0, |last_parent| {
-        last_parent.field_index_offset + last_parent.fields.len()
+    let num_inherited_fields = inherits.last().map_or(0, |last_parent| {
+        last_parent.num_inherited_fields + last_parent.fields.len()
     });
     let sealed = sealed.is_true();
     let opaque = opaque.is_true();
     let fields = Field::parse_fields(fields)?;
+
+    // Inherit any embedded vtable or constructors:
+    let (embedded_vtable, embedded_constructor) = inherits
+        .last()
+        .map(|rtd| (rtd.embedded_vtable, rtd.embedded_constructor))
+        .unzip();
+
     let rtd = Arc::new(RecordTypeDescriptor {
         name,
         sealed,
         opaque,
         uid,
-        rust_type: false,
-        rust_parent_constructor: None,
         inherits,
-        field_index_offset,
+        num_inherited_fields,
         fields,
+        embedded_vtable: embedded_vtable.flatten(),
+        embedded_constructor: embedded_constructor.flatten(),
     });
 
     if let Some(uid) = uid {
@@ -425,14 +905,19 @@ pub fn record_type_descriptor_pred(obj: &Value) -> Result<Vec<Value>, Exception>
 /// A description of a record's constructor.
 #[derive(Trace, Clone)]
 pub struct RecordConstructorDescriptor {
-    parent: Option<Gc<RecordConstructorDescriptor>>,
+    parent: Option<Embedded<RecordConstructorDescriptor>>,
     rtd: Arc<RecordTypeDescriptor>,
     protocol: Procedure,
 }
 
-impl SchemeCompatible for RecordConstructorDescriptor {
+impl Embeddable for RecordConstructorDescriptor {
     fn rtd() -> Arc<RecordTypeDescriptor> {
-        rtd!(name: "record-constructor-descriptor", sealed: true, opaque: true)
+        rtd!(
+            ty: RecordConstructorDescriptor,
+            name: "record-constructor-descriptor",
+            sealed: true,
+            opaque: true
+        )
     }
 }
 
@@ -445,7 +930,7 @@ impl fmt::Debug for RecordConstructorDescriptor {
 fn make_default_record_constructor_descriptor(
     runtime: Runtime,
     rtd: Arc<RecordTypeDescriptor>,
-) -> Gc<RecordConstructorDescriptor> {
+) -> Embedded<RecordConstructorDescriptor> {
     let parent = rtd.inherits.last().map(|parent| {
         make_default_record_constructor_descriptor(runtime.clone(), parent.0.clone())
     });
@@ -456,7 +941,7 @@ fn make_default_record_constructor_descriptor(
         1,
         false,
     );
-    Gc::new(RecordConstructorDescriptor {
+    Embedded::new(RecordConstructorDescriptor {
         parent,
         rtd,
         protocol,
@@ -481,7 +966,7 @@ pub fn make_record_constructor_descriptor(
 
     let rtd: Arc<RecordTypeDescriptor> = rtd.clone().try_into()?;
 
-    if rtd.rust_type && rtd.rust_parent_constructor.is_none() {
+    if rtd.is_rust_type() && rtd.embedded_constructor.is_none() {
         return Err(Exception::error(format!(
             "cannot create a record-constructor-descriptor for rust type without a constructor {}",
             rtd.name
@@ -492,7 +977,7 @@ pub fn make_record_constructor_descriptor(
         let Some(parent_rtd) = rtd.inherits.last() else {
             return Err(Exception::error("rtd is a base type"));
         };
-        let parent_rcd = parent_rcd.try_to_rust_type::<RecordConstructorDescriptor>()?;
+        let parent_rcd = parent_rcd.try_to::<Embedded<RecordConstructorDescriptor>>()?;
         if !Arc::ptr_eq(&parent_rcd.rtd, parent_rtd) {
             return Err(Exception::error("parent rtd does not match parent rcd"));
         }
@@ -524,7 +1009,7 @@ pub fn make_record_constructor_descriptor(
         protocol,
     };
 
-    Ok(Application::new(k, None, vec![Value::from_rust_type(rcd)]))
+    Ok(Application::new(k, None, vec![Value::from(rcd)]))
 }
 
 #[cps_bridge(def = "record-constructor rcd", lib = "(rnrs records procedural (6))")]
@@ -539,16 +1024,9 @@ pub fn record_constructor(
     let [rcd] = args else {
         unreachable!();
     };
-    let rcd = rcd.try_to_rust_type::<RecordConstructorDescriptor>()?;
+    let rcd = rcd.try_to::<Embedded<RecordConstructorDescriptor>>()?;
 
     let (protocols, rtds) = rcd_to_protocols_and_rtds(&rcd);
-
-    // See if there is a rust constructor available
-    let rust_constructor = rtds
-        .iter()
-        .rev()
-        .find(|rtd| rtd.rust_parent_constructor.is_some())
-        .map_or_else(|| Value::from(false), |rtd| Value::from(rtd.clone()));
 
     let protocols = protocols.into_iter().map(Value::from).collect::<Vec<_>>();
     let rtds = rtds.into_iter().map(Value::from).collect::<Vec<_>>();
@@ -563,7 +1041,7 @@ pub fn record_constructor(
 
     Ok(chain_constructors(
         runtime,
-        &[Value::from(rtds), rust_constructor],
+        &[Value::from(rtds)],
         chain_protocols,
         &[],
         &[],
@@ -572,7 +1050,7 @@ pub fn record_constructor(
 }
 
 fn rcd_to_protocols_and_rtds(
-    rcd: &Gc<RecordConstructorDescriptor>,
+    rcd: &Embedded<RecordConstructorDescriptor>,
 ) -> (Vec<Procedure>, Vec<Arc<RecordTypeDescriptor>>) {
     let (mut protocols, mut rtds) = if let Some(ref parent) = rcd.parent {
         rcd_to_protocols_and_rtds(parent)
@@ -605,7 +1083,7 @@ pub(crate) unsafe extern "C" fn chain_protocols(
         if remaining_protocols.is_empty() {
             return Box::into_raw(Box::new(Application::new(
                 curr_protocol,
-                k.cast_to_scheme_type(),
+                k.cast_to(),
                 vec![args.as_ref().unwrap().clone()],
             )));
         }
@@ -639,21 +1117,19 @@ fn chain_constructors(
 ) -> Result<Application, Exception> {
     // env[0] is a vector of RTDs
     let rtds: Vector = env[0].clone().try_into()?;
-    // env[1] is the possible rust constructor
-    let rust_constructor = env[1].clone();
     let mut rtds = rtds.0.vec.read().clone();
     let remaining_rtds = rtds.split_off(1);
     let curr_rtd: Arc<RecordTypeDescriptor> = rtds[0].clone().try_into()?;
     let rtds_remain = !remaining_rtds.is_empty();
     let num_args = curr_rtd.fields.len();
     let env = if rtds_remain {
-        vec![Value::from(remaining_rtds), rust_constructor]
+        vec![Value::from(remaining_rtds)]
     } else {
-        vec![Value::from(curr_rtd), rust_constructor]
+        vec![Value::from(curr_rtd)]
     }
     .into_iter()
     // Chain the current environment:
-    .chain(env[2..].iter().cloned())
+    .chain(env[1..].iter().cloned())
     // Chain the arguments passed to this function:
     .chain(args.iter().cloned())
     .collect::<Vec<_>>();
@@ -683,36 +1159,85 @@ fn constructor(
     let rtd: Arc<RecordTypeDescriptor> = env[0].clone().try_into()?;
     // The fields of the record are all of the env variables chained with
     // the arguments to this function.
-    let mut fields = env[2..]
+    let mut fields = env[1..]
         .iter()
         .cloned()
         .chain(args.iter().cloned())
         .collect::<Vec<_>>();
-    // Check for a rust constructor
-    let rust_constructor = env[1].clone();
-    let (rust_parent, fields) = if rust_constructor.is_true() {
-        let rust_rtd: Arc<RecordTypeDescriptor> = rust_constructor.try_into()?;
-        let num_fields: usize = rust_rtd
+    let (embedded_vtable_and_writer, fields) =
+        if let Some(embedded_constructor) = rtd.embedded_constructor {
+            let embedded_vtable = rtd.embedded_vtable.unwrap();
+            let remaining_fields = fields.split_off(embedded_vtable.embedded_fields);
+            // Call the rust constructor for the embedded type
+            let writer = (embedded_constructor.constructor)(&fields)?;
+            (Some((embedded_vtable, writer)), remaining_fields)
+        } else {
+            (None, fields)
+        };
+
+    let prefix = Layout::from_size_align(
+        RecordInner::fields_offset(),
+        align_of::<GcInner<RecordInner>>(),
+    )
+    .unwrap();
+    let (layout, fields_offset) = prefix
+        .extend(Layout::array::<Value>(fields.len()).unwrap())
+        .unwrap();
+
+    let (layout, embedded_offset_and_writer) =
+        if let Some((embedded_vtable, writer)) = embedded_vtable_and_writer {
+            let (layout, embed_offset) = layout.extend(embedded_vtable.layout).unwrap();
+            (layout, Some((embed_offset, writer)))
+        } else {
+            (layout, None)
+        };
+
+    let layout = layout.pad_to_align();
+
+    let record = unsafe {
+        let record = alloc::alloc(layout) as *mut GcInner<RecordInner>;
+        ptr::write(
+            record,
+            GcInner::new(RecordInner {
+                rtd: rtd.clone(),
+                fields: [],
+            }),
+        );
+
+        let fields_ptr = record.byte_add(fields_offset) as *mut Value;
+
+        let field_mutability = rtd
             .inherits
             .iter()
-            .map(|parent| parent.fields.len())
-            .sum();
-        let remaining_fields = fields.split_off(num_fields + rust_rtd.fields.len());
-        (
-            Some((rust_rtd.rust_parent_constructor.unwrap().constructor)(
-                &fields,
-            )?),
-            remaining_fields,
-        )
-    } else {
-        (None, fields)
+            .flat_map(|parent| parent.fields.iter())
+            .chain(rtd.fields.iter())
+            .map(Field::is_mutable)
+            .skip(rtd.embedded_vtable.map_or(0, |vt| vt.embedded_fields));
+
+        for (i, (field, mutable)) in fields.into_iter().zip(field_mutability).enumerate() {
+            let field = if mutable {
+                Value::from(Cell::new(field))
+            } else {
+                field
+            };
+            fields_ptr.add(i).write(field);
+        }
+
+        if let Some((embedded_offset, writer)) = embedded_offset_and_writer {
+            (writer)(record.byte_add(embedded_offset) as *mut ());
+        }
+
+        let inner = Gc {
+            ptr: NonNull::new(record).unwrap(),
+            marker: PhantomData,
+        };
+
+        crate::gc::unroot(&inner, layout);
+
+        Record(inner)
     };
-    let record = Value::from(Record(Gc::new(RecordInner {
-        rust_parent,
-        rtd,
-        fields: fields.into_iter().map(RwLock::new).collect(),
-    })));
-    Ok(Application::new(k, None, vec![record]))
+
+    Ok(Application::new(k, None, vec![Value::from(record)]))
 }
 
 #[cps_bridge]
@@ -783,217 +1308,10 @@ pub(crate) unsafe extern "C" fn call_constructor_continuation(
         // Call the constructor
         Box::into_raw(Box::new(Application::new(
             constructor,
-            cont.cast_to_scheme_type(),
+            cont.cast_to(),
             args,
         )))
     }
-}
-
-/// A Scheme record type. Effectively a tuple of a fixed size array and some type
-/// information.
-#[derive(Trace, Clone)]
-pub struct Record(pub(crate) Gc<RecordInner>);
-
-impl Record {
-    pub fn rtd(&self) -> Arc<RecordTypeDescriptor> {
-        self.0.rtd.clone()
-    }
-
-    /// Convert any Rust type that implements [SchemeCompatible] into an opaque
-    /// record.
-    pub fn from_rust_type<T: SchemeCompatible>(t: T) -> Self {
-        let opaque_parent = Some(into_scheme_compatible(Gc::new(t)));
-        let rtd = T::rtd();
-        Self(Gc::new(RecordInner {
-            rust_parent: opaque_parent,
-            rtd,
-            fields: Vec::new(),
-        }))
-    }
-
-    pub fn from_rust_gc_type<T: SchemeCompatible>(t: Gc<T>) -> Self {
-        let opaque_parent = Some(into_scheme_compatible(t));
-        let rtd = T::rtd();
-        Self(Gc::new(RecordInner {
-            rust_parent: opaque_parent,
-            rtd,
-            fields: Vec::new(),
-        }))
-    }
-
-    /// Attempt to convert the record into a Rust type that implements
-    /// [SchemeCompatible].
-    pub fn cast<T: SchemeCompatible>(&self) -> Option<Gc<T>> {
-        let rust_parent = self.0.rust_parent.as_ref()?;
-
-        // Attempt to extract any embedded records
-        let rtd = T::rtd();
-        let mut t = rust_parent.clone();
-        while let Some(embedded) = { t.extract_embedded_record(&rtd) } {
-            t = embedded;
-        }
-
-        let t = ManuallyDrop::new(t);
-
-        // Second, convert the opaque_parent type into a Gc<dyn Any>
-        let any: NonNull<GcInner<dyn Any + Send + Sync>> = t.ptr;
-        let gc_any = Gc {
-            ptr: any,
-            marker: std::marker::PhantomData,
-        };
-
-        // Then, convert that back into the desired type
-        Gc::downcast::<T>(gc_any).ok()
-    }
-
-    /// Get the kth field of the Record
-    pub fn get_field(&self, k: usize) -> Result<Value, Exception> {
-        self.get_parent_field(&self.rtd(), k)
-    }
-
-    /// Get the kth field of a parent Record
-    pub fn get_parent_field(
-        &self,
-        rtd: &Arc<RecordTypeDescriptor>,
-        k: usize,
-    ) -> Result<Value, Exception> {
-        if !self.0.rtd.is_subtype_of(rtd) {
-            Err(Exception::error(format!("not a subtype of {}", rtd.name)))
-        } else if let Some(mut t) = self.0.rust_parent.clone() {
-            while let Some(embedded) = { t.extract_embedded_record(rtd) } {
-                t = embedded;
-            }
-            t.get_field(rtd.field_index_offset + k)
-        } else {
-            Ok(self.0.fields[rtd.field_index_offset + k].read().clone())
-        }
-    }
-
-    /// Set the kth field of the Record
-    pub fn set_field(&self, k: usize, new_value: Value) -> Result<(), Exception> {
-        self.set_parent_field(&self.rtd(), k, new_value)
-    }
-
-    /// Set the kth field of a parent Record
-    pub fn set_parent_field(
-        &self,
-        rtd: &Arc<RecordTypeDescriptor>,
-        k: usize,
-        new_value: Value,
-    ) -> Result<(), Exception> {
-        if !self.0.rtd.is_subtype_of(rtd) {
-            Err(Exception::error(format!("not a subtype of {}", rtd.name)))
-        } else if let Some(mut t) = self.0.rust_parent.clone() {
-            while let Some(embedded) = { t.extract_embedded_record(rtd) } {
-                t = embedded;
-            }
-            t.set_field(rtd.field_index_offset + k, new_value)
-        } else {
-            *self.0.fields[rtd.field_index_offset + k].write() = new_value;
-            Ok(())
-        }
-    }
-}
-
-impl fmt::Debug for Record {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-#[derive(Trace)]
-#[repr(align(16))]
-pub(crate) struct RecordInner {
-    pub(crate) rust_parent: Option<Gc<dyn SchemeCompatible>>,
-    pub(crate) rtd: Arc<RecordTypeDescriptor>,
-    pub(crate) fields: Vec<RwLock<Value>>,
-}
-
-impl fmt::Debug for RecordInner {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "#<{}", self.rtd.name)?;
-        if let Some(parent) = &self.rust_parent {
-            write!(f, "{parent:?}")?;
-        }
-        let mut field_names = self
-            .rtd
-            .inherits
-            .iter()
-            .cloned()
-            .chain(Some(ByAddress(self.rtd.clone())))
-            .flat_map(|rtd| rtd.fields.clone());
-        for field in &self.fields {
-            let field = field.read();
-            let name = field_names.next().unwrap().name();
-            write!(f, " {name}: {field:?}")?;
-        }
-        write!(f, ">")
-    }
-}
-
-/// A Rust value that can present itself as a Scheme record.
-pub trait SchemeCompatible: fmt::Debug + Trace + Any + Send + Sync + 'static {
-    /// The Record Type Descriptor of the value. Can be constructed at runtime,
-    /// but cannot change.
-    fn rtd() -> Arc<RecordTypeDescriptor>
-    where
-        Self: Sized;
-
-    /// Extract the embedded record type with the matching record type
-    /// descriptor if it exists.
-    fn extract_embedded_record(
-        &self,
-        _rtd: &Arc<RecordTypeDescriptor>,
-    ) -> Option<Gc<dyn SchemeCompatible>> {
-        None
-    }
-
-    /// Fetch the kth field of the record.
-    fn get_field(&self, k: usize) -> Result<Value, Exception> {
-        Err(Exception::error(format!("invalid record field: {k}")))
-    }
-
-    /// Set the kth field of the record.
-    fn set_field(&self, k: usize, _val: Value) -> Result<(), Exception> {
-        Err(Exception::error(format!("invalid record field: {k}")))
-    }
-}
-
-/// Convenience function for converting a `Gc<T>` into a
-/// `Gc<dyn SchemeCompatible>`.
-///
-/// This isn't as simple as using the `as` keyword in Rust due to the
-/// instability of the `CoerceUnsized` trait.
-pub fn into_scheme_compatible(t: Gc<impl SchemeCompatible>) -> Gc<dyn SchemeCompatible> {
-    // Convert t into a Gc<dyn SchemeCompatible>. This has to be done
-    // manually since [CoerceUnsized] is unstable.
-    let t = ManuallyDrop::new(t);
-    let any: NonNull<GcInner<dyn SchemeCompatible>> = t.ptr;
-    Gc {
-        ptr: any,
-        marker: std::marker::PhantomData,
-    }
-}
-
-#[derive(Copy, Clone, Debug, Trace)]
-pub struct RustParentConstructor {
-    #[trace(skip)]
-    constructor: ParentConstructor,
-}
-
-impl RustParentConstructor {
-    pub fn new(constructor: ParentConstructor) -> Self {
-        Self { constructor }
-    }
-}
-
-type ParentConstructor = fn(&[Value]) -> Result<Gc<dyn SchemeCompatible>, Exception>;
-
-pub(crate) fn is_subtype_of(val: &Value, rt: Arc<RecordTypeDescriptor>) -> Result<bool, Exception> {
-    let UnpackedValue::Record(rec) = val.clone().unpack() else {
-        return Ok(false);
-    };
-    Ok(Arc::ptr_eq(&rec.0.rtd, &rt) || rec.0.rtd.inherits.contains(&ByAddress::from(rt)))
 }
 
 #[cps_bridge]
@@ -1009,7 +1327,7 @@ fn record_predicate_fn(
         unreachable!();
     };
     // RTD is the first environment variable:
-    let rtd: Arc<RecordTypeDescriptor> = env[0].try_to_scheme_type()?;
+    let rtd: Arc<RecordTypeDescriptor> = env[0].try_to()?;
     Ok(Application::new(
         k,
         None,
@@ -1053,26 +1371,36 @@ fn record_accessor_fn(
         unreachable!();
     };
     let record: Record = val.clone().try_into()?;
-    // RTD is the first environment variable, field index is the second
-    let rtd: Arc<RecordTypeDescriptor> = env[0].try_to_scheme_type()?;
+    let rtd: Arc<RecordTypeDescriptor> = env[0].try_to()?;
     if !is_subtype_of(val, rtd.clone())? {
         return Err(Exception::error("not a child of this record type"));
     }
-    let idx: usize = env[1].clone().try_into()?;
-    let val = if let Some(rust_parent) = &record.0.rust_parent
-        && rtd.rust_type
-    {
-        let mut t = rust_parent.clone();
-        while let Some(embedded) = { t.extract_embedded_record(&rtd) } {
-            t = embedded;
+    let local_idx: usize = env[1].clone().try_into()?;
+    let abs_idx = local_idx + rtd.num_inherited_fields;
+    let val = if abs_idx < record.0.num_embedded_fields() {
+        // The field lives inside the embedded Rust value.
+        let embedded_ptr = record.0.embedded_ptr().unwrap();
+        let embedded_vtable = record.0.rtd.embedded_vtable.as_ref().unwrap();
+        if rtd.embedded_vtable.unwrap().type_id == embedded_vtable.type_id {
+            (embedded_vtable.get_field)(embedded_ptr, local_idx)?
+        } else {
+            let mut embedded = embedded_vtable.ptr_to_parent(embedded_ptr, &rtd).unwrap();
+            while let Some(parent) = embedded.parent_record(&rtd) {
+                embedded = parent;
+            }
+            embedded.get_field(local_idx)?
         }
-        t.get_field(idx)?
     } else {
-        record.0.fields[idx].read().clone()
+        let k = abs_idx - record.0.num_embedded_fields();
+        if let Some(cell) = record.0.fields()[k].cast_to::<Cell>() {
+            cell.get()
+        } else {
+            record.0.fields()[k].clone()
+        }
     };
     if val.is_undefined() {
         return Err(Exception::error(format!(
-            "failed to get field: {}, {idx}",
+            "failed to get field: {}, {local_idx}",
             rtd.name
         )));
     }
@@ -1099,7 +1427,8 @@ pub fn record_accessor(
             rtd.fields.len()
         )));
     }
-    let idx = idx + rtd.field_index_offset;
+    // Store the local (within-rtd) index; `record_accessor_fn` resolves it to
+    // either the embed or an inline slot.
     let accessor_fn = Procedure::new(
         runtime.clone(),
         vec![Value::from(rtd), Value::from(idx)],
@@ -1123,22 +1452,31 @@ fn record_mutator_fn(
         unreachable!();
     };
     let record: Record = rec.clone().try_into()?;
-    // RTD is the first environment variable, field index is the second
-    let rtd: Arc<RecordTypeDescriptor> = env[0].try_to_scheme_type()?;
+    // RTD is the first environment variable, the field's local index the second.
+    let rtd: Arc<RecordTypeDescriptor> = env[0].try_to()?;
     if !is_subtype_of(rec, rtd.clone())? {
         return Err(Exception::error("not a child of this record type"));
     }
-    let idx: usize = env[1].clone().try_into()?;
-    if let Some(rust_parent) = &record.0.rust_parent
-        && rtd.rust_type
-    {
-        let mut t = rust_parent.clone();
-        while let Some(embedded) = { t.extract_embedded_record(&rtd) } {
-            t = embedded;
+    let local_idx: usize = env[1].clone().try_into()?;
+    let abs_idx = local_idx + rtd.num_inherited_fields;
+    if abs_idx < record.0.num_embedded_fields() {
+        // The field lives inside the embedded Rust value.
+        let embedded_ptr = record.0.embedded_ptr().unwrap();
+        let embedded_vtable = record.0.rtd.embedded_vtable.as_ref().unwrap();
+        if rtd.embedded_vtable.unwrap().type_id == embedded_vtable.type_id {
+            (embedded_vtable.set_field)(embedded_ptr, local_idx, new_val.clone())?;
+        } else {
+            let mut embedded = embedded_vtable.ptr_to_parent(embedded_ptr, &rtd).unwrap();
+            while let Some(parent) = embedded.parent_record(&rtd) {
+                embedded = parent;
+            }
+            embedded.set_field(local_idx, new_val.clone())?;
         }
-        t.set_field(idx, new_val.clone())?;
     } else {
-        *record.0.fields[idx].write() = new_val.clone();
+        let slot = abs_idx - record.0.num_embedded_fields();
+        record.0.fields()[slot]
+            .try_to::<Cell>()?
+            .set(new_val.clone());
     }
     Ok(Application::new(k, None, Vec::new()))
 }
@@ -1166,7 +1504,6 @@ pub fn record_mutator(
     if matches!(rtd.fields[idx], Field::Immutable(_)) {
         return Err(Exception::error(format!("{idx} is immutable")));
     }
-    let idx = idx + rtd.field_index_offset;
     let mutator_fn = Procedure::new(
         runtime.clone(),
         vec![Value::from(rtd), Value::from(idx)],
@@ -1198,14 +1535,12 @@ pub fn record_rtd(record: &Value) -> Result<Vec<Value>, Exception> {
 }
 
 #[bridge(name = "record-type-name", lib = "(rnrs records inspection (6))")]
-pub fn record_type_name(rtd: &Value) -> Result<Vec<Value>, Exception> {
-    let rtd: Arc<RecordTypeDescriptor> = rtd.clone().try_into()?;
+pub fn record_type_name(rtd: Arc<RecordTypeDescriptor>) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(rtd.name)])
 }
 
 #[bridge(name = "record-type-parent", lib = "(rnrs records inspection (6))")]
-pub fn record_type_parent(rtd: &Value) -> Result<Vec<Value>, Exception> {
-    let rtd: Arc<RecordTypeDescriptor> = rtd.clone().try_into()?;
+pub fn record_type_parent(rtd: Arc<RecordTypeDescriptor>) -> Result<Vec<Value>, Exception> {
     if let Some(parent) = rtd.inherits.last() {
         Ok(vec![Value::from(parent.0.clone())])
     } else {
@@ -1214,8 +1549,7 @@ pub fn record_type_parent(rtd: &Value) -> Result<Vec<Value>, Exception> {
 }
 
 #[bridge(name = "record-type-uid", lib = "(rnrs records inspection (6))")]
-pub fn record_type_uid(rtd: &Value) -> Result<Vec<Value>, Exception> {
-    let rtd: Arc<RecordTypeDescriptor> = rtd.clone().try_into()?;
+pub fn record_type_uid(rtd: Arc<RecordTypeDescriptor>) -> Result<Vec<Value>, Exception> {
     if let Some(uid) = rtd.uid {
         Ok(vec![Value::from(uid)])
     } else {
@@ -1227,20 +1561,19 @@ pub fn record_type_uid(rtd: &Value) -> Result<Vec<Value>, Exception> {
     name = "record-type-generative?",
     lib = "(rnrs records inspection (6))"
 )]
-pub fn record_type_generative_pred(rtd: &Value) -> Result<Vec<Value>, Exception> {
-    let rtd: Arc<RecordTypeDescriptor> = rtd.clone().try_into()?;
+pub fn record_type_generative_pred(
+    rtd: Arc<RecordTypeDescriptor>,
+) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(rtd.uid.is_none())])
 }
 
 #[bridge(name = "record-type-sealed?", lib = "(rnrs records inspection (6))")]
-pub fn record_type_sealed_pred(rtd: &Value) -> Result<Vec<Value>, Exception> {
-    let rtd: Arc<RecordTypeDescriptor> = rtd.clone().try_into()?;
+pub fn record_type_sealed_pred(rtd: Arc<RecordTypeDescriptor>) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(rtd.sealed)])
 }
 
 #[bridge(name = "record-type-opaque?", lib = "(rnrs records inspection (6))")]
-pub fn record_type_opaque_pred(rtd: &Value) -> Result<Vec<Value>, Exception> {
-    let rtd: Arc<RecordTypeDescriptor> = rtd.clone().try_into()?;
+pub fn record_type_opaque_pred(rtd: Arc<RecordTypeDescriptor>) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(rtd.opaque)])
 }
 
@@ -1248,8 +1581,7 @@ pub fn record_type_opaque_pred(rtd: &Value) -> Result<Vec<Value>, Exception> {
     name = "record-type-field-names",
     lib = "(rnrs records inspection (6))"
 )]
-pub fn record_type_field_names(rtd: &Value) -> Result<Vec<Value>, Exception> {
-    let rtd: Arc<RecordTypeDescriptor> = rtd.clone().try_into()?;
+pub fn record_type_field_names(rtd: Arc<RecordTypeDescriptor>) -> Result<Vec<Value>, Exception> {
     let fields = rtd
         .fields
         .iter()
@@ -1260,10 +1592,10 @@ pub fn record_type_field_names(rtd: &Value) -> Result<Vec<Value>, Exception> {
 }
 
 #[bridge(name = "record-field-mutable?", lib = "(rnrs records inspection (6))")]
-pub fn record_field_mutable_pred(rtd: &Value, k: &Value) -> Result<Vec<Value>, Exception> {
-    let rtd: Arc<RecordTypeDescriptor> = rtd.clone().try_into()?;
-    let k: usize = k.try_to_scheme_type()?;
-
+pub fn record_field_mutable_pred(
+    rtd: Arc<RecordTypeDescriptor>,
+    k: usize,
+) -> Result<Vec<Value>, Exception> {
     if k >= rtd.fields.len() {
         return Err(Exception::invalid_index(k, rtd.fields.len()));
     }

--- a/src/records.rs
+++ b/src/records.rs
@@ -715,7 +715,7 @@ pub unsafe trait Embeddable: Trace + Any + Send + Sync {
         Err(Exception::error(format!("invalid record field: {k}")))
     }
 
-    fn display_fmt(
+    fn debug_fmt(
         &self,
         _circular_values: &mut IndexMap<Value, bool>,
         _fmt: &mut fmt::Formatter<'_>,
@@ -723,12 +723,12 @@ pub unsafe trait Embeddable: Trace + Any + Send + Sync {
         Ok(())
     }
 
-    fn debug_fmt(
+    fn display_fmt(
         &self,
-        _circular_values: &mut IndexMap<Value, bool>,
-        _fmt: &mut fmt::Formatter<'_>,
+        circular_values: &mut IndexMap<Value, bool>,
+        fmt: &mut fmt::Formatter<'_>,
     ) -> fmt::Result {
-        Ok(())
+        self.debug_fmt(circular_values, fmt)
     }
 
     fn eq(&self, rhs: &Record) -> bool

--- a/src/records.rs
+++ b/src/records.rs
@@ -590,10 +590,8 @@ impl fmt::Debug for Record {
     }
 }
 
-// #[derive(Trace)]
 #[repr(C, align(16))]
 pub(crate) struct RecordInner {
-    // pub(crate) rust_parent: Option<Gc<dyn SchemeCompatible>>,
     rtd: Arc<RecordTypeDescriptor>,
     /// Pointer to the first field. If the record contains an embedded value it
     /// will be stored after the last field.
@@ -925,10 +923,10 @@ impl<T> AsRef<T> for Embedded<T> {
 
 impl<T> fmt::Debug for Embedded<T>
 where
-    T: fmt::Debug,
+    T: Embeddable,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.as_ref().fmt(f)
+        self.as_ref().debug_fmt(&mut IndexMap::default(), f)
     }
 }
 

--- a/src/records.rs
+++ b/src/records.rs
@@ -44,7 +44,7 @@
 //! #   pos_y: f64,
 //! #   health: Mutex<f64>,
 //! # }
-//! impl Embeddable for Enemy {
+//! unsafe impl Embeddable for Enemy {
 //!     fn rtd() -> Arc<RecordTypeDescriptor> {
 //!         rtd!(
 //!             ty: Enemy,
@@ -86,7 +86,7 @@
 //! #   pos_y: f64,
 //! #   health: Mutex<f64>,
 //! # }
-//! impl Embeddable for Enemy {
+//! unsafe impl Embeddable for Enemy {
 //! #    fn rtd() -> Arc<RecordTypeDescriptor> {
 //! #        rtd!(ty: Enemy, name: "enemy", sealed: true)
 //! #    }
@@ -123,7 +123,7 @@
 //! #   pos_y: f64,
 //! #   health: f64,
 //! # }
-//! # impl Embeddable for Enemy {
+//! # unsafe impl Embeddable for Enemy {
 //! #    fn rtd() -> Arc<RecordTypeDescriptor> {
 //! #        rtd!(ty: Enemy, name: "enemy", sealed: true)
 //! #    }
@@ -134,7 +134,7 @@
 //!     special: u64,
 //! }
 //!
-//! impl Embeddable for SpecialEnemy {
+//! unsafe impl Embeddable for SpecialEnemy {
 //!     fn rtd() -> Arc<RecordTypeDescriptor> {
 //!         rtd!(
 //!             ty: SpecialEnemy,
@@ -184,7 +184,7 @@
 //! # exceptions::Exception };
 //! # #[derive(Debug, Trace)]
 //! # struct Enemy {}
-//! impl Embeddable for Enemy {
+//! unsafe impl Embeddable for Enemy {
 //!     fn rtd() -> Arc<RecordTypeDescriptor> {
 //!         rtd!(
 //!             ty: Enemy,
@@ -528,6 +528,7 @@ impl Record {
         }
     }
 
+    #[allow(clippy::should_implement_trait)]
     pub fn eq(&self, rhs: &Record) -> bool {
         if let Some(vtable) = self.0.rtd.embedded_vtable {
             (vtable.eq)(self.0.embedded_ptr().unwrap(), rhs)
@@ -685,7 +686,7 @@ unsafe impl Trace for RecordInner {
 
 /// A Rust type that can be embedded safely in a Scheme record.
 ///
-/// # Safety:
+/// # Safety
 ///
 /// The [rtd] function cannot return a RecordTypeDescriptor created for a
 /// different type than the type implementing that function. Doing so is

--- a/src/records.rs
+++ b/src/records.rs
@@ -508,24 +508,24 @@ impl Record {
         fmt: &mut fmt::Formatter<'_>,
     ) -> fmt::Result {
         if let Some(vtable) = self.0.rtd.embedded_vtable {
-            (vtable.debug_fmt)(self.0.embedded_ptr().unwrap(), circular_values, fmt)?;
+            (vtable.debug_fmt)(self.0.embedded_ptr().unwrap(), circular_values, fmt)
+        } else {
+            write!(fmt, "#<{}", self.0.rtd.name)?;
+            for (Field::Mutable(name) | Field::Immutable(name), field) in self
+                .0
+                .rtd
+                .inherits
+                .iter()
+                .cloned()
+                .chain(Some(ByAddress(self.0.rtd.clone())))
+                .flat_map(|rtd| rtd.fields.clone())
+                .zip(self.0.fields())
+            {
+                write!(fmt, " {name}: ")?;
+                field.debug_fmt(circular_values, fmt)?;
+            }
+            write!(fmt, ">")
         }
-
-        write!(fmt, "#<{}", self.0.rtd.name)?;
-        for (Field::Mutable(name) | Field::Immutable(name), field) in self
-            .0
-            .rtd
-            .inherits
-            .iter()
-            .cloned()
-            .chain(Some(ByAddress(self.0.rtd.clone())))
-            .flat_map(|rtd| rtd.fields.clone())
-            .zip(self.0.fields())
-        {
-            write!(fmt, " {name}: ")?;
-            field.debug_fmt(circular_values, fmt)?;
-        }
-        write!(fmt, ">")
     }
 
     pub fn eq(&self, rhs: &Record) -> bool {

--- a/src/records.rs
+++ b/src/records.rs
@@ -225,6 +225,7 @@ use std::{
 };
 
 use by_address::ByAddress;
+use indexmap::{IndexMap, IndexSet};
 use parking_lot::RwLock;
 
 use crate::{
@@ -489,6 +490,44 @@ impl Record {
     }
      */
 
+    pub fn display_fmt(
+        &self,
+        circular_values: &mut IndexMap<Value, bool>,
+        fmt: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        if let Some(vtable) = self.0.rtd.embedded_vtable {
+            (vtable.display_fmt)(self.0.embedded_ptr().unwrap(), circular_values, fmt)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn debug_fmt(
+        &self,
+        circular_values: &mut IndexMap<Value, bool>,
+        fmt: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        if let Some(vtable) = self.0.rtd.embedded_vtable {
+            (vtable.debug_fmt)(self.0.embedded_ptr().unwrap(), circular_values, fmt)?;
+        }
+
+        write!(fmt, "#<{}", self.0.rtd.name)?;
+        for (Field::Mutable(name) | Field::Immutable(name), field) in self
+            .0
+            .rtd
+            .inherits
+            .iter()
+            .cloned()
+            .chain(Some(ByAddress(self.0.rtd.clone())))
+            .flat_map(|rtd| rtd.fields.clone())
+            .zip(self.0.fields())
+        {
+            write!(fmt, " {name}: ")?;
+            field.debug_fmt(circular_values, fmt)?;
+        }
+        write!(fmt, ">")
+    }
+
     pub fn eq(&self, rhs: &Record) -> bool {
         if let Some(vtable) = self.0.rtd.embedded_vtable {
             (vtable.eq)(self.0.embedded_ptr().unwrap(), rhs)
@@ -529,9 +568,9 @@ impl Record {
         }
     }
 
-    pub fn equal_hash<H: Hasher>(&self, hasher: &mut H) {
+    pub fn equal_hash<H: Hasher>(&self, recursive: &mut IndexSet<Value>, hasher: &mut H) {
         if let Some(vtable) = self.0.rtd.embedded_vtable {
-            (vtable.equal_hash)(self.0.embedded_ptr().unwrap(), hasher)
+            (vtable.equal_hash)(self.0.embedded_ptr().unwrap(), recursive, hasher)
         } else {
             Gc::as_ptr(&self.0).hash(hasher)
         }
@@ -540,13 +579,13 @@ impl Record {
 
 impl fmt::Display for Record {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
+        self.display_fmt(&mut IndexMap::default(), f)
     }
 }
 
 impl fmt::Debug for Record {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
+        self.debug_fmt(&mut IndexMap::default(), f)
     }
 }
 
@@ -644,38 +683,6 @@ unsafe impl Trace for RecordInner {
     }
 }
 
-impl fmt::Display for RecordInner {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(vtable) = self.rtd.embedded_vtable {
-            (vtable.display_fmt)(self.embedded_ptr().unwrap(), f)
-        } else {
-            Ok(())
-        }
-    }
-}
-
-impl fmt::Debug for RecordInner {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(vtable) = self.rtd.embedded_vtable {
-            (vtable.debug_fmt)(self.embedded_ptr().unwrap(), f)?;
-        }
-
-        write!(f, "#<{}", self.rtd.name)?;
-        for (Field::Mutable(name) | Field::Immutable(name), field) in self
-            .rtd
-            .inherits
-            .iter()
-            .cloned()
-            .chain(Some(ByAddress(self.rtd.clone())))
-            .flat_map(|rtd| rtd.fields.clone())
-            .zip(self.fields())
-        {
-            write!(f, " {name}: {field:?}")?;
-        }
-        write!(f, ">")
-    }
-}
-
 /// A Rust type that can be embedded safely in a Scheme record.
 ///
 /// # Safety:
@@ -708,11 +715,19 @@ pub unsafe trait Embeddable: Trace + Any + Send + Sync {
         Err(Exception::error(format!("invalid record field: {k}")))
     }
 
-    fn display_fmt(&self, _fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn display_fmt(
+        &self,
+        _circular_values: &mut IndexMap<Value, bool>,
+        _fmt: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
         Ok(())
     }
 
-    fn debug_fmt(&self, _fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn debug_fmt(
+        &self,
+        _circular_values: &mut IndexMap<Value, bool>,
+        _fmt: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
         Ok(())
     }
 
@@ -769,7 +784,7 @@ pub unsafe trait Embeddable: Trace + Any + Send + Sync {
         hasher.write_usize(self as *const Self as usize)
     }
 
-    fn equal_hash(&self, hasher: &mut dyn Hasher)
+    fn equal_hash(&self, _recursive: &mut IndexSet<Value>, hasher: &mut dyn Hasher)
     where
         Self: Sized,
     {
@@ -796,9 +811,11 @@ pub struct EmbeddableVTable {
     #[trace(skip)]
     pub set_field: fn(*const (), usize, Value) -> Result<(), Exception>,
     #[trace(skip)]
-    pub display_fmt: fn(*const (), &mut fmt::Formatter<'_>) -> fmt::Result,
+    pub display_fmt:
+        fn(*const (), &mut IndexMap<Value, bool>, &mut fmt::Formatter<'_>) -> fmt::Result,
     #[trace(skip)]
-    pub debug_fmt: fn(*const (), &mut fmt::Formatter<'_>) -> fmt::Result,
+    pub debug_fmt:
+        fn(*const (), &mut IndexMap<Value, bool>, &mut fmt::Formatter<'_>) -> fmt::Result,
     #[trace(skip)]
     pub eq: for<'a> fn(*const (), &'a Record) -> bool,
     #[trace(skip)]
@@ -810,7 +827,7 @@ pub struct EmbeddableVTable {
     #[trace(skip)]
     pub eqv_hash: for<'a> fn(*const (), &'a mut dyn Hasher),
     #[trace(skip)]
-    pub equal_hash: for<'a> fn(*const (), &'a mut dyn Hasher),
+    pub equal_hash: for<'a> fn(*const (), &'a mut IndexSet<Value>, &'a mut dyn Hasher),
 }
 
 impl EmbeddableVTable {
@@ -833,10 +850,12 @@ impl EmbeddableVTable {
             set_field: |this, k, val| {
                 E::set_field(unsafe { this.cast::<E>().as_ref().unwrap() }, k, val)
             },
-            display_fmt: |this, fmt| {
-                E::display_fmt(unsafe { this.cast::<E>().as_ref().unwrap() }, fmt)
+            display_fmt: |this, circ, fmt| {
+                E::display_fmt(unsafe { this.cast::<E>().as_ref().unwrap() }, circ, fmt)
             },
-            debug_fmt: |this, fmt| E::debug_fmt(unsafe { this.cast::<E>().as_ref().unwrap() }, fmt),
+            debug_fmt: |this, circ, fmt| {
+                E::debug_fmt(unsafe { this.cast::<E>().as_ref().unwrap() }, circ, fmt)
+            },
             eq: |lhs, rhs| E::eq(unsafe { lhs.cast::<E>().as_ref().unwrap() }, rhs),
             eqv: |lhs, rhs| E::eqv(unsafe { lhs.cast::<E>().as_ref().unwrap() }, rhs),
             equal: |lhs, rhs| E::equal(unsafe { lhs.cast::<E>().as_ref().unwrap() }, rhs),
@@ -846,8 +865,8 @@ impl EmbeddableVTable {
             eqv_hash: |this, hasher| {
                 E::eqv_hash(unsafe { this.cast::<E>().as_ref().unwrap() }, hasher)
             },
-            equal_hash: |this, hasher| {
-                E::equal_hash(unsafe { this.cast::<E>().as_ref().unwrap() }, hasher)
+            equal_hash: |this, rec, hasher| {
+                E::equal_hash(unsafe { this.cast::<E>().as_ref().unwrap() }, rec, hasher)
             },
         }
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -730,6 +730,17 @@ unsafe extern "C" fn sub(vals: *const *const (), num_vals: u32, error: *mut Valu
 }
 
 #[runtime_fn]
+unsafe extern "C" fn i64_to_number(value: i64) -> *const () {
+    Value::into_raw(Value::from(num::Number::from(value)))
+}
+
+#[runtime_fn]
+unsafe extern "C" fn i128_to_number(lo: i64, hi: i64) -> *const () {
+    let value = ((hi as i128) << 64) | ((lo as u64) as i128);
+    Value::into_raw(Value::from(num::Number::from(value)))
+}
+
+#[runtime_fn]
 unsafe extern "C" fn mul(vals: *const *const (), num_vals: u32, error: *mut Value) -> *const () {
     unsafe {
         let vals: Vec<_> = (0..num_vals)

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -458,7 +458,7 @@ unsafe extern "C" fn apply(
             x => {
                 let raised = raise(
                     Runtime::from_raw_inc_rc(runtime),
-                    Exception::invalid_operator(x.type_name()).into(),
+                    Exception::invalid_operator(&*x.type_name()).into(),
                     barrier.as_mut().unwrap_unchecked(),
                 );
                 return Box::into_raw(Box::new(raised));

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -466,7 +466,7 @@ unsafe extern "C" fn apply(
         };
 
         let (k, offset) = if !op.0.is_continuation() {
-            (Value::from_raw_inc_rc(args.read()).cast_to(), 1)
+            (Value::from_raw_inc_rc(args.read()).cast(), 1)
         } else {
             (None, 0)
         };
@@ -488,11 +488,11 @@ unsafe extern "C" fn apply(
 unsafe extern "C" fn get_frame(op: *const (), span: *const ()) -> *const () {
     unsafe {
         let op = Value::from_raw_inc_rc(op);
-        let Some(op) = op.cast_to::<Procedure>() else {
+        let Some(op) = op.cast::<Procedure>() else {
             return Value::into_raw(Value::null());
         };
         let span = Value::from_raw_inc_rc(span);
-        let span = span.cast_to::<Embedded<Span>>().unwrap();
+        let span = span.cast::<Embedded<Span>>().unwrap();
         let frame = Syntax::Identifier {
             ident: Identifier {
                 sym: op
@@ -519,7 +519,7 @@ unsafe extern "C" fn set_continuation_mark(
         barrier
             .as_mut()
             .unwrap()
-            .set_continuation_mark(tag.cast_to().unwrap(), val);
+            .set_continuation_mark(tag.cast().unwrap(), val);
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -458,7 +458,7 @@ unsafe extern "C" fn apply(
             x => {
                 let raised = raise(
                     Runtime::from_raw_inc_rc(runtime),
-                    Exception::invalid_operator(&*x.type_name()).into(),
+                    Exception::invalid_operator(&x.type_name()).into(),
                     barrier.as_mut().unwrap_unchecked(),
                 );
                 return Box::into_raw(Box::new(raised));

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -18,6 +18,7 @@ use crate::{
         Application, ContBarrier, ContinuationPtr, FuncPtr, ProcDebugInfo, Procedure,
         ProcedureInner, UserPtr,
     },
+    records::Embedded,
     registry::Registry,
     symbols::Symbol,
     syntax::{Identifier, Span, Syntax},
@@ -465,7 +466,7 @@ unsafe extern "C" fn apply(
         };
 
         let (k, offset) = if !op.0.is_continuation() {
-            (Value::from_raw_inc_rc(args.read()).cast_to_scheme_type(), 1)
+            (Value::from_raw_inc_rc(args.read()).cast_to(), 1)
         } else {
             (None, 0)
         };
@@ -487,11 +488,11 @@ unsafe extern "C" fn apply(
 unsafe extern "C" fn get_frame(op: *const (), span: *const ()) -> *const () {
     unsafe {
         let op = Value::from_raw_inc_rc(op);
-        let Some(op) = op.cast_to_scheme_type::<Procedure>() else {
+        let Some(op) = op.cast_to::<Procedure>() else {
             return Value::into_raw(Value::null());
         };
         let span = Value::from_raw_inc_rc(span);
-        let span = span.cast_to_rust_type::<Span>().unwrap();
+        let span = span.cast_to::<Embedded<Span>>().unwrap();
         let frame = Syntax::Identifier {
             ident: Identifier {
                 sym: op
@@ -518,7 +519,7 @@ unsafe extern "C" fn set_continuation_mark(
         barrier
             .as_mut()
             .unwrap()
-            .set_continuation_mark(tag.cast_to_scheme_type().unwrap(), val);
+            .set_continuation_mark(tag.cast_to().unwrap(), val);
     }
 }
 
@@ -552,7 +553,7 @@ unsafe extern "C" fn store(from: *const (), to: *const ()) {
 unsafe extern "C" fn car(val: *const (), error: *mut Value) -> *const () {
     unsafe {
         let val = ManuallyDrop::new(Value::from_raw(val));
-        match val.try_to_scheme_type::<Pair>() {
+        match val.try_to::<Pair>() {
             Ok(pair) => Value::into_raw(pair.car()),
             Err(condition) => {
                 error.write(condition.into());
@@ -567,7 +568,7 @@ unsafe extern "C" fn car(val: *const (), error: *mut Value) -> *const () {
 unsafe extern "C" fn cdr(val: *const (), error: *mut Value) -> *const () {
     unsafe {
         let val = ManuallyDrop::new(Value::from_raw(val));
-        match val.try_to_scheme_type::<Pair>() {
+        match val.try_to::<Pair>() {
             Ok(pair) => Value::into_raw(pair.cdr()),
             Err(condition) => {
                 error.write(condition.into());
@@ -672,8 +673,7 @@ unsafe extern "C" fn patch_env_slot(proc: *const (), slot_idx: u32, value: *cons
         let proc_gc = ManuallyDrop::new(Gc::from_raw(
             proc.map_addr(|raw| raw & !TAG) as *mut GcInner<ProcedureInner>
         ));
-        (*Gc::as_ptr(&proc_gc)).data.get_mut().env[slot_idx as usize] =
-            Value::from_raw_inc_rc(value);
+        (*Gc::as_ptr(&proc_gc)).data_mut().env[slot_idx as usize] = Value::from_raw_inc_rc(value);
     }
 }
 

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -379,7 +379,7 @@ pub fn string_set_bang(string: &Value, k: &Value, chr: &Value) -> Result<Vec<Val
 
 #[bridge(name = "string-foldcase", lib = "(rnrs base builtins (6))")]
 pub fn string_foldcase(string: &Value) -> Result<Vec<Value>, Exception> {
-    let string: WideString = string.try_to_scheme_type()?;
+    let string: WideString = string.try_to()?;
     let folded = string
         .0
         .chars

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -217,7 +217,7 @@ impl TryFrom<Value> for WideString {
 
 impl From<&Value> for Option<WideString> {
     fn from(value: &Value) -> Self {
-        Some(WideString(value.cast_to()?))
+        Some(WideString(value.cast()?))
     }
 }
 

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -8,40 +8,84 @@
 use std::{fmt, hash::Hash, sync::Arc};
 
 use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard};
+use scheme_rs_macros::rtd;
 
 use crate::{
     Either,
     character::{char_switch_case, to_foldcase},
     exceptions::Exception,
     gc::Trace,
+    records::{Embeddable, Embedded, Record, RecordTypeDescriptor},
     registry::bridge,
-    value::{Value, ValueType},
+    value::Value,
 };
 
+#[derive(Trace)]
 #[repr(align(16))]
 pub(crate) struct WideStringInner {
     pub(crate) chars: RwLock<Vec<char>>,
     mutable: bool,
 }
 
+impl fmt::Debug for WideStringInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "\"")?;
+        for char in self.chars.read().iter().flat_map(|chr| chr.escape_debug()) {
+            write!(f, "{char}")?;
+        }
+        write!(f, "\"")
+    }
+}
+
+unsafe impl Embeddable for WideStringInner {
+    fn rtd() -> Arc<RecordTypeDescriptor>
+    where
+        Self: Sized,
+    {
+        rtd!(ty: WideStringInner, name: "string", sealed: true, opaque: true)
+    }
+
+    fn equal(&self, rhs: &Record) -> bool
+    where
+        Self: Sized,
+    {
+        let Some(rhs) = rhs.cast::<Self>() else {
+            return false;
+        };
+        *self.chars.read() == *rhs.chars.read()
+    }
+
+    fn equal_hash(&self, hasher: &mut dyn std::hash::Hasher)
+    where
+        Self: Sized,
+    {
+        let chars = self.chars.read();
+        hasher.write_usize(chars.len());
+        for chr in chars.iter() {
+            hasher.write_u32(*chr as u32);
+        }
+    }
+}
+
 /// A string that is a vector of characters, rather than a vector bytes encoding
 /// a utf-8 string. This is because R6RS mandates O(1) lookups of character
 /// indices.
 #[derive(Clone, Trace)]
-pub struct WideString(pub(crate) Arc<WideStringInner>);
+pub struct WideString(pub(crate) Embedded<WideStringInner>);
 
 impl WideString {
-    pub fn immutable(s: impl fmt::Display) -> Self {
-        Self::from(s.to_string())
+    pub fn immutable(s: impl IntoIterator<Item = char>) -> Self {
+        Self(Embedded::new(WideStringInner {
+            chars: RwLock::new(s.into_iter().collect()),
+            mutable: false,
+        }))
     }
 
-    pub fn mutable<V>(value: V) -> Self
-    where
-        Self: From<V>,
-    {
-        let mut this = Self::from(value);
-        Arc::get_mut(&mut this.0).unwrap().mutable = true;
-        this
+    pub fn mutable(s: impl IntoIterator<Item = char>) -> Self {
+        Self(Embedded::new(WideStringInner {
+            chars: RwLock::new(s.into_iter().collect()),
+            mutable: true,
+        }))
     }
 
     pub fn as_slice(&self) -> MappedRwLockReadGuard<'_, [char]> {
@@ -67,7 +111,7 @@ impl WideString {
 
 impl From<Vec<char>> for WideString {
     fn from(value: Vec<char>) -> Self {
-        Self(Arc::new(WideStringInner {
+        Self(Embedded::new(WideStringInner {
             chars: RwLock::new(value),
             mutable: false,
         }))
@@ -76,7 +120,7 @@ impl From<Vec<char>> for WideString {
 
 impl From<String> for WideString {
     fn from(value: String) -> Self {
-        Self(Arc::new(WideStringInner {
+        Self(Embedded::new(WideStringInner {
             chars: RwLock::new(value.chars().collect()),
             mutable: false,
         }))
@@ -85,7 +129,7 @@ impl From<String> for WideString {
 
 impl From<&str> for WideString {
     fn from(value: &str) -> Self {
-        Self(Arc::new(WideStringInner {
+        Self(Embedded::new(WideStringInner {
             chars: RwLock::new(value.chars().collect()),
             mutable: false,
         }))
@@ -127,23 +171,47 @@ impl fmt::Display for WideString {
 
 impl fmt::Debug for WideString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "\"")?;
-        for char in self
-            .0
-            .chars
-            .read()
-            .iter()
-            .flat_map(|chr| chr.escape_debug())
-        {
-            write!(f, "{char}")?;
-        }
-        write!(f, "\"")
+        self.0.fmt(f)
+    }
+}
+
+impl From<WideString> for Value {
+    fn from(value: WideString) -> Self {
+        Value::from(value.0)
+    }
+}
+
+impl TryFrom<Value> for WideString {
+    type Error = Exception;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        Ok(Self((&value).try_into()?))
+    }
+}
+
+impl From<&Value> for Option<WideString> {
+    fn from(value: &Value) -> Self {
+        Some(WideString(value.cast_to()?))
+    }
+}
+
+impl TryFrom<&Value> for WideString {
+    type Error = Exception;
+
+    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+        Ok(Self(value.try_into()?))
+    }
+}
+
+impl From<String> for Value {
+    fn from(value: String) -> Self {
+        Value::from(WideString::mutable(value.chars()))
     }
 }
 
 #[bridge(name = "string?", lib = "(rnrs base builtins (6))")]
-pub fn string_pred(arg: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(arg.type_of() == ValueType::String)])
+pub fn string_pred(arg: &Value) -> bool {
+    arg.is_a::<Embedded<WideStringInner>>()
 }
 
 #[bridge(name = "make-string", lib = "(rnrs base builtins (6))")]
@@ -154,7 +222,7 @@ pub fn make_string(k: &Value, chr: &[Value]) -> Result<Vec<Value>, Exception> {
         x => return Err(Exception::wrong_num_of_args(2, 1 + x.len())),
     };
     let k: usize = k.clone().try_into()?;
-    let ret = Value::from(WideString(Arc::new(WideStringInner {
+    let ret = Value::from(WideString(Embedded::new(WideStringInner {
         chars: RwLock::new(std::iter::repeat_n(chr, k).collect()),
         mutable: true,
     })));
@@ -163,17 +231,19 @@ pub fn make_string(k: &Value, chr: &[Value]) -> Result<Vec<Value>, Exception> {
 
 #[bridge(name = "string", lib = "(rnrs base builtins (6))")]
 pub fn string(char: &Value, chars: &[Value]) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(WideString(Arc::new(WideStringInner {
-        chars: RwLock::new(
-            Some(char)
-                .into_iter()
-                .chain(chars.iter())
-                .cloned()
-                .map(Value::try_into)
-                .collect::<Result<Vec<char>, _>>()?,
-        ),
-        mutable: true,
-    })))])
+    Ok(vec![Value::from(WideString(Embedded::new(
+        WideStringInner {
+            chars: RwLock::new(
+                Some(char)
+                    .into_iter()
+                    .chain(chars.iter())
+                    .cloned()
+                    .map(Value::try_into)
+                    .collect::<Result<Vec<char>, _>>()?,
+            ),
+            mutable: true,
+        },
+    )))])
 }
 
 #[bridge(name = "string-length", lib = "(rnrs base builtins (6))")]
@@ -390,7 +460,7 @@ pub fn string_foldcase(string: &Value) -> Result<Vec<Value>, Exception> {
             Either::Right(s) => s,
         })
         .collect::<Vec<_>>();
-    let folded = WideString(Arc::new(WideStringInner {
+    let folded = WideString(Embedded::new(WideStringInner {
         chars: RwLock::new(folded),
         mutable: true,
     }));

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -27,6 +27,15 @@ pub(crate) struct WideStringInner {
     mutable: bool,
 }
 
+impl fmt::Display for WideStringInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for char in &*self.chars.read() {
+            write!(f, "{char}")?;
+        }
+        Ok(())
+    }
+}
+
 impl fmt::Debug for WideStringInner {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "\"")?;
@@ -43,6 +52,14 @@ unsafe impl Embeddable for WideStringInner {
         Self: Sized,
     {
         rtd!(ty: WideStringInner, name: "string", sealed: true, opaque: true)
+    }
+
+    fn display_fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "{self}")
+    }
+
+    fn debug_fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "{self:?}")
     }
 
     fn equal(&self, rhs: &Record) -> bool

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -7,6 +7,7 @@
 
 use std::{fmt, hash::Hash, sync::Arc};
 
+use indexmap::{IndexMap, IndexSet};
 use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard};
 use scheme_rs_macros::rtd;
 
@@ -54,11 +55,19 @@ unsafe impl Embeddable for WideStringInner {
         rtd!(ty: WideStringInner, name: "string", sealed: true, opaque: true)
     }
 
-    fn display_fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn display_fmt(
+        &self,
+        _circular: &mut IndexMap<Value, bool>,
+        fmt: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
         write!(fmt, "{self}")
     }
 
-    fn debug_fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn debug_fmt(
+        &self,
+        _circular: &mut IndexMap<Value, bool>,
+        fmt: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
         write!(fmt, "{self:?}")
     }
 
@@ -72,7 +81,7 @@ unsafe impl Embeddable for WideStringInner {
         *self.chars.read() == *rhs.chars.read()
     }
 
-    fn equal_hash(&self, hasher: &mut dyn std::hash::Hasher)
+    fn equal_hash(&self, _recursive: &mut IndexSet<Value>, hasher: &mut dyn std::hash::Hasher)
     where
         Self: Sized,
     {

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -79,7 +79,7 @@ pub fn symbol_equal_pred(
         return Ok(vec![Value::from(false)]);
     }
     for symboln in symboln {
-        let symboln = symboln.try_to_scheme_type::<Symbol>()?;
+        let symboln = symboln.try_to::<Symbol>()?;
         if symbol1 != symboln {
             return Ok(vec![Value::from(false)]);
         }

--- a/src/syntax/lex.rs
+++ b/src/syntax/lex.rs
@@ -12,7 +12,7 @@ use futures::future::BoxFuture;
 
 use crate::{
     exceptions::Exception,
-    num::{self, SimpleNumber},
+    num::{self, NumberRepr, SimpleNumber},
     ports::{PortData, PortInfo},
 };
 
@@ -765,22 +765,22 @@ impl TryFrom<Number> for num::Number {
             } else {
                 SimpleNumber::Real(0.0)
             };
-            return Ok(num::Number(Arc::new(num::NumberInner::Complex(
+            return Ok(num::Number(NumberRepr::Heap(Arc::new(num::NumberInner::Complex(
                 if value.is_polar {
                     num::ComplexNumber::from_polar(real_part, imag_part)
                 } else {
                     num::ComplexNumber::new(real_part, imag_part)
                 },
-            ))));
+            )))));
         }
 
         let part = value
             .real_part
             .ok_or(ParseNumberError::NoValidRepresentation)?;
 
-        Ok(num::Number(Arc::new(num::NumberInner::Simple(
+        Ok(num::Number::from(num::NumberInner::Simple(
             (part, value.radix).try_into()?,
-        ))))
+        )))
     }
 }
 

--- a/src/syntax/lex.rs
+++ b/src/syntax/lex.rs
@@ -765,13 +765,13 @@ impl TryFrom<Number> for num::Number {
             } else {
                 SimpleNumber::Real(0.0)
             };
-            return Ok(num::Number(NumberRepr::Heap(Arc::new(num::NumberInner::Complex(
-                if value.is_polar {
+            return Ok(num::Number(NumberRepr::Heap(Arc::new(
+                num::NumberInner::Complex(if value.is_polar {
                     num::ComplexNumber::from_polar(real_part, imag_part)
                 } else {
                     num::ComplexNumber::new(real_part, imag_part)
-                },
-            )))));
+                }),
+            ))));
         }
 
         let part = value

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -649,7 +649,7 @@ impl PartialEq<str> for Identifier {
 impl From<&Value> for Option<Identifier> {
     fn from(value: &Value) -> Self {
         if let Some(Syntax::Identifier { ident, .. }) =
-            value.cast_to::<Embedded<Syntax>>().as_deref()
+            value.cast::<Embedded<Syntax>>().as_deref()
         {
             Some(ident.clone())
         } else {
@@ -686,7 +686,7 @@ pub fn datum_to_syntax(template_id: Identifier, datum: &Value) -> Result<Vec<Val
 
 #[bridge(name = "identifier?", lib = "(rnrs syntax-case builtins (6))")]
 pub fn identifier_pred(obj: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(obj.cast_to::<Identifier>().is_some())])
+    Ok(vec![Value::from(obj.cast::<Identifier>().is_some())])
 }
 
 #[bridge(name = "bound-identifier=?", lib = "(rnrs syntax-case builtins (6))")]
@@ -739,7 +739,7 @@ pub fn syntax_violation(
     let mut conditions = Vec::new();
     if who.is_true() {
         conditions.push(Value::from(Who::new(who.clone())));
-    } else if let Some(syntax) = form.cast_to::<Embedded<Syntax>>() {
+    } else if let Some(syntax) = form.cast::<Embedded<Syntax>>() {
         let who = if let Syntax::Identifier { ident, .. } = syntax.as_ref() {
             Some(ident.sym)
         } else if let Some([Syntax::Identifier { ident, .. }, ..]) = syntax.as_list() {

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -392,25 +392,22 @@ impl Syntax {
         let bytes = Cursor::new(s.as_bytes().to_vec());
 
         // This is kind of convoluted, but convenient
-        let port = Arc::into_inner(
-            Port::new(
-                file_name,
-                bytes,
-                BufferMode::Block,
-                Some(Transcoder::native()),
-            )
-            .0,
-        )
-        .unwrap();
-        let info = port.info;
-        let mut data = port.data.into_inner();
+        let port = Port::new(
+            file_name,
+            bytes,
+            BufferMode::Block,
+            Some(Transcoder::native()),
+        );
+        let info = &port.0.info;
+        // The port was just created, so the lock is uncontested.
+        let mut data = port.0.data.try_lock().unwrap();
 
         // This is safe since we don't need the async executor to drive anything
         // here
         futures::executor::block_on(async move {
             use crate::syntax::parse::Parser;
 
-            let mut parser = Parser::new(&mut data, &info, Span::new(file_name));
+            let mut parser = Parser::new(&mut data, info, Span::new(file_name));
             parser.all_sexprs().await
         })
     }

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     symbols::Symbol,
     syntax::parse::ParseSyntaxError,
     value::{Expect1, UnpackedValue, Value},
+    vectors::{Vector, VectorInner},
 };
 use scheme_rs_macros::{maybe_async, maybe_await};
 use std::{
@@ -152,12 +153,19 @@ impl Syntax {
                     },
                 }
             }
-            UnpackedValue::Vector(vec) => Syntax::Vector {
-                vector: vec.iter().map(|value| Syntax::wrap(value, span)).collect(),
-                span: span.clone(),
-            },
             UnpackedValue::Record(rec) if let Some(syn) = rec.cast::<Syntax>() => {
                 syn.as_ref().clone()
+            }
+            UnpackedValue::Record(rec) if let Some(vec) = rec.cast::<VectorInner<Value>>() => {
+                Syntax::Vector {
+                    vector: vec
+                        .vec
+                        .read()
+                        .iter()
+                        .map(|value| Syntax::wrap(value.clone(), span))
+                        .collect(),
+                    span: span.clone(),
+                }
             }
             value => Syntax::Wrapped {
                 value: value.into_value(),
@@ -200,13 +208,18 @@ impl Syntax {
                     },
                 }
             }
-            UnpackedValue::Vector(vec) => Syntax::Vector {
-                vector: vec
-                    .iter()
-                    .map(|value| Syntax::datum_to_syntax(scopes, value, span))
-                    .collect(),
-                span: Span::default(),
-            },
+
+            UnpackedValue::Record(rec) if let Some(vec) = rec.cast::<VectorInner<Value>>() => {
+                Syntax::Vector {
+                    vector: vec
+                        .vec
+                        .read()
+                        .iter()
+                        .map(|value| Syntax::datum_to_syntax(scopes, value.clone(), span))
+                        .collect(),
+                    span: Span::default(),
+                }
+            }
             UnpackedValue::Record(rec) if let Some(syn) = rec.cast::<Syntax>() => {
                 let mut syn = syn.as_ref().clone();
                 for scope in scopes {
@@ -234,8 +247,15 @@ impl Syntax {
                 let (car, cdr) = pair.into();
                 Value::from((Self::syntax_to_datum(car), Self::syntax_to_datum(cdr)))
             }
-            UnpackedValue::Vector(vec) => {
-                Value::from(vec.iter().map(Self::syntax_to_datum).collect::<Vec<_>>())
+            UnpackedValue::Record(rec) if let Some(vec) = rec.cast::<VectorInner<Value>>() => {
+                Value::from(
+                    vec.vec
+                        .read()
+                        .iter()
+                        .cloned()
+                        .map(Self::syntax_to_datum)
+                        .collect::<Vec<_>>(),
+                )
             }
             UnpackedValue::Record(rec) if let Some(syn) = rec.cast::<Syntax>() => {
                 match syn.as_ref() {

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     gc::{Gc, Trace},
     ports::Port,
     proc::{ContBarrier, Procedure},
-    records::{RecordTypeDescriptor, SchemeCompatible, rtd},
+    records::{Embeddable, RecordTypeDescriptor, rtd},
     registry::bridge,
     symbols::Symbol,
     syntax::parse::ParseSyntaxError,
@@ -64,9 +64,9 @@ impl Default for Span {
     }
 }
 
-impl SchemeCompatible for Span {
+impl Embeddable for Span {
     fn rtd() -> Arc<RecordTypeDescriptor> {
-        rtd!(name: "span", sealed: true, opaque: true)
+        rtd!(ty: Span, name: "span", sealed: true, opaque: true)
     }
 }
 
@@ -622,9 +622,7 @@ pub fn datum_to_syntax(template_id: Identifier, datum: &Value) -> Result<Vec<Val
 
 #[bridge(name = "identifier?", lib = "(rnrs syntax-case builtins (6))")]
 pub fn identifier_pred(obj: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(
-        obj.cast_to_scheme_type::<Identifier>().is_some(),
-    )])
+    Ok(vec![Value::from(obj.cast_to::<Identifier>().is_some())])
 }
 
 #[bridge(name = "bound-identifier=?", lib = "(rnrs syntax-case builtins (6))")]
@@ -676,8 +674,8 @@ pub fn syntax_violation(
     };
     let mut conditions = Vec::new();
     if who.is_true() {
-        conditions.push(Value::from_rust_type(Who::new(who.clone())));
-    } else if let Some(syntax) = form.cast_to_scheme_type::<Gc<Syntax>>() {
+        conditions.push(Value::from(Who::new(who.clone())));
+    } else if let Some(syntax) = form.cast_to::<Gc<Syntax>>() {
         let who = if let Syntax::Identifier { ident, .. } = syntax.as_ref() {
             Some(ident.sym)
         } else if let Some([Syntax::Identifier { ident, .. }, ..]) = syntax.as_list() {
@@ -685,10 +683,10 @@ pub fn syntax_violation(
         } else {
             None
         };
-        conditions.push(Value::from_rust_type(Who::new(Value::from(who))));
+        conditions.push(Value::from(Who::new(Value::from(who))));
     }
-    conditions.push(Value::from_rust_type(Message::new(message)));
-    conditions.push(Value::from_rust_type(SyntaxViolation::new_from_values(
+    conditions.push(Value::from(Message::new(message)));
+    conditions.push(Value::from(SyntaxViolation::new_from_values(
         form.clone(),
         subform,
     )));

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     ast::Primitive,
     env::{Binding, Environment, Scope, add_binding, resolve},
     exceptions::{CompoundCondition, Exception, Message, SyntaxViolation, Who},
-    gc::{Gc, Trace},
+    gc::Trace,
     ports::Port,
     proc::{ContBarrier, Procedure},
     records::{Embeddable, Embedded, RecordTypeDescriptor, rtd},
@@ -12,7 +12,7 @@ use crate::{
     symbols::Symbol,
     syntax::parse::ParseSyntaxError,
     value::{Expect1, UnpackedValue, Value},
-    vectors::{Vector, VectorInner},
+    vectors::VectorInner,
 };
 use scheme_rs_macros::{maybe_async, maybe_await};
 use std::{
@@ -648,8 +648,7 @@ impl PartialEq<str> for Identifier {
 
 impl From<&Value> for Option<Identifier> {
     fn from(value: &Value) -> Self {
-        if let Some(Syntax::Identifier { ident, .. }) =
-            value.cast::<Embedded<Syntax>>().as_deref()
+        if let Some(Syntax::Identifier { ident, .. }) = value.cast::<Embedded<Syntax>>().as_deref()
         {
             Some(ident.clone())
         } else {

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     gc::{Gc, Trace},
     ports::Port,
     proc::{ContBarrier, Procedure},
-    records::{Embeddable, RecordTypeDescriptor, rtd},
+    records::{Embeddable, Embedded, RecordTypeDescriptor, rtd},
     registry::bridge,
     symbols::Symbol,
     syntax::parse::ParseSyntaxError,
@@ -96,6 +96,15 @@ pub enum Syntax {
     },
 }
 
+unsafe impl Embeddable for Syntax {
+    fn rtd() -> Arc<RecordTypeDescriptor>
+    where
+        Self: Sized,
+    {
+        rtd!(ty: Syntax, name: "syntax", sealed: true, opaque: true)
+    }
+}
+
 impl Syntax {
     pub(crate) fn adjust_scope(&mut self, scope: Scope, op: fn(&mut Identifier, Scope)) {
         match self {
@@ -147,7 +156,9 @@ impl Syntax {
                 vector: vec.iter().map(|value| Syntax::wrap(value, span)).collect(),
                 span: span.clone(),
             },
-            UnpackedValue::Syntax(syn) => syn.as_ref().clone(),
+            UnpackedValue::Record(rec) if let Some(syn) = rec.cast::<Syntax>() => {
+                syn.as_ref().clone()
+            }
             value => Syntax::Wrapped {
                 value: value.into_value(),
                 span: Span::default(),
@@ -196,7 +207,7 @@ impl Syntax {
                     .collect(),
                 span: Span::default(),
             },
-            UnpackedValue::Syntax(syn) => {
+            UnpackedValue::Record(rec) if let Some(syn) = rec.cast::<Syntax>() => {
                 let mut syn = syn.as_ref().clone();
                 for scope in scopes {
                     syn.add_scope(*scope);
@@ -226,11 +237,13 @@ impl Syntax {
             UnpackedValue::Vector(vec) => {
                 Value::from(vec.iter().map(Self::syntax_to_datum).collect::<Vec<_>>())
             }
-            UnpackedValue::Syntax(syn) => match syn.as_ref() {
-                Syntax::Identifier { ident, .. } => Value::from(ident.sym),
-                Syntax::Wrapped { value, .. } => value.clone(),
-                syn => Syntax::syntax_to_datum(Self::unwrap(syn.clone())),
-            },
+            UnpackedValue::Record(rec) if let Some(syn) = rec.cast::<Syntax>() => {
+                match syn.as_ref() {
+                    Syntax::Identifier { ident, .. } => Value::from(ident.sym),
+                    Syntax::Wrapped { value, .. } => value.clone(),
+                    syn => Syntax::syntax_to_datum(Self::unwrap(syn.clone())),
+                }
+            }
             unpacked => unpacked.into_value(),
         }
     }
@@ -605,6 +618,29 @@ impl PartialEq<str> for Identifier {
     }
 }
 
+impl From<&Value> for Option<Identifier> {
+    fn from(value: &Value) -> Self {
+        if let Some(Syntax::Identifier { ident, .. }) =
+            value.cast_to::<Embedded<Syntax>>().as_deref()
+        {
+            Some(ident.clone())
+        } else {
+            None
+        }
+    }
+}
+
+impl TryFrom<&Value> for Identifier {
+    type Error = Exception;
+
+    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+        match Option::<Identifier>::from(value) {
+            Some(ident) => Ok(ident),
+            None => Err(Exception::type_error("identifier", &value.type_name())),
+        }
+    }
+}
+
 #[bridge(name = "syntax->datum", lib = "(rnrs syntax-case builtins (6))")]
 pub fn syntax_to_datum(value: &Value) -> Result<Vec<Value>, Exception> {
     // This is quite slow and could be improved
@@ -675,7 +711,7 @@ pub fn syntax_violation(
     let mut conditions = Vec::new();
     if who.is_true() {
         conditions.push(Value::from(Who::new(who.clone())));
-    } else if let Some(syntax) = form.cast_to::<Gc<Syntax>>() {
+    } else if let Some(syntax) = form.cast_to::<Embedded<Syntax>>() {
         let who = if let Syntax::Identifier { ident, .. } = syntax.as_ref() {
             Some(ident.sym)
         } else if let Some([Syntax::Identifier { ident, .. }, ..]) = syntax.as_list() {

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -64,7 +64,7 @@ impl Default for Span {
     }
 }
 
-impl Embeddable for Span {
+unsafe impl Embeddable for Span {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(ty: Span, name: "span", sealed: true, opaque: true)
     }

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -104,6 +104,14 @@ unsafe impl Embeddable for Syntax {
     {
         rtd!(ty: Syntax, name: "syntax", sealed: true, opaque: true)
     }
+
+    fn debug_fmt(
+        &self,
+        _circular_values: &mut indexmap::IndexMap<Value, bool>,
+        fmt: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        write!(fmt, "#<syntax:{} {:#?}>", self.span(), self)
+    }
 }
 
 impl Syntax {

--- a/src/syntax/parse.rs
+++ b/src/syntax/parse.rs
@@ -286,7 +286,7 @@ impl Parser<'_> {
                 token!(Lexeme::Number(num), span) => {
                     let num: Number = num.try_into()?;
                     if let Some(simple) = num.as_simple()
-                        && let Ok(byte) = u8::try_from(simple)
+                        && let Ok(byte) = u8::try_from(&*simple)
                     {
                         output.push(byte);
                         continue;

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -14,7 +14,7 @@ use crate::{
     exceptions::Exception,
     gc::{Gc, Trace},
     proc::{ContBarrier, Procedure},
-    records::{RecordTypeDescriptor, SchemeCompatible, rtd},
+    records::{Embeddable, Embedded, RecordTypeDescriptor, rtd},
     value::Value,
 };
 
@@ -31,9 +31,9 @@ impl fmt::Debug for JoinHandle {
     }
 }
 
-impl SchemeCompatible for JoinHandle {
+impl Embeddable for JoinHandle {
     fn rtd() -> Arc<RecordTypeDescriptor> {
-        rtd!(name: "join-handle", sealed: true, opaque: true)
+        rtd!(ty: JoinHandle, name: "join-handle", sealed: true, opaque: true)
     }
 }
 
@@ -55,12 +55,11 @@ pub fn spawn(thunk: Procedure) -> Result<Vec<Value>, Exception> {
         }
     });
     let id = join_handle.thread().id();
-    Ok(vec![Value::from_rust_type(JoinHandle { id, result: cell })])
+    Ok(vec![Value::from(JoinHandle { id, result: cell })])
 }
 
 #[bridge(name = "join", lib = "(threads (1))")]
-pub fn join(handle: &Value) -> Result<Vec<Value>, Exception> {
-    let handle = handle.try_to_rust_type::<JoinHandle>()?;
+pub fn join(handle: Embedded<JoinHandle>) -> Result<Vec<Value>, Exception> {
     let curr_id = thread::current().id();
     if curr_id == handle.id {
         Err(Exception::error(format!(
@@ -79,7 +78,5 @@ pub fn sleep(ms: u64) -> Result<Vec<Value>, Exception> {
 
 #[bridge(name = "join-handle?", lib = "(threads (1))")]
 pub fn join_handle_pred(obj: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(
-        obj.cast_to_rust_type::<JoinHandle>().is_some(),
-    )])
+    Ok(vec![Value::from(obj.is_a::<Embedded<JoinHandle>>())])
 }

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -31,7 +31,7 @@ impl fmt::Debug for JoinHandle {
     }
 }
 
-impl Embeddable for JoinHandle {
+unsafe impl Embeddable for JoinHandle {
     fn rtd() -> Arc<RecordTypeDescriptor> {
         rtd!(ty: JoinHandle, name: "join-handle", sealed: true, opaque: true)
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -118,6 +118,7 @@ pub(crate) const SYMBOL_CHAR: u32 = 0x110000;
 pub(crate) const NULL_VALUE: usize = Tag::Pair as usize;
 pub(crate) const TRUE_VALUE: usize = Tag::Boolean as usize | 1 << TAG_BITS;
 pub(crate) const FALSE_VALUE: usize = Tag::Boolean as usize;
+pub(crate) const UNDEFINED_VALUE: usize = Tag::Record as usize;
 pub const FIXNUM_MIN: i64 = -(1 << 62);
 pub const FIXNUM_MAX: i64 = (1 << 62) - 1;
 
@@ -187,7 +188,7 @@ impl Value {
                 Tag::Cell => {
                     Gc::increment_reference_count(untagged as *mut GcInner<Value>);
                 }
-                Tag::Boolean | Tag::CharacterOrSymbol => (),
+                Tag::FixNum | Tag::Boolean | Tag::CharacterOrSymbol => (),
             }
         }
         Self(raw)
@@ -215,11 +216,11 @@ impl Value {
     }
 
     pub fn undefined() -> Self {
-        Self(null::<()>().map_addr(|raw| raw | Tag::Record as usize))
+        Self(null::<()>().map_addr(|raw| raw | UNDEFINED_VALUE))
     }
 
     pub fn null() -> Self {
-        Self(null::<()>().map_addr(|raw| raw | Tag::Pair as usize))
+        Self(null::<()>().map_addr(|raw| raw | NULL_VALUE))
     }
 
     /// Convert a [`Syntax`] into its corresponding datum representation.
@@ -280,7 +281,6 @@ impl Value {
         let tag = Tag::from(raw as usize & TAG);
         let untagged = raw.map_addr(|raw| raw & !TAG);
         match tag {
-            // Tag::Undefined => UnpackedValue::Undefined,
             Tag::Boolean => {
                 let untagged = untagged as usize >> TAG_BITS;
                 UnpackedValue::Boolean(untagged != 0)
@@ -326,6 +326,9 @@ impl Value {
             Tag::Cell => {
                 let cell = unsafe { Gc::from_raw(untagged as *mut GcInner<RwLock<Value>>) };
                 UnpackedValue::Cell(Cell(cell))
+            }
+            Tag::FixNum => {
+                UnpackedValue::Number(Number(NumberRepr::Fixed(raw as i64 >> 1)))
             }
         }
     }
@@ -631,28 +634,39 @@ impl From<Exception> for Value {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum Tag {
     Pair = 0,
-    Boolean = 1,
-    CharacterOrSymbol = 2,
-    Number = 3,
-    Procedure = 4,
-    Record = 5,
-    RecordTypeDescriptor = 6,
-    Cell = 7,
+    Boolean = 1 << 1,
+    CharacterOrSymbol = 2 << 1,
+    Number = 3 << 1,
+    Procedure = 4 << 1,
+    Record = 5 << 1,
+    RecordTypeDescriptor = 6 << 1,
+    Cell = 7 << 1,
+    FixNum = 1,
 }
 
 // TODO: Make TryFrom with error
 impl From<usize> for Tag {
     fn from(tag: usize) -> Self {
-        match tag {
-            0 => Self::Pair,
-            1 => Self::Boolean,
-            2 => Self::CharacterOrSymbol,
-            3 => Self::Number,
-            4 => Self::Procedure,
-            5 => Self::Record,
-            6 => Self::RecordTypeDescriptor,
-            7 => Self::Cell,
-            tag => panic!("Invalid tag: {tag}"),
+        if tag & 1 == 1 {
+            Self::FixNum
+        } else if tag == Self::Pair as usize {
+            Self::Pair
+        } else if tag == Self::Boolean as usize{
+            Self::Boolean 
+        } else if tag == Self::CharacterOrSymbol  as usize{
+            Self::CharacterOrSymbol
+        } else if tag == Self::Number  as usize{
+            Self::Number
+        } else if tag == Self::Procedure as usize {
+            Self::Procedure
+        } else if tag == Self::Record as usize{
+            Self::Record
+        } else if tag == Self::RecordTypeDescriptor as usize {
+            Self::RecordTypeDescriptor
+        } else if tag == Self::Cell as usize {
+            Self::Cell
+        } else {
+            panic!("Invalid tag: {tag}")
         }
     }
 }
@@ -709,7 +723,9 @@ impl UnpackedValue {
                     let untagged = Arc::into_raw(num);
                     Value::from_ptr_and_tag(untagged, Tag::Number)
                 }
-                _ => todo!(),
+                NumberRepr::Fixed(fixed) => {
+                    Value::from_ptr_and_tag((fixed << 1) as *const (), Tag::FixNum)
+                }
             },
             Self::Symbol(sym) => Value::from_ptr_and_tag(
                 (((sym.0 as usize) << 32) | (SYMBOL_CHAR as usize) << TAG_BITS) as *const (),

--- a/src/value.rs
+++ b/src/value.rs
@@ -90,7 +90,7 @@ use crate::{
     exceptions::Exception,
     gc::{Gc, GcInner, Trace},
     lists::{self, Pair, PairInner},
-    num::{ComplexNumber, Number, NumberInner, SimpleNumber},
+    num::{ComplexNumber, Number, NumberInner, NumberRepr, SimpleNumber},
     proc::{Procedure, ProcedureInner},
     records::{Embedded, Record, RecordInner, RecordTypeDescriptor},
     registry::bridge,
@@ -118,6 +118,8 @@ pub(crate) const SYMBOL_CHAR: u32 = 0x110000;
 pub(crate) const NULL_VALUE: usize = Tag::Pair as usize;
 pub(crate) const TRUE_VALUE: usize = Tag::Boolean as usize | 1 << TAG_BITS;
 pub(crate) const FALSE_VALUE: usize = Tag::Boolean as usize;
+pub const FIXNUM_MIN: i64 = -(1 << 62);
+pub const FIXNUM_MAX: i64 = (1 << 62) - 1;
 
 /// A Scheme value. See [the module documentation](scheme_rs::value) for more
 /// information.
@@ -250,7 +252,7 @@ impl Value {
     }
 
     /// Attempt to cast the value.
-    pub fn cast_to<T>(&self) -> Option<T>
+    pub fn cast<T>(&self) -> Option<T>
     where
         for<'a> &'a Self: Into<Option<T>>,
     {
@@ -295,7 +297,7 @@ impl Value {
             }
             Tag::Number => {
                 let number = unsafe { Arc::from_raw(untagged as *const NumberInner) };
-                UnpackedValue::Number(Number(number))
+                UnpackedValue::Number(Number(NumberRepr::Heap(number)))
             }
             Tag::Procedure => {
                 let clos = unsafe { Gc::from_raw(untagged as *mut GcInner<ProcedureInner>) };
@@ -413,7 +415,7 @@ impl Value {
             UnpackedValue::Null => (),
             UnpackedValue::Boolean(b) => b.hash(state),
             UnpackedValue::Character(c) => c.hash(state),
-            UnpackedValue::Number(n) => Arc::as_ptr(&n.0).hash(state),
+            UnpackedValue::Number(n) => n.eq_hash(state),
             UnpackedValue::Symbol(s) => s.hash(state),
             UnpackedValue::Procedure(c) => Gc::as_ptr(&c.0).hash(state),
             UnpackedValue::Record(r) => r.eq_hash(state),
@@ -628,28 +630,28 @@ impl From<Exception> for Value {
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum Tag {
-    Pair = 1,
-    Boolean = 2,
-    CharacterOrSymbol = 3,
-    Number = 4,
-    Procedure = 10,
-    Record = 11,
-    RecordTypeDescriptor = 12,
-    Cell = 15,
+    Pair = 0,
+    Boolean = 1,
+    CharacterOrSymbol = 2,
+    Number = 3,
+    Procedure = 4,
+    Record = 5,
+    RecordTypeDescriptor = 6,
+    Cell = 7,
 }
 
 // TODO: Make TryFrom with error
 impl From<usize> for Tag {
     fn from(tag: usize) -> Self {
         match tag {
-            1 => Self::Pair,
-            2 => Self::Boolean,
-            3 => Self::CharacterOrSymbol,
-            4 => Self::Number,
-            10 => Self::Procedure,
-            11 => Self::Record,
-            12 => Self::RecordTypeDescriptor,
-            15 => Self::Cell,
+            0 => Self::Pair,
+            1 => Self::Boolean,
+            2 => Self::CharacterOrSymbol,
+            3 => Self::Number,
+            4 => Self::Procedure,
+            5 => Self::Record,
+            6 => Self::RecordTypeDescriptor,
+            7 => Self::Cell,
             tag => panic!("Invalid tag: {tag}"),
         }
     }
@@ -698,16 +700,21 @@ impl UnpackedValue {
             Self::Boolean(b) => {
                 Value::from_ptr_and_tag(((b as usize) << TAG_BITS) as *const (), Tag::Boolean)
             }
-            Self::Character(c) => {
-                Value::from_ptr_and_tag(((c as usize) << TAG_BITS) as *const (), Tag::CharacterOrSymbol)
-            }
-            Self::Number(num) => {
-                let untagged = Arc::into_raw(num.0);
-                Value::from_ptr_and_tag(untagged, Tag::Number)
-            }
-            Self::Symbol(sym) => {
-                Value::from_ptr_and_tag((((sym.0 as usize) << 32) | (SYMBOL_CHAR as usize) << TAG_BITS) as *const (), Tag::CharacterOrSymbol)
-            }
+            Self::Character(c) => Value::from_ptr_and_tag(
+                ((c as usize) << TAG_BITS) as *const (),
+                Tag::CharacterOrSymbol,
+            ),
+            Self::Number(num) => match num.0 {
+                NumberRepr::Heap(num) => {
+                    let untagged = Arc::into_raw(num);
+                    Value::from_ptr_and_tag(untagged, Tag::Number)
+                }
+                _ => todo!(),
+            },
+            Self::Symbol(sym) => Value::from_ptr_and_tag(
+                (((sym.0 as usize) << 32) | (SYMBOL_CHAR as usize) << TAG_BITS) as *const (),
+                Tag::CharacterOrSymbol,
+            ),
             Self::Procedure(clos) => {
                 let untagged = Gc::into_raw(clos.0);
                 Value::from_mut_ptr_and_tag(untagged, Tag::Procedure)
@@ -736,7 +743,7 @@ impl UnpackedValue {
         match (self, rhs) {
             (Self::Boolean(a), Self::Boolean(b)) => a == b,
             (Self::Symbol(a), Self::Symbol(b)) => a == b,
-            (Self::Number(a), Self::Number(b)) => Arc::ptr_eq(&a.0, &b.0),
+            (Self::Number(a), Self::Number(b)) => a.eq(b),
             (Self::Character(a), Self::Character(b)) => a == b,
             (Self::Null, Self::Null) => true,
             (Self::Pair(a), Self::Pair(b)) => Gc::ptr_eq(&a.0, &b.0),
@@ -837,7 +844,7 @@ fn fast(ht: &mut HashMap<Value, Value>, obj1: &Value, obj2: &Value, k: i64) -> O
     }
     match (obj1.type_of(), obj2.type_of()) {
         (ValueType::Pair, ValueType::Pair) => pair_eq(ht, obj1, obj2, k),
-        (ValueType::Record, ValueType::Record) => record_equal(ht, obj1.cast_to()?, obj2.cast_to()?, k),
+        (ValueType::Record, ValueType::Record) => record_equal(ht, obj1.cast()?, obj2.cast()?, k),
         _ => None,
     }
 }
@@ -858,7 +865,7 @@ fn slow(ht: &mut HashMap<Value, Value>, obj1: &Value, obj2: &Value, k: i64) -> O
             if union_find(ht, obj1, obj2) {
                 Some(0)
             } else {
-                record_equal(ht, obj1.cast_to()?, obj2.cast_to()?, k)
+                record_equal(ht, obj1.cast()?, obj2.cast()?, k)
             }
         }
         _ => None,
@@ -873,7 +880,12 @@ fn pair_eq(ht: &mut HashMap<Value, Value>, obj1: &Value, obj2: &Value, k: i64) -
     e(ht, &car_x, &car_y, k - 1).and_then(|k| e(ht, &cdr_x, &cdr_y, k))
 }
 
-fn vector_eq(ht: &mut HashMap<Value, Value>, vobj1: Embedded<VectorInner<Value>>, vobj2: Embedded<VectorInner<Value>>, k: i64) -> Option<i64> {
+fn vector_eq(
+    ht: &mut HashMap<Value, Value>,
+    vobj1: Embedded<VectorInner<Value>>,
+    vobj2: Embedded<VectorInner<Value>>,
+    k: i64,
+) -> Option<i64> {
     let vobj1 = vobj1.vec.read();
     let vobj2 = vobj2.vec.read();
     if vobj1.len() != vobj2.len() {
@@ -896,7 +908,8 @@ fn bytevector_eq(obj1: &Value, obj2: &Value, k: i64) -> Option<i64> {
 
 fn record_equal(ht: &mut HashMap<Value, Value>, obj1: Record, obj2: Record, k: i64) -> Option<i64> {
     if let Some(vobj1) = obj1.cast::<VectorInner<Value>>() {
-        obj2.cast::<VectorInner<Value>>().map_or(None, |vobj2| vector_eq(ht, vobj1, vobj2, k))
+        obj2.cast::<VectorInner<Value>>()
+            .map_or(None, |vobj2| vector_eq(ht, vobj1, vobj2, k))
     } else {
         /*
         let obj1: Record = obj1.clone().try_into().unwrap();

--- a/src/value.rs
+++ b/src/value.rs
@@ -37,8 +37,8 @@
 //! ```
 //! # use scheme_rs::value::{Value, UnpackedValue};
 //! let value = Value::from(3);
-//! let float = value.cast_to::<f64>().unwrap();
-//! let int = value.cast_to::<i64>().unwrap();
+//! let float = value.cast::<f64>().unwrap();
+//! let int = value.cast::<i64>().unwrap();
 //! ```
 //!
 //! ## Converting to and from arbitrary Rust types
@@ -70,17 +70,17 @@
 //! - **Boolean**: Can either be `true` or `false`.
 //! - **Character**: A unicode code point. Same thing as a [`char`](std::char).
 //! - **Number**: A numerical value on the numerical tower. Represented by a
-//!   [`Arc<Number>`](crate::num::Number).
-//! - **String**: An array of [`chars`](std::char).
+//!   [`Number`](crate::num::Number).
 //! - **Symbol**: A [`Symbol`].
-//! - **Vector**: A [`Vector`].
-//! - **Syntax**: A [`Syntax`].
 //! - **Procedure**: A [`Procedure`].
 //! - **Record**: A [`Record`], which can possibly embed an
 //!   [`Embeddable`](records::Embeddable) Rust value.
 //! - **Record Type Descriptor**: A [descriptor of a record's type](RecordTypeDescriptor).
 //! - **Cell**: A mutable reference to another Value. This type is completely
 //!   transparent and impossible to observe.
+//!
+//! Any type that is not one of these can be stored in a Value, but they are
+//! considered to be [`Records`](records::Record).
 
 use indexmap::{IndexMap, IndexSet};
 use malachite::Integer;
@@ -96,8 +96,8 @@ use crate::{
     registry::bridge,
     strings::WideString,
     symbols::Symbol,
-    syntax::{Identifier, Syntax},
-    vectors::{self, ByteVector, Vector, VectorInner},
+    syntax::Syntax,
+    vectors::VectorInner,
 };
 use std::{
     collections::HashMap,
@@ -912,23 +912,11 @@ fn vector_eq(
     Some(k)
 }
 
-/*
-fn bytevector_eq(obj1: &Value, obj2: &Value, k: i64) -> Option<i64> {
-    let obj1: ByteVector = obj1.clone().try_into().unwrap();
-    let obj2: ByteVector = obj2.clone().try_into().unwrap();
-    (*obj1.0.vec.read() == *obj2.0.vec.read()).then_some(k)
-}
-*/
-
 fn record_equal(ht: &mut HashMap<Value, Value>, obj1: Record, obj2: Record, k: i64) -> Option<i64> {
     if let Some(vobj1) = obj1.cast::<VectorInner<Value>>() {
         obj2.cast::<VectorInner<Value>>()
-            .map_or(None, |vobj2| vector_eq(ht, vobj1, vobj2, k))
+            .and_then(|vobj2| vector_eq(ht, vobj1, vobj2, k))
     } else {
-        /*
-        let obj1: Record = obj1.clone().try_into().unwrap();
-        let obj2: Record = obj2.clone().try_into().unwrap();
-        */
         (obj1.equal(&obj2)).then_some(k)
     }
 }
@@ -1130,7 +1118,7 @@ impl TryFrom<UnpackedValue> for Cell {
     fn try_from(v: UnpackedValue) -> Result<Self, Self::Error> {
         match v {
             UnpackedValue::Cell(cell) => Ok(cell.clone()),
-            e => Err(Exception::type_error("cell", &*e.type_name())),
+            e => Err(Exception::type_error("cell", &e.type_name())),
         }
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -615,19 +615,6 @@ impl From<Exception> for Value {
     }
 }
 
-/*
-
-1: Symbol,
-2: Pair,
-3: Boolean,
-4: Character,
-5: Number,
-6: Procedure,
-7: Record,
-8: Cell,
-
-*/
-
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum Tag {

--- a/src/value.rs
+++ b/src/value.rs
@@ -95,7 +95,7 @@ use crate::{
     proc::{Procedure, ProcedureInner},
     records::{Record, RecordInner, RecordTypeDescriptor},
     registry::bridge,
-    strings::{WideString, WideStringInner},
+    strings::WideString,
     symbols::Symbol,
     syntax::{Identifier, Syntax},
     vectors::{self, ByteVector, Vector, VectorInner},
@@ -166,7 +166,6 @@ impl Value {
         unsafe {
             match tag {
                 Tag::Number => Arc::increment_strong_count(untagged as *const NumberInner),
-                Tag::String => Arc::increment_strong_count(untagged as *const WideStringInner),
                 Tag::Vector => {
                     Gc::increment_reference_count(untagged as *mut GcInner<VectorInner<Value>>)
                 }
@@ -247,7 +246,7 @@ impl Value {
         self.unpacked_ref().type_of()
     }
 
-    pub fn type_name(&self) -> &'static str {
+    pub fn type_name(&self) -> Arc<str> {
         self.unpacked_ref().type_name()
     }
 
@@ -292,10 +291,6 @@ impl Value {
             Tag::Number => {
                 let number = unsafe { Arc::from_raw(untagged as *const NumberInner) };
                 UnpackedValue::Number(Number(number))
-            }
-            Tag::String => {
-                let str = unsafe { Arc::from_raw(untagged as *const WideStringInner) };
-                UnpackedValue::String(WideString(str))
             }
             Tag::Symbol => {
                 let untagged = (untagged as usize >> TAG_BITS) as u32;
@@ -378,12 +373,11 @@ impl Value {
             UnpackedValue::Boolean(b) => b.hash(state),
             UnpackedValue::Character(c) => c.hash(state),
             UnpackedValue::Number(n) => Arc::as_ptr(&n.0).hash(state),
-            UnpackedValue::String(s) => Arc::as_ptr(&s.0).hash(state),
             UnpackedValue::Symbol(s) => s.hash(state),
             UnpackedValue::ByteVector(v) => Arc::as_ptr(&v.0).hash(state),
             UnpackedValue::Syntax(s) => Gc::as_ptr(s).hash(state),
             UnpackedValue::Procedure(c) => Gc::as_ptr(&c.0).hash(state),
-            UnpackedValue::Record(r) => Gc::as_ptr(&r.0).hash(state),
+            UnpackedValue::Record(r) => r.eq_hash(state),
             UnpackedValue::RecordTypeDescriptor(rt) => Arc::as_ptr(rt).hash(state),
             UnpackedValue::Pair(p) => Gc::as_ptr(&p.0).hash(state),
             UnpackedValue::Vector(v) => Gc::as_ptr(&v.0).hash(state),
@@ -401,12 +395,11 @@ impl Value {
             UnpackedValue::Boolean(b) => b.hash(state),
             UnpackedValue::Character(c) => c.hash(state),
             UnpackedValue::Number(n) => n.hash(state),
-            UnpackedValue::String(s) => Arc::as_ptr(&s.0).hash(state),
             UnpackedValue::Symbol(s) => s.hash(state),
             UnpackedValue::ByteVector(v) => Arc::as_ptr(&v.0).hash(state),
             UnpackedValue::Syntax(s) => Gc::as_ptr(s).hash(state),
             UnpackedValue::Procedure(c) => Gc::as_ptr(&c.0).hash(state),
-            UnpackedValue::Record(r) => Gc::as_ptr(&r.0).hash(state),
+            UnpackedValue::Record(r) => r.eqv_hash(state),
             UnpackedValue::RecordTypeDescriptor(rt) => Arc::as_ptr(rt).hash(state),
             UnpackedValue::Pair(p) => Gc::as_ptr(&p.0).hash(state),
             UnpackedValue::Vector(v) => Gc::as_ptr(&v.0).hash(state),
@@ -432,12 +425,11 @@ impl Value {
             UnpackedValue::Boolean(b) => b.hash(state),
             UnpackedValue::Character(c) => c.hash(state),
             UnpackedValue::Number(n) => n.hash(state),
-            UnpackedValue::String(s) => s.hash(state),
             UnpackedValue::Symbol(s) => s.hash(state),
             UnpackedValue::ByteVector(v) => v.hash(state),
             UnpackedValue::Syntax(s) => Gc::as_ptr(s).hash(state),
             UnpackedValue::Procedure(c) => Gc::as_ptr(&c.0).hash(state),
-            UnpackedValue::Record(r) => Gc::as_ptr(&r.0).hash(state),
+            UnpackedValue::Record(r) => r.equal_hash(state),
             UnpackedValue::RecordTypeDescriptor(rt) => Arc::as_ptr(rt).hash(state),
             UnpackedValue::Pair(p) => {
                 recursive.insert(self.clone());
@@ -613,7 +605,6 @@ pub(crate) enum Tag {
     Boolean = 2,
     Character = 3,
     Number = 4,
-    String = 5,
     Symbol = 6,
     Vector = 7,
     ByteVector = 8,
@@ -633,7 +624,6 @@ impl From<usize> for Tag {
             2 => Self::Boolean,
             3 => Self::Character,
             4 => Self::Number,
-            5 => Self::String,
             6 => Self::Symbol,
             7 => Self::Vector,
             8 => Self::ByteVector,
@@ -656,7 +646,6 @@ pub enum ValueType {
     Boolean,
     Character,
     Number,
-    String,
     Symbol,
     Vector,
     ByteVector,
@@ -678,7 +667,6 @@ pub enum UnpackedValue {
     Boolean(bool),
     Character(char),
     Number(Number),
-    String(WideString),
     Symbol(Symbol),
     Vector(Vector),
     ByteVector(ByteVector),
@@ -704,10 +692,6 @@ impl UnpackedValue {
             Self::Number(num) => {
                 let untagged = Arc::into_raw(num.0);
                 Value::from_ptr_and_tag(untagged, Tag::Number)
-            }
-            Self::String(str) => {
-                let untagged = Arc::into_raw(str.0);
-                Value::from_ptr_and_tag(untagged, Tag::String)
             }
             Self::Symbol(sym) => {
                 Value::from_ptr_and_tag(((sym.0 as usize) << TAG_BITS) as *const (), Tag::Symbol)
@@ -755,13 +739,12 @@ impl UnpackedValue {
             (Self::Number(a), Self::Number(b)) => Arc::ptr_eq(&a.0, &b.0),
             (Self::Character(a), Self::Character(b)) => a == b,
             (Self::Null, Self::Null) => true,
-            (Self::String(a), Self::String(b)) => Arc::ptr_eq(&a.0, &b.0),
             (Self::Pair(a), Self::Pair(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::Vector(a), Self::Vector(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::ByteVector(a), Self::ByteVector(b)) => Arc::ptr_eq(&a.0, &b.0),
             (Self::Procedure(a), Self::Procedure(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::Syntax(a), Self::Syntax(b)) => Gc::ptr_eq(a, b),
-            (Self::Record(a), Self::Record(b)) => Gc::ptr_eq(&a.0, &b.0),
+            (Self::Record(a), Self::Record(b)) => a.eq(b),
             (Self::RecordTypeDescriptor(a), Self::RecordTypeDescriptor(b)) => Arc::ptr_eq(a, b),
             (Self::Cell(a), b) => a.0.read().unpacked_ref().eq(b),
             (a, Self::Cell(b)) => a.eq(&b.0.read().unpacked_ref()),
@@ -784,13 +767,12 @@ impl UnpackedValue {
             // Both obj1 and obj2 are the empty list
             (Self::Null, Self::Null) => true,
             // Everything else is pointer equivalence
-            (Self::String(a), Self::String(b)) => Arc::ptr_eq(&a.0, &b.0),
             (Self::Pair(a), Self::Pair(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::Vector(a), Self::Vector(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::ByteVector(a), Self::ByteVector(b)) => Arc::ptr_eq(&a.0, &b.0),
             (Self::Procedure(a), Self::Procedure(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::Syntax(a), Self::Syntax(b)) => Gc::ptr_eq(a, b),
-            (Self::Record(a), Self::Record(b)) => Gc::ptr_eq(&a.0, &b.0),
+            (Self::Record(a), Self::Record(b)) => a.eqv(b),
             (Self::RecordTypeDescriptor(a), Self::RecordTypeDescriptor(b)) => Arc::ptr_eq(a, b),
             (Self::Cell(a), b) => a.0.read().unpacked_ref().eqv(b),
             (a, Self::Cell(b)) => a.eqv(&b.0.read().unpacked_ref()),
@@ -798,21 +780,20 @@ impl UnpackedValue {
         }
     }
 
-    pub fn type_name(&self) -> &'static str {
+    pub fn type_name(&self) -> Arc<str> {
         match self {
-            Self::Undefined => "undefined",
-            Self::Boolean(_) => "bool",
-            Self::Number(_) => "number",
-            Self::Character(_) => "character",
-            Self::String(_) => "string",
-            Self::Symbol(_) => "symbol",
-            Self::Pair(_) | Self::Null => "pair",
-            Self::Vector(_) => "vector",
-            Self::ByteVector(_) => "byte vector",
-            Self::Syntax(_) => "syntax",
-            Self::Procedure(_) => "procedure",
-            Self::Record(_) => "record",
-            Self::RecordTypeDescriptor(_) => "rtd",
+            Self::Undefined => Symbol::intern("undefined").to_str(),
+            Self::Boolean(_) => Symbol::intern("bool").to_str(),
+            Self::Number(_) => Symbol::intern("number").to_str(),
+            Self::Character(_) => Symbol::intern("character").to_str(),
+            Self::Symbol(_) => Symbol::intern("symbol").to_str(),
+            Self::Pair(_) | Self::Null => Symbol::intern("pair").to_str(),
+            Self::Vector(_) => Symbol::intern("vector").to_str(),
+            Self::ByteVector(_) => Symbol::intern("bytevector").to_str(),
+            Self::Syntax(_) => Symbol::intern("syntax").to_str(),
+            Self::Procedure(_) => Symbol::intern("procedure").to_str(),
+            Self::Record(record) => record.rtd().name.to_str(),
+            Self::RecordTypeDescriptor(_) => Symbol::intern("rtd").to_str(),
             Self::Cell(cell) => cell.0.read().type_name(),
         }
     }
@@ -824,7 +805,6 @@ impl UnpackedValue {
             Self::Boolean(_) => ValueType::Boolean,
             Self::Number(_) => ValueType::Number,
             Self::Character(_) => ValueType::Character,
-            Self::String(_) => ValueType::String,
             Self::Symbol(_) => ValueType::Symbol,
             Self::Pair(_) => ValueType::Pair,
             Self::Vector(_) => ValueType::Vector,
@@ -871,7 +851,7 @@ fn fast(ht: &mut HashMap<Value, Value>, obj1: &Value, obj2: &Value, k: i64) -> O
         (ValueType::Pair, ValueType::Pair) => pair_eq(ht, obj1, obj2, k),
         (ValueType::Vector, ValueType::Vector) => vector_eq(ht, obj1, obj2, k),
         (ValueType::ByteVector, ValueType::ByteVector) => bytevector_eq(obj1, obj2, k),
-        (ValueType::String, ValueType::String) => string_eq(obj1, obj2, k),
+        (ValueType::Record, ValueType::Record) => record_equal(obj1, obj2, k),
         _ => None,
     }
 }
@@ -894,7 +874,7 @@ fn slow(ht: &mut HashMap<Value, Value>, obj1: &Value, obj2: &Value, k: i64) -> O
             vector_eq(ht, obj1, obj2, k)
         }
         (ValueType::ByteVector, ValueType::ByteVector) => bytevector_eq(obj1, obj2, k),
-        (ValueType::String, ValueType::String) => string_eq(obj1, obj2, k),
+        (ValueType::Record, ValueType::Record) => record_equal(obj1, obj2, k),
         _ => None,
     }
 }
@@ -928,10 +908,10 @@ fn bytevector_eq(obj1: &Value, obj2: &Value, k: i64) -> Option<i64> {
     (*obj1.0.vec.read() == *obj2.0.vec.read()).then_some(k)
 }
 
-fn string_eq(obj1: &Value, obj2: &Value, k: i64) -> Option<i64> {
-    let obj1: WideString = obj1.clone().try_into().unwrap();
-    let obj2: WideString = obj2.clone().try_into().unwrap();
-    (obj1 == obj2).then_some(k)
+fn record_equal(obj1: &Value, obj2: &Value, k: i64) -> Option<i64> {
+    let obj1: Record = obj1.clone().try_into().unwrap();
+    let obj2: Record = obj2.clone().try_into().unwrap();
+    (obj1.equal(&obj2)).then_some(k)
 }
 
 fn union_find(ht: &mut HashMap<Value, Value>, x: &Value, y: &Value) -> bool {
@@ -1053,7 +1033,7 @@ macro_rules! impl_try_from_value_for {
                 match v {
                     UnpackedValue::$variant(v) => Ok(v),
                     UnpackedValue::Cell(cell) => cell.0.read().clone().try_into(),
-                    e => Err(Exception::type_error($type_name, e.type_name())),
+                    e => Err(Exception::type_error($type_name, &*e.type_name())),
                 }
             }
         }
@@ -1100,7 +1080,7 @@ impl TryFrom<UnpackedValue> for () {
     fn try_from(value: UnpackedValue) -> Result<Self, Self::Error> {
         match value {
             UnpackedValue::Null => Ok(()),
-            e => Err(Exception::type_error("null", e.type_name())),
+            e => Err(Exception::type_error("null", &e.type_name())),
         }
     }
 }
@@ -1131,7 +1111,7 @@ impl TryFrom<UnpackedValue> for Cell {
     fn try_from(v: UnpackedValue) -> Result<Self, Self::Error> {
         match v {
             UnpackedValue::Cell(cell) => Ok(cell.clone()),
-            e => Err(Exception::type_error("cell", e.type_name())),
+            e => Err(Exception::type_error("cell", &*e.type_name())),
         }
     }
 }
@@ -1174,7 +1154,6 @@ impl From<bool> for Value {
 
 impl_try_from_value_for!(char, Character, "char");
 impl_try_from_value_for!(Number, Number, "number");
-impl_try_from_value_for!(WideString, String, "string");
 impl_try_from_value_for!(Symbol, Symbol, "symbol");
 impl_try_from_value_for!(Vector, Vector, "vector");
 impl_try_from_value_for!(ByteVector, ByteVector, "byte-vector");
@@ -1200,7 +1179,6 @@ macro_rules! impl_from_wrapped_for {
     };
 }
 
-impl_from_wrapped_for!(String, String, WideString::immutable);
 impl_from_wrapped_for!(Vec<Value>, Vector, Vector::immutable);
 impl_from_wrapped_for!(Vec<u8>, ByteVector, ByteVector::immutable);
 impl_from_wrapped_for!(Syntax, Syntax, Gc::new);
@@ -1221,7 +1199,7 @@ impl TryFrom<UnpackedValue> for (Value, Value) {
     fn try_from(val: UnpackedValue) -> Result<Self, Self::Error> {
         match val {
             UnpackedValue::Pair(pair) => Ok(pair.into()),
-            e => Err(Exception::type_error("pair", e.type_name())),
+            e => Err(Exception::type_error("pair", &e.type_name())),
         }
     }
 }
@@ -1235,7 +1213,7 @@ macro_rules! impl_num_conversion {
             fn try_from(value: &Value) -> Result<$ty, Self::Error> {
                 match &*value.unpacked_ref() {
                     UnpackedValue::Number(num) => num.try_into(),
-                    e => Err(Exception::type_error("number", e.type_name())),
+                    e => Err(Exception::type_error("number", &e.type_name())),
                 }
             }
         }
@@ -1309,7 +1287,7 @@ impl TryFrom<&Value> for Identifier {
     fn try_from(value: &Value) -> Result<Self, Self::Error> {
         match Option::<Identifier>::from(value) {
             Some(ident) => Ok(ident),
-            None => Err(Exception::type_error("identifier", value.type_name())),
+            None => Err(Exception::type_error("identifier", &value.type_name())),
         }
     }
 }
@@ -1458,7 +1436,6 @@ fn display_value(
         UnpackedValue::Boolean(false) => write!(f, "#f"),
         UnpackedValue::Number(number) => write!(f, "{number}"),
         UnpackedValue::Character(c) => write!(f, "#\\{c}"),
-        UnpackedValue::String(string) => write!(f, "{string}"),
         UnpackedValue::Symbol(symbol) => write!(f, "{symbol}"),
         UnpackedValue::Pair(pair) => {
             let (car, cdr) = pair.into();
@@ -1486,7 +1463,6 @@ fn debug_value(
         UnpackedValue::Boolean(false) => write!(f, "#f"),
         UnpackedValue::Number(number) => write!(f, "{number}"),
         UnpackedValue::Character(c) => write!(f, "#\\{c}"),
-        UnpackedValue::String(string) => write!(f, "{string:?}"),
         UnpackedValue::Symbol(symbol) => write!(f, "{symbol}"),
         UnpackedValue::Pair(pair) => {
             let (car, cdr) = pair.into();

--- a/src/value.rs
+++ b/src/value.rs
@@ -29,34 +29,34 @@
 //! It is generally preferrable to use `try_into` as opposed to `unpack` since
 //! `UnpackedValue` is an enumeration that is subject to change.
 //!
-//! Alternatively, the [`cast_to_scheme_type`](Value::cast_to_scheme_type)
+//! Alternatively, the [`cast_to`](Value::cast_to)
 //! method can be used to obtain an Option from a reference for more ergonomic
-//! casting. There is also the [`try_to_scheme_type`](Value::try_to_scheme_type)
+//! casting. There is also the [`try_to`](Value::try_to)
 //! function that is similarly more ergonomic:
 //!
 //! ```
 //! # use scheme_rs::value::{Value, UnpackedValue};
 //! let value = Value::from(3);
-//! let float = value.cast_to_scheme_type::<f64>().unwrap();
-//! let int = value.cast_to_scheme_type::<i64>().unwrap();
+//! let float = value.cast_to::<f64>().unwrap();
+//! let int = value.cast_to::<i64>().unwrap();
 //! ```
 //!
 //! ## Converting to and from arbitrary Rust types
 //!
 //! Besides primitives and standard library types, scheme-rs supports converting
-//! arbitrary Rust types (such as structs and enums) to `Values` by representing
-//! them as [`Records`](Record). To do this, the type must implement the
-//! [`SchemeCompatible`] trait (see [`records`](scheme_rs::records) for more
-//! information).
+//! arbitrary Rust types (such as structs and enums) to `Values` by embedding
+//! them inside [`Records`](Record). To do this, the type must implement the
+//! [`Embeddable`](records::Embeddable) trait (see [`records`](scheme_rs::records)
+//! for more information).
 //!
-//! `Value` provides three convenience methods to facilitate these conversions:
-//! - [`from_rust_type`](Value::from_rust_type): convert a `SchemeCompatible`
-//!   type to a record type, and then to a `Value`.
-//! - [`try_to_rust_type`](Value::try_to_rust_type): attempt to convert the
-//!   value to a `Gc<T>` where `T: SchemeCompatible` providing a detailed error
-//!   on failure.
-//! - [`cast_to_rust_type`](Value::cast_to_rust_type): attempt to convert the
-//!   value to a `Gc<T>` where `T: SchemeCompatible`, returning `None` on
+//! These conversions are performed with the standard conversion traits:
+//! - `Value::from(t)`: embed an [`Embeddable`](records::Embeddable) value into a
+//!   record, and then convert it to a `Value`.
+//! - [`try_to`](Value::try_to)`::<Embedded<T>>()`: attempt to convert the value
+//!   to an [`Embedded<T>`](records::Embedded), providing a detailed error on
+//!   failure.
+//! - [`cast_to`](Value::cast_to)`::<Embedded<T>>()`: attempt to convert the
+//!   value to an [`Embedded<T>`](records::Embedded), returning `None` on
 //!   failure.
 //!
 //! ## Scheme types
@@ -77,7 +77,8 @@
 //! - **Byte-vector**: A [`ByteVector`].
 //! - **Syntax**: A [`Syntax`].
 //! - **Procedure**: A [`Procedure`].
-//! - **Record**: A [`Record`], which can possibly be a [`SchemeCompatible`].
+//! - **Record**: A [`Record`], which can possibly embed an
+//!   [`Embeddable`](records::Embeddable) Rust value.
 //! - **Record Type Descriptor**: A [descriptor of a record's type](RecordTypeDescriptor).
 //! - **Hashtable**: A [`HashTable`].
 //! - **Port**: A value that can handle [input/output](scheme_rs::ports::Port)
@@ -97,7 +98,7 @@ use crate::{
     num::{ComplexNumber, Number, NumberInner, SimpleNumber},
     ports::{Port, PortInner},
     proc::{Procedure, ProcedureInner},
-    records::{Record, RecordInner, RecordTypeDescriptor, SchemeCompatible},
+    records::{Record, RecordInner, RecordTypeDescriptor},
     registry::bridge,
     strings::{WideString, WideStringInner},
     symbols::Symbol,
@@ -259,23 +260,33 @@ impl Value {
         self.unpacked_ref().type_name()
     }
 
+    // TODO: These will be cast_to and try_to
+
     /// Attempt to cast the value into a Scheme primitive type.
-    pub fn cast_to_scheme_type<T>(&self) -> Option<T>
+    pub fn cast_to<T>(&self) -> Option<T>
     where
         for<'a> &'a Self: Into<Option<T>>,
     {
         self.into()
     }
 
+    pub fn is_a<T>(&self) -> bool
+    where
+        for<'a> &'a Self: Into<Option<T>>,
+    {
+        self.into().is_some()
+    }
+
     /// Attempt to cast the value into a Scheme primitive type and return a
     /// descriptive error on failure.
-    pub fn try_to_scheme_type<T>(&self) -> Result<T, Exception>
+    pub fn try_to<T>(&self) -> Result<T, Exception>
     where
         T: for<'a> TryFrom<&'a Self, Error = Exception>,
     {
         self.try_into()
     }
 
+    /*
     /// Attempt to cast the value into a Rust type that implements
     /// [`SchemeCompatible`].
     pub fn cast_to_rust_type<T: SchemeCompatible>(&self) -> Option<Gc<T>> {
@@ -287,7 +298,7 @@ impl Value {
 
     /// Attempt to cast the value into a Rust type and return a descriptive
     /// error on failure.
-    pub fn try_to_rust_type<T: SchemeCompatible>(&self) -> Result<Gc<T>, Exception> {
+    pub fn try_to_rust_type<T: Embeddable>(&self) -> Result<Gc<T>, Exception> {
         let type_name = T::rtd().name.to_str();
         let this = self.clone().unpack();
         let record = match this {
@@ -299,12 +310,16 @@ impl Value {
             .cast::<T>()
             .ok_or_else(|| Exception::type_error(&type_name, &record.rtd().name.to_str()))
     }
+    */
 
+    /*
     /// Automatically convert a `SchemeCompatible` type to a `Record` and then
     /// into a `Value`.
-    pub fn from_rust_type<T: SchemeCompatible>(t: T) -> Self {
-        Self::from(Record::from_rust_type(t))
+    pub fn embed<T: Embeddable>(t: T) -> Self {
+        // Self::from(Record::from_rust_type(t))
+        todo!()
     }
+    */
 
     /// Unpack the value into an enum representation.
     pub fn unpack(self) -> UnpackedValue {
@@ -588,6 +603,15 @@ impl Cell {
     }
 }
 
+impl From<&Value> for Option<Cell> {
+    fn from(val: &Value) -> Option<Cell> {
+        match val.clone().unpack() {
+            UnpackedValue::Cell(cell) => Some(cell),
+            _ => None,
+        }
+    }
+}
+
 /// A reference to an [`UnpackedValue`]. Allows for unpacking a `Value` without
 /// cloning/modifying the reference count.
 pub struct UnpackedValueRef<'a> {
@@ -623,19 +647,24 @@ where
     }
 }
 
-/*
-impl From<ast::Literal> for Value {
-    fn from(lit: ast::Literal) -> Self {
-        Value::new(lit.into())
-    }
-}
-*/
-
 impl From<Exception> for Value {
     fn from(value: Exception) -> Self {
         value.0
     }
 }
+
+/*
+
+1: Symbol,
+2: Pair,
+3: Boolean,
+4: Character,
+5: Number,
+6: Procedure,
+7: Record,
+8: Cell,
+
+*/
 
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/value.rs
+++ b/src/value.rs
@@ -170,11 +170,14 @@ impl Value {
                     Gc::increment_reference_count(untagged as *mut GcInner<VectorInner<Value>>)
                 }
                 Tag::ByteVector => Arc::increment_strong_count(untagged as *const VectorInner<u8>),
-                Tag::Syntax => Gc::increment_reference_count(untagged as *mut GcInner<Syntax>),
                 Tag::Procedure => {
                     Gc::increment_reference_count(untagged as *mut GcInner<ProcedureInner>)
                 }
-                Tag::Record => Gc::increment_reference_count(untagged as *mut GcInner<RecordInner>),
+                Tag::Record => {
+                    if !untagged.is_null() {
+                        Gc::increment_reference_count(untagged as *mut GcInner<RecordInner>)
+                    }
+                }
                 Tag::RecordTypeDescriptor => {
                     Arc::increment_strong_count(untagged as *const RecordTypeDescriptor)
                 }
@@ -186,7 +189,7 @@ impl Value {
                 Tag::Cell => {
                     Gc::increment_reference_count(untagged as *mut GcInner<Value>);
                 }
-                Tag::Undefined | Tag::Symbol | Tag::Boolean | Tag::Character => (),
+                Tag::Symbol | Tag::Boolean | Tag::Character => (),
             }
         }
         Self(raw)
@@ -214,7 +217,7 @@ impl Value {
     }
 
     pub fn undefined() -> Self {
-        Self(null::<()>().map_addr(|raw| raw | Tag::Undefined as usize))
+        Self(null::<()>().map_addr(|raw| raw | Tag::Record as usize))
     }
 
     pub fn null() -> Self {
@@ -279,7 +282,7 @@ impl Value {
         let tag = Tag::from(raw as usize & TAG);
         let untagged = raw.map_addr(|raw| raw & !TAG);
         match tag {
-            Tag::Undefined => UnpackedValue::Undefined,
+            // Tag::Undefined => UnpackedValue::Undefined,
             Tag::Boolean => {
                 let untagged = untagged as usize >> TAG_BITS;
                 UnpackedValue::Boolean(untagged != 0)
@@ -304,17 +307,23 @@ impl Value {
                 let bvec = unsafe { Arc::from_raw(untagged as *const VectorInner<u8>) };
                 UnpackedValue::ByteVector(ByteVector(bvec))
             }
+            /*
             Tag::Syntax => {
                 let syn = unsafe { Gc::from_raw(untagged as *mut GcInner<Syntax>) };
                 UnpackedValue::Syntax(syn)
             }
+            */
             Tag::Procedure => {
                 let clos = unsafe { Gc::from_raw(untagged as *mut GcInner<ProcedureInner>) };
                 UnpackedValue::Procedure(Procedure(clos))
             }
             Tag::Record => {
-                let rec = unsafe { Gc::from_raw(untagged as *mut GcInner<RecordInner>) };
-                UnpackedValue::Record(Record(rec))
+                if untagged.is_null() {
+                    UnpackedValue::Undefined
+                } else {
+                    let rec = unsafe { Gc::from_raw(untagged as *mut GcInner<RecordInner>) };
+                    UnpackedValue::Record(Record(rec))
+                }
             }
             Tag::RecordTypeDescriptor => {
                 let rt = unsafe { Arc::from_raw(untagged as *const RecordTypeDescriptor) };
@@ -375,7 +384,6 @@ impl Value {
             UnpackedValue::Number(n) => Arc::as_ptr(&n.0).hash(state),
             UnpackedValue::Symbol(s) => s.hash(state),
             UnpackedValue::ByteVector(v) => Arc::as_ptr(&v.0).hash(state),
-            UnpackedValue::Syntax(s) => Gc::as_ptr(s).hash(state),
             UnpackedValue::Procedure(c) => Gc::as_ptr(&c.0).hash(state),
             UnpackedValue::Record(r) => r.eq_hash(state),
             UnpackedValue::RecordTypeDescriptor(rt) => Arc::as_ptr(rt).hash(state),
@@ -397,7 +405,6 @@ impl Value {
             UnpackedValue::Number(n) => n.hash(state),
             UnpackedValue::Symbol(s) => s.hash(state),
             UnpackedValue::ByteVector(v) => Arc::as_ptr(&v.0).hash(state),
-            UnpackedValue::Syntax(s) => Gc::as_ptr(s).hash(state),
             UnpackedValue::Procedure(c) => Gc::as_ptr(&c.0).hash(state),
             UnpackedValue::Record(r) => r.eqv_hash(state),
             UnpackedValue::RecordTypeDescriptor(rt) => Arc::as_ptr(rt).hash(state),
@@ -427,7 +434,6 @@ impl Value {
             UnpackedValue::Number(n) => n.hash(state),
             UnpackedValue::Symbol(s) => s.hash(state),
             UnpackedValue::ByteVector(v) => v.hash(state),
-            UnpackedValue::Syntax(s) => Gc::as_ptr(s).hash(state),
             UnpackedValue::Procedure(c) => Gc::as_ptr(&c.0).hash(state),
             UnpackedValue::Record(r) => r.equal_hash(state),
             UnpackedValue::RecordTypeDescriptor(rt) => Arc::as_ptr(rt).hash(state),
@@ -600,7 +606,6 @@ impl From<Exception> for Value {
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum Tag {
-    Undefined = 0,
     Pair = 1,
     Boolean = 2,
     Character = 3,
@@ -608,7 +613,6 @@ pub(crate) enum Tag {
     Symbol = 6,
     Vector = 7,
     ByteVector = 8,
-    Syntax = 9,
     Procedure = 10,
     Record = 11,
     RecordTypeDescriptor = 12,
@@ -619,7 +623,6 @@ pub(crate) enum Tag {
 impl From<usize> for Tag {
     fn from(tag: usize) -> Self {
         match tag {
-            0 => Self::Undefined,
             1 => Self::Pair,
             2 => Self::Boolean,
             3 => Self::Character,
@@ -627,7 +630,6 @@ impl From<usize> for Tag {
             6 => Self::Symbol,
             7 => Self::Vector,
             8 => Self::ByteVector,
-            9 => Self::Syntax,
             10 => Self::Procedure,
             11 => Self::Record,
             12 => Self::RecordTypeDescriptor,
@@ -649,7 +651,6 @@ pub enum ValueType {
     Symbol,
     Vector,
     ByteVector,
-    Syntax,
     Procedure,
     Record,
     RecordTypeDescriptor,
@@ -670,7 +671,6 @@ pub enum UnpackedValue {
     Symbol(Symbol),
     Vector(Vector),
     ByteVector(ByteVector),
-    Syntax(Gc<Syntax>),
     Procedure(Procedure),
     Record(Record),
     RecordTypeDescriptor(Arc<RecordTypeDescriptor>),
@@ -703,10 +703,6 @@ impl UnpackedValue {
             Self::ByteVector(b_vec) => {
                 let untagged = Arc::into_raw(b_vec.0);
                 Value::from_ptr_and_tag(untagged, Tag::ByteVector)
-            }
-            Self::Syntax(syn) => {
-                let untagged = Gc::into_raw(syn);
-                Value::from_mut_ptr_and_tag(untagged, Tag::Syntax)
             }
             Self::Procedure(clos) => {
                 let untagged = Gc::into_raw(clos.0);
@@ -743,7 +739,6 @@ impl UnpackedValue {
             (Self::Vector(a), Self::Vector(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::ByteVector(a), Self::ByteVector(b)) => Arc::ptr_eq(&a.0, &b.0),
             (Self::Procedure(a), Self::Procedure(b)) => Gc::ptr_eq(&a.0, &b.0),
-            (Self::Syntax(a), Self::Syntax(b)) => Gc::ptr_eq(a, b),
             (Self::Record(a), Self::Record(b)) => a.eq(b),
             (Self::RecordTypeDescriptor(a), Self::RecordTypeDescriptor(b)) => Arc::ptr_eq(a, b),
             (Self::Cell(a), b) => a.0.read().unpacked_ref().eq(b),
@@ -771,7 +766,6 @@ impl UnpackedValue {
             (Self::Vector(a), Self::Vector(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::ByteVector(a), Self::ByteVector(b)) => Arc::ptr_eq(&a.0, &b.0),
             (Self::Procedure(a), Self::Procedure(b)) => Gc::ptr_eq(&a.0, &b.0),
-            (Self::Syntax(a), Self::Syntax(b)) => Gc::ptr_eq(a, b),
             (Self::Record(a), Self::Record(b)) => a.eqv(b),
             (Self::RecordTypeDescriptor(a), Self::RecordTypeDescriptor(b)) => Arc::ptr_eq(a, b),
             (Self::Cell(a), b) => a.0.read().unpacked_ref().eqv(b),
@@ -790,7 +784,6 @@ impl UnpackedValue {
             Self::Pair(_) | Self::Null => Symbol::intern("pair").to_str(),
             Self::Vector(_) => Symbol::intern("vector").to_str(),
             Self::ByteVector(_) => Symbol::intern("bytevector").to_str(),
-            Self::Syntax(_) => Symbol::intern("syntax").to_str(),
             Self::Procedure(_) => Symbol::intern("procedure").to_str(),
             Self::Record(record) => record.rtd().name.to_str(),
             Self::RecordTypeDescriptor(_) => Symbol::intern("rtd").to_str(),
@@ -809,7 +802,6 @@ impl UnpackedValue {
             Self::Pair(_) => ValueType::Pair,
             Self::Vector(_) => ValueType::Vector,
             Self::ByteVector(_) => ValueType::ByteVector,
-            Self::Syntax(_) => ValueType::Syntax,
             Self::Procedure(_) => ValueType::Procedure,
             Self::Record(_) => ValueType::Record,
             Self::RecordTypeDescriptor(_) => ValueType::RecordTypeDescriptor,
@@ -1157,7 +1149,6 @@ impl_try_from_value_for!(Number, Number, "number");
 impl_try_from_value_for!(Symbol, Symbol, "symbol");
 impl_try_from_value_for!(Vector, Vector, "vector");
 impl_try_from_value_for!(ByteVector, ByteVector, "byte-vector");
-impl_try_from_value_for!(Gc<Syntax>, Syntax, "syntax");
 impl_try_from_value_for!(Procedure, Procedure, "procedure");
 impl_try_from_value_for!(Pair, Pair, "pair");
 impl_try_from_value_for!(Record, Record, "record");
@@ -1181,7 +1172,6 @@ macro_rules! impl_from_wrapped_for {
 
 impl_from_wrapped_for!(Vec<Value>, Vector, Vector::immutable);
 impl_from_wrapped_for!(Vec<u8>, ByteVector, ByteVector::immutable);
-impl_from_wrapped_for!(Syntax, Syntax, Gc::new);
 impl_from_wrapped_for!((Value, Value), Pair, |(car, cdr)| Pair::immutable(car, cdr));
 
 impl From<UnpackedValue> for Option<(Value, Value)> {
@@ -1268,29 +1258,6 @@ impl_num_conversion!(f64);
 impl_num_conversion!(Integer);
 impl_num_conversion!(SimpleNumber);
 impl_num_conversion!(ComplexNumber);
-
-impl From<&Value> for Option<Identifier> {
-    fn from(value: &Value) -> Self {
-        match &*value.unpacked_ref() {
-            UnpackedValue::Syntax(syn) => match syn.as_ref() {
-                Syntax::Identifier { ident, .. } => Some(ident.clone()),
-                _ => None,
-            },
-            _ => None,
-        }
-    }
-}
-
-impl TryFrom<&Value> for Identifier {
-    type Error = Exception;
-
-    fn try_from(value: &Value) -> Result<Self, Self::Error> {
-        match Option::<Identifier>::from(value) {
-            Some(ident) => Ok(ident),
-            None => Err(Exception::type_error("identifier", &value.type_name())),
-        }
-    }
-}
 
 impl From<Value> for Option<(Value, Value)> {
     fn from(value: Value) -> Self {
@@ -1444,8 +1411,7 @@ fn display_value(
         UnpackedValue::Vector(v) => vectors::write_vec(&v, display_value, circular_values, f),
         UnpackedValue::ByteVector(v) => vectors::write_bytevec(&v, f),
         UnpackedValue::Procedure(_) => write!(f, "<procedure>"),
-        UnpackedValue::Record(record) => write!(f, "{record:?}"),
-        UnpackedValue::Syntax(syntax) => write!(f, "#<syntax {syntax:#?}>"),
+        UnpackedValue::Record(record) => write!(f, "{record}"),
         UnpackedValue::RecordTypeDescriptor(rtd) => write!(f, "{rtd:?}"),
         UnpackedValue::Cell(cell) => display_value(&cell.0.read(), circular_values, f),
     }
@@ -1470,10 +1436,12 @@ fn debug_value(
         }
         UnpackedValue::Vector(v) => vectors::write_vec(&v, debug_value, circular_values, f),
         UnpackedValue::ByteVector(v) => vectors::write_bytevec(&v, f),
+        /*
         UnpackedValue::Syntax(syntax) => {
             let span = syntax.span();
             write!(f, "#<syntax:{span} {syntax:#?}>")
         }
+        */
         UnpackedValue::Procedure(proc) => write!(f, "#<procedure {proc:?}>"),
         UnpackedValue::Record(record) => write!(f, "{record:#?}"),
         UnpackedValue::RecordTypeDescriptor(rtd) => write!(f, "{rtd:?}"),

--- a/src/value.rs
+++ b/src/value.rs
@@ -93,7 +93,7 @@ use crate::{
     lists::{self, Pair, PairInner},
     num::{ComplexNumber, Number, NumberInner, SimpleNumber},
     proc::{Procedure, ProcedureInner},
-    records::{Record, RecordInner, RecordTypeDescriptor},
+    records::{Embedded, Record, RecordInner, RecordTypeDescriptor},
     registry::bridge,
     strings::WideString,
     symbols::Symbol,
@@ -166,9 +166,6 @@ impl Value {
         unsafe {
             match tag {
                 Tag::Number => Arc::increment_strong_count(untagged as *const NumberInner),
-                Tag::Vector => {
-                    Gc::increment_reference_count(untagged as *mut GcInner<VectorInner<Value>>)
-                }
                 Tag::ByteVector => Arc::increment_strong_count(untagged as *const VectorInner<u8>),
                 Tag::Procedure => {
                     Gc::increment_reference_count(untagged as *mut GcInner<ProcedureInner>)
@@ -299,20 +296,10 @@ impl Value {
                 let untagged = (untagged as usize >> TAG_BITS) as u32;
                 UnpackedValue::Symbol(Symbol(untagged))
             }
-            Tag::Vector => {
-                let vec = unsafe { Gc::from_raw(untagged as *mut GcInner<VectorInner<Self>>) };
-                UnpackedValue::Vector(Vector(vec))
-            }
             Tag::ByteVector => {
                 let bvec = unsafe { Arc::from_raw(untagged as *const VectorInner<u8>) };
                 UnpackedValue::ByteVector(ByteVector(bvec))
             }
-            /*
-            Tag::Syntax => {
-                let syn = unsafe { Gc::from_raw(untagged as *mut GcInner<Syntax>) };
-                UnpackedValue::Syntax(syn)
-            }
-            */
             Tag::Procedure => {
                 let clos = unsafe { Gc::from_raw(untagged as *mut GcInner<ProcedureInner>) };
                 UnpackedValue::Procedure(Procedure(clos))
@@ -352,6 +339,62 @@ impl Value {
         }
     }
 
+    pub fn display_fmt(
+        &self,
+        circular_values: &mut IndexMap<Value, bool>,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        match self.clone().unpack() {
+            UnpackedValue::Undefined => write!(f, "<undefined>"),
+            UnpackedValue::Null => write!(f, "()"),
+            UnpackedValue::Boolean(true) => write!(f, "#t"),
+            UnpackedValue::Boolean(false) => write!(f, "#f"),
+            UnpackedValue::Number(number) => write!(f, "{number}"),
+            UnpackedValue::Character(c) => write!(f, "#\\{c}"),
+            UnpackedValue::Symbol(symbol) => write!(f, "{symbol}"),
+            UnpackedValue::Pair(pair) => {
+                let (car, cdr) = pair.into();
+                lists::write_list(&car, &cdr, Value::display_fmt, circular_values, f)
+            }
+            UnpackedValue::ByteVector(v) => vectors::write_bytevec(&v, f),
+            UnpackedValue::Procedure(_) => write!(f, "<procedure>"),
+            UnpackedValue::Record(record) => record.display_fmt(circular_values, f),
+            UnpackedValue::RecordTypeDescriptor(rtd) => write!(f, "{rtd:?}"),
+            UnpackedValue::Cell(cell) => cell.0.read().display_fmt(circular_values, f),
+        }
+    }
+
+    pub fn debug_fmt(
+        &self,
+        circular_values: &mut IndexMap<Value, bool>,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        match self.clone().unpack() {
+            UnpackedValue::Undefined => write!(f, "<undefined>"),
+            UnpackedValue::Null => write!(f, "()"),
+            UnpackedValue::Boolean(true) => write!(f, "#t"),
+            UnpackedValue::Boolean(false) => write!(f, "#f"),
+            UnpackedValue::Number(number) => write!(f, "{number}"),
+            UnpackedValue::Character(c) => write!(f, "#\\{c}"),
+            UnpackedValue::Symbol(symbol) => write!(f, "{symbol}"),
+            UnpackedValue::Pair(pair) => {
+                let (car, cdr) = pair.into();
+                lists::write_list(&car, &cdr, Value::debug_fmt, circular_values, f)
+            }
+            UnpackedValue::ByteVector(v) => vectors::write_bytevec(&v, f),
+            /*
+            UnpackedValue::Syntax(syntax) => {
+                let span = syntax.span();
+                write!(f, "#<syntax:{span} {syntax:#?}>")
+            }
+            */
+            UnpackedValue::Procedure(proc) => write!(f, "#<procedure {proc:?}>"),
+            UnpackedValue::Record(record) => record.debug_fmt(circular_values, f),
+            UnpackedValue::RecordTypeDescriptor(rtd) => write!(f, "{rtd:?}"),
+            UnpackedValue::Cell(cell) => cell.0.read().debug_fmt(circular_values, f),
+        }
+    }
+
     /// The eq? predicate as defined by the R6RS specification.
     #[allow(clippy::should_implement_trait)]
     pub fn eq(&self, rhs: &Self) -> bool {
@@ -388,7 +431,6 @@ impl Value {
             UnpackedValue::Record(r) => r.eq_hash(state),
             UnpackedValue::RecordTypeDescriptor(rt) => Arc::as_ptr(rt).hash(state),
             UnpackedValue::Pair(p) => Gc::as_ptr(&p.0).hash(state),
-            UnpackedValue::Vector(v) => Gc::as_ptr(&v.0).hash(state),
             UnpackedValue::Cell(c) => c.0.read().eqv_hash(state),
         }
     }
@@ -409,7 +451,6 @@ impl Value {
             UnpackedValue::Record(r) => r.eqv_hash(state),
             UnpackedValue::RecordTypeDescriptor(rt) => Arc::as_ptr(rt).hash(state),
             UnpackedValue::Pair(p) => Gc::as_ptr(&p.0).hash(state),
-            UnpackedValue::Vector(v) => Gc::as_ptr(&v.0).hash(state),
             UnpackedValue::Cell(c) => c.0.read().eqv_hash(state),
         }
     }
@@ -435,21 +476,16 @@ impl Value {
             UnpackedValue::Symbol(s) => s.hash(state),
             UnpackedValue::ByteVector(v) => v.hash(state),
             UnpackedValue::Procedure(c) => Gc::as_ptr(&c.0).hash(state),
-            UnpackedValue::Record(r) => r.equal_hash(state),
+            UnpackedValue::Record(r) => {
+                recursive.insert(self.clone());
+                r.equal_hash(recursive, state);
+            }
             UnpackedValue::RecordTypeDescriptor(rt) => Arc::as_ptr(rt).hash(state),
             UnpackedValue::Pair(p) => {
                 recursive.insert(self.clone());
                 let (car, cdr) = p.clone().into();
                 car.equal_hash(recursive, state);
                 cdr.equal_hash(recursive, state);
-            }
-            UnpackedValue::Vector(v) => {
-                recursive.insert(self.clone());
-                let v_read = v.0.vec.read();
-                state.write_usize(v_read.len());
-                for val in v_read.iter() {
-                    val.equal_hash(recursive, state);
-                }
             }
             UnpackedValue::Cell(c) => c.0.read().eqv_hash(state),
         }
@@ -497,7 +533,7 @@ impl fmt::Display for Value {
         let mut circular_values = IndexSet::default();
         determine_circularity(self, &mut IndexSet::default(), &mut circular_values);
         let mut circular_values = circular_values.into_iter().map(|k| (k, false)).collect();
-        write_value(self, display_value, &mut circular_values, f)
+        write_value(self, Value::display_fmt, &mut circular_values, f)
     }
 }
 
@@ -506,7 +542,7 @@ impl fmt::Debug for Value {
         let mut circular_values = IndexSet::default();
         determine_circularity(self, &mut IndexSet::default(), &mut circular_values);
         let mut circular_values = circular_values.into_iter().map(|k| (k, false)).collect();
-        write_value(self, debug_value, &mut circular_values, f)
+        write_value(self, Value::debug_fmt, &mut circular_values, f)
     }
 }
 
@@ -611,7 +647,6 @@ pub(crate) enum Tag {
     Character = 3,
     Number = 4,
     Symbol = 6,
-    Vector = 7,
     ByteVector = 8,
     Procedure = 10,
     Record = 11,
@@ -628,7 +663,6 @@ impl From<usize> for Tag {
             3 => Self::Character,
             4 => Self::Number,
             6 => Self::Symbol,
-            7 => Self::Vector,
             8 => Self::ByteVector,
             10 => Self::Procedure,
             11 => Self::Record,
@@ -649,7 +683,6 @@ pub enum ValueType {
     Character,
     Number,
     Symbol,
-    Vector,
     ByteVector,
     Procedure,
     Record,
@@ -669,7 +702,6 @@ pub enum UnpackedValue {
     Character(char),
     Number(Number),
     Symbol(Symbol),
-    Vector(Vector),
     ByteVector(ByteVector),
     Procedure(Procedure),
     Record(Record),
@@ -695,10 +727,6 @@ impl UnpackedValue {
             }
             Self::Symbol(sym) => {
                 Value::from_ptr_and_tag(((sym.0 as usize) << TAG_BITS) as *const (), Tag::Symbol)
-            }
-            Self::Vector(vec) => {
-                let untagged = Gc::into_raw(vec.0);
-                Value::from_mut_ptr_and_tag(untagged, Tag::Vector)
             }
             Self::ByteVector(b_vec) => {
                 let untagged = Arc::into_raw(b_vec.0);
@@ -736,7 +764,6 @@ impl UnpackedValue {
             (Self::Character(a), Self::Character(b)) => a == b,
             (Self::Null, Self::Null) => true,
             (Self::Pair(a), Self::Pair(b)) => Gc::ptr_eq(&a.0, &b.0),
-            (Self::Vector(a), Self::Vector(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::ByteVector(a), Self::ByteVector(b)) => Arc::ptr_eq(&a.0, &b.0),
             (Self::Procedure(a), Self::Procedure(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::Record(a), Self::Record(b)) => a.eq(b),
@@ -763,7 +790,6 @@ impl UnpackedValue {
             (Self::Null, Self::Null) => true,
             // Everything else is pointer equivalence
             (Self::Pair(a), Self::Pair(b)) => Gc::ptr_eq(&a.0, &b.0),
-            (Self::Vector(a), Self::Vector(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::ByteVector(a), Self::ByteVector(b)) => Arc::ptr_eq(&a.0, &b.0),
             (Self::Procedure(a), Self::Procedure(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::Record(a), Self::Record(b)) => a.eqv(b),
@@ -782,7 +808,6 @@ impl UnpackedValue {
             Self::Character(_) => Symbol::intern("character").to_str(),
             Self::Symbol(_) => Symbol::intern("symbol").to_str(),
             Self::Pair(_) | Self::Null => Symbol::intern("pair").to_str(),
-            Self::Vector(_) => Symbol::intern("vector").to_str(),
             Self::ByteVector(_) => Symbol::intern("bytevector").to_str(),
             Self::Procedure(_) => Symbol::intern("procedure").to_str(),
             Self::Record(record) => record.rtd().name.to_str(),
@@ -800,7 +825,6 @@ impl UnpackedValue {
             Self::Character(_) => ValueType::Character,
             Self::Symbol(_) => ValueType::Symbol,
             Self::Pair(_) => ValueType::Pair,
-            Self::Vector(_) => ValueType::Vector,
             Self::ByteVector(_) => ValueType::ByteVector,
             Self::Procedure(_) => ValueType::Procedure,
             Self::Record(_) => ValueType::Record,
@@ -841,9 +865,8 @@ fn fast(ht: &mut HashMap<Value, Value>, obj1: &Value, obj2: &Value, k: i64) -> O
     }
     match (obj1.type_of(), obj2.type_of()) {
         (ValueType::Pair, ValueType::Pair) => pair_eq(ht, obj1, obj2, k),
-        (ValueType::Vector, ValueType::Vector) => vector_eq(ht, obj1, obj2, k),
         (ValueType::ByteVector, ValueType::ByteVector) => bytevector_eq(obj1, obj2, k),
-        (ValueType::Record, ValueType::Record) => record_equal(obj1, obj2, k),
+        (ValueType::Record, ValueType::Record) => record_equal(ht, obj1, obj2, k),
         _ => None,
     }
 }
@@ -859,14 +882,13 @@ fn slow(ht: &mut HashMap<Value, Value>, obj1: &Value, obj2: &Value, k: i64) -> O
             }
             pair_eq(ht, obj1, obj2, k)
         }
-        (ValueType::Vector, ValueType::Vector) => {
+        (ValueType::ByteVector, ValueType::ByteVector) => bytevector_eq(obj1, obj2, k),
+        (ValueType::Record, ValueType::Record) => {
             if union_find(ht, obj1, obj2) {
                 return Some(0);
             }
-            vector_eq(ht, obj1, obj2, k)
+            record_equal(ht, obj1, obj2, k)
         }
-        (ValueType::ByteVector, ValueType::ByteVector) => bytevector_eq(obj1, obj2, k),
-        (ValueType::Record, ValueType::Record) => record_equal(obj1, obj2, k),
         _ => None,
     }
 }
@@ -879,9 +901,7 @@ fn pair_eq(ht: &mut HashMap<Value, Value>, obj1: &Value, obj2: &Value, k: i64) -
     e(ht, &car_x, &car_y, k - 1).and_then(|k| e(ht, &cdr_x, &cdr_y, k))
 }
 
-fn vector_eq(ht: &mut HashMap<Value, Value>, obj1: &Value, obj2: &Value, k: i64) -> Option<i64> {
-    let vobj1: Vector = obj1.clone().try_into().unwrap();
-    let vobj2: Vector = obj2.clone().try_into().unwrap();
+fn vector_eq(ht: &mut HashMap<Value, Value>, vobj1: Vector, vobj2: Vector, k: i64) -> Option<i64> {
     let vobj1 = vobj1.0.vec.read();
     let vobj2 = vobj2.0.vec.read();
     if vobj1.len() != vobj2.len() {
@@ -900,10 +920,16 @@ fn bytevector_eq(obj1: &Value, obj2: &Value, k: i64) -> Option<i64> {
     (*obj1.0.vec.read() == *obj2.0.vec.read()).then_some(k)
 }
 
-fn record_equal(obj1: &Value, obj2: &Value, k: i64) -> Option<i64> {
-    let obj1: Record = obj1.clone().try_into().unwrap();
-    let obj2: Record = obj2.clone().try_into().unwrap();
-    (obj1.equal(&obj2)).then_some(k)
+fn record_equal(ht: &mut HashMap<Value, Value>, obj1: &Value, obj2: &Value, k: i64) -> Option<i64> {
+    if let Some(vobj1) = obj1.cast_to::<Vector>()
+        && let Some(vobj2) = obj2.cast_to::<Vector>()
+    {
+        vector_eq(ht, vobj1, vobj2, k)
+    } else {
+        let obj1: Record = obj1.clone().try_into().unwrap();
+        let obj2: Record = obj2.clone().try_into().unwrap();
+        (obj1.equal(&obj2)).then_some(k)
+    }
 }
 
 fn union_find(ht: &mut HashMap<Value, Value>, x: &Value, y: &Value) -> bool {
@@ -1147,7 +1173,6 @@ impl From<bool> for Value {
 impl_try_from_value_for!(char, Character, "char");
 impl_try_from_value_for!(Number, Number, "number");
 impl_try_from_value_for!(Symbol, Symbol, "symbol");
-impl_try_from_value_for!(Vector, Vector, "vector");
 impl_try_from_value_for!(ByteVector, ByteVector, "byte-vector");
 impl_try_from_value_for!(Procedure, Procedure, "procedure");
 impl_try_from_value_for!(Pair, Pair, "pair");
@@ -1170,7 +1195,6 @@ macro_rules! impl_from_wrapped_for {
     };
 }
 
-impl_from_wrapped_for!(Vec<Value>, Vector, Vector::immutable);
 impl_from_wrapped_for!(Vec<u8>, ByteVector, ByteVector::immutable);
 impl_from_wrapped_for!((Value, Value), Pair, |(car, cdr)| Pair::immutable(car, cdr));
 
@@ -1360,8 +1384,8 @@ fn determine_circularity(
             determine_circularity(&car, visited, circular);
             determine_circularity(&cdr, visited, circular);
         }
-        UnpackedValue::Vector(vec) => {
-            let vec_read = vec.0.vec.read();
+        UnpackedValue::Record(rec) if let Some(vec) = rec.cast::<VectorInner<Value>>() => {
+            let vec_read = vec.vec.read();
             for item in vec_read.iter() {
                 determine_circularity(item, visited, circular);
             }
@@ -1391,81 +1415,23 @@ pub(crate) fn write_value(
     fmt(val, circular_values, f)
 }
 
-fn display_value(
-    val: &Value,
-    circular_values: &mut IndexMap<Value, bool>,
-    f: &mut fmt::Formatter<'_>,
-) -> fmt::Result {
-    match val.clone().unpack() {
-        UnpackedValue::Undefined => write!(f, "<undefined>"),
-        UnpackedValue::Null => write!(f, "()"),
-        UnpackedValue::Boolean(true) => write!(f, "#t"),
-        UnpackedValue::Boolean(false) => write!(f, "#f"),
-        UnpackedValue::Number(number) => write!(f, "{number}"),
-        UnpackedValue::Character(c) => write!(f, "#\\{c}"),
-        UnpackedValue::Symbol(symbol) => write!(f, "{symbol}"),
-        UnpackedValue::Pair(pair) => {
-            let (car, cdr) = pair.into();
-            lists::write_list(&car, &cdr, display_value, circular_values, f)
-        }
-        UnpackedValue::Vector(v) => vectors::write_vec(&v, display_value, circular_values, f),
-        UnpackedValue::ByteVector(v) => vectors::write_bytevec(&v, f),
-        UnpackedValue::Procedure(_) => write!(f, "<procedure>"),
-        UnpackedValue::Record(record) => write!(f, "{record}"),
-        UnpackedValue::RecordTypeDescriptor(rtd) => write!(f, "{rtd:?}"),
-        UnpackedValue::Cell(cell) => display_value(&cell.0.read(), circular_values, f),
-    }
-}
-
-fn debug_value(
-    val: &Value,
-    circular_values: &mut IndexMap<Value, bool>,
-    f: &mut fmt::Formatter<'_>,
-) -> fmt::Result {
-    match val.clone().unpack() {
-        UnpackedValue::Undefined => write!(f, "<undefined>"),
-        UnpackedValue::Null => write!(f, "()"),
-        UnpackedValue::Boolean(true) => write!(f, "#t"),
-        UnpackedValue::Boolean(false) => write!(f, "#f"),
-        UnpackedValue::Number(number) => write!(f, "{number}"),
-        UnpackedValue::Character(c) => write!(f, "#\\{c}"),
-        UnpackedValue::Symbol(symbol) => write!(f, "{symbol}"),
-        UnpackedValue::Pair(pair) => {
-            let (car, cdr) = pair.into();
-            lists::write_list(&car, &cdr, debug_value, circular_values, f)
-        }
-        UnpackedValue::Vector(v) => vectors::write_vec(&v, debug_value, circular_values, f),
-        UnpackedValue::ByteVector(v) => vectors::write_bytevec(&v, f),
-        /*
-        UnpackedValue::Syntax(syntax) => {
-            let span = syntax.span();
-            write!(f, "#<syntax:{span} {syntax:#?}>")
-        }
-        */
-        UnpackedValue::Procedure(proc) => write!(f, "#<procedure {proc:?}>"),
-        UnpackedValue::Record(record) => write!(f, "{record:#?}"),
-        UnpackedValue::RecordTypeDescriptor(rtd) => write!(f, "{rtd:?}"),
-        UnpackedValue::Cell(cell) => debug_value(&cell.0.read(), circular_values, f),
-    }
-}
 #[bridge(name = "not", lib = "(rnrs base builtins (6))")]
 pub fn not(a: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(a.0 as usize == Tag::Boolean as usize)])
 }
 
-#[bridge(name = "eqv?", lib = "(rnrs base builtins (6))")]
-pub fn eqv(a: &Value, b: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(a.eqv(b))])
-}
-
 #[bridge(name = "eq?", lib = "(rnrs base builtins (6))")]
-pub fn eq(a: &Value, b: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(a.eq(b))])
+pub fn eq(a: &Value, b: &Value) -> bool {
+    a.eq(b)
+}
+#[bridge(name = "eqv?", lib = "(rnrs base builtins (6))")]
+pub fn eqv(a: &Value, b: &Value) -> bool {
+    a.eqv(b)
 }
 
 #[bridge(name = "equal?", lib = "(rnrs base builtins (6))")]
-pub fn equal_pred(a: &Value, b: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(a.equal(b))])
+pub fn equal_pred(a: &Value, b: &Value) -> bool {
+    a.equal(b)
 }
 
 #[bridge(name = "boolean?", lib = "(rnrs base builtins (6))")]
@@ -1491,11 +1457,6 @@ pub fn symbol_pred(arg: &Value) -> Result<Vec<Value>, Exception> {
 #[bridge(name = "char?", lib = "(rnrs base builtins (6))")]
 pub fn char_pred(arg: &Value) -> Result<Vec<Value>, Exception> {
     Ok(vec![Value::from(arg.type_of() == ValueType::Character)])
-}
-
-#[bridge(name = "vector?", lib = "(rnrs base builtins (6))")]
-pub fn vector_pred(arg: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(arg.type_of() == ValueType::Vector)])
 }
 
 #[bridge(name = "null?", lib = "(rnrs base builtins (6))")]

--- a/src/value.rs
+++ b/src/value.rs
@@ -327,9 +327,7 @@ impl Value {
                 let cell = unsafe { Gc::from_raw(untagged as *mut GcInner<RwLock<Value>>) };
                 UnpackedValue::Cell(Cell(cell))
             }
-            Tag::FixNum => {
-                UnpackedValue::Number(Number(NumberRepr::Fixed(raw as i64 >> 1)))
-            }
+            Tag::FixNum => UnpackedValue::Number(Number(NumberRepr::Fixed(raw as i64 >> 1))),
         }
     }
 
@@ -651,15 +649,15 @@ impl From<usize> for Tag {
             Self::FixNum
         } else if tag == Self::Pair as usize {
             Self::Pair
-        } else if tag == Self::Boolean as usize{
-            Self::Boolean 
-        } else if tag == Self::CharacterOrSymbol  as usize{
+        } else if tag == Self::Boolean as usize {
+            Self::Boolean
+        } else if tag == Self::CharacterOrSymbol as usize {
             Self::CharacterOrSymbol
-        } else if tag == Self::Number  as usize{
+        } else if tag == Self::Number as usize {
             Self::Number
         } else if tag == Self::Procedure as usize {
             Self::Procedure
-        } else if tag == Self::Record as usize{
+        } else if tag == Self::Record as usize {
             Self::Record
         } else if tag == Self::RecordTypeDescriptor as usize {
             Self::RecordTypeDescriptor

--- a/src/value.rs
+++ b/src/value.rs
@@ -114,6 +114,7 @@ use std::{
 const ALIGNMENT: usize = 16;
 const TAG_BITS: usize = ALIGNMENT.ilog2() as usize;
 pub(crate) const TAG: usize = 0b1111;
+pub(crate) const SYMBOL_CHAR: u32 = 0x110000;
 pub(crate) const NULL_VALUE: usize = Tag::Pair as usize;
 pub(crate) const TRUE_VALUE: usize = Tag::Boolean as usize | 1 << TAG_BITS;
 pub(crate) const FALSE_VALUE: usize = Tag::Boolean as usize;
@@ -184,7 +185,7 @@ impl Value {
                 Tag::Cell => {
                     Gc::increment_reference_count(untagged as *mut GcInner<Value>);
                 }
-                Tag::Symbol | Tag::Boolean | Tag::Character => (),
+                Tag::Boolean | Tag::CharacterOrSymbol => (),
             }
         }
         Self(raw)
@@ -282,17 +283,19 @@ impl Value {
                 let untagged = untagged as usize >> TAG_BITS;
                 UnpackedValue::Boolean(untagged != 0)
             }
-            Tag::Character => {
-                let untagged = (untagged as usize >> TAG_BITS) as u32;
-                UnpackedValue::Character(char::from_u32(untagged).unwrap())
+            Tag::CharacterOrSymbol => {
+                let untagged_char = (untagged as usize as u32) >> TAG_BITS;
+                if untagged_char == SYMBOL_CHAR {
+                    // Upper 32 bits used for symbols
+                    UnpackedValue::Symbol(Symbol((untagged as usize >> 32) as u32))
+                } else {
+                    // Lower 32 bits used for character
+                    UnpackedValue::Character(char::from_u32(untagged_char).unwrap())
+                }
             }
             Tag::Number => {
                 let number = unsafe { Arc::from_raw(untagged as *const NumberInner) };
                 UnpackedValue::Number(Number(number))
-            }
-            Tag::Symbol => {
-                let untagged = (untagged as usize >> TAG_BITS) as u32;
-                UnpackedValue::Symbol(Symbol(untagged))
             }
             Tag::Procedure => {
                 let clos = unsafe { Gc::from_raw(untagged as *mut GcInner<ProcedureInner>) };
@@ -627,9 +630,8 @@ impl From<Exception> for Value {
 pub(crate) enum Tag {
     Pair = 1,
     Boolean = 2,
-    Character = 3,
+    CharacterOrSymbol = 3,
     Number = 4,
-    Symbol = 6,
     Procedure = 10,
     Record = 11,
     RecordTypeDescriptor = 12,
@@ -642,9 +644,8 @@ impl From<usize> for Tag {
         match tag {
             1 => Self::Pair,
             2 => Self::Boolean,
-            3 => Self::Character,
+            3 => Self::CharacterOrSymbol,
             4 => Self::Number,
-            6 => Self::Symbol,
             10 => Self::Procedure,
             11 => Self::Record,
             12 => Self::RecordTypeDescriptor,
@@ -698,14 +699,14 @@ impl UnpackedValue {
                 Value::from_ptr_and_tag(((b as usize) << TAG_BITS) as *const (), Tag::Boolean)
             }
             Self::Character(c) => {
-                Value::from_ptr_and_tag(((c as usize) << TAG_BITS) as *const (), Tag::Character)
+                Value::from_ptr_and_tag(((c as usize) << TAG_BITS) as *const (), Tag::CharacterOrSymbol)
             }
             Self::Number(num) => {
                 let untagged = Arc::into_raw(num.0);
                 Value::from_ptr_and_tag(untagged, Tag::Number)
             }
             Self::Symbol(sym) => {
-                Value::from_ptr_and_tag(((sym.0 as usize) << TAG_BITS) as *const (), Tag::Symbol)
+                Value::from_ptr_and_tag((((sym.0 as usize) << 32) | (SYMBOL_CHAR as usize) << TAG_BITS) as *const (), Tag::CharacterOrSymbol)
             }
             Self::Procedure(clos) => {
                 let untagged = Gc::into_raw(clos.0);

--- a/src/value.rs
+++ b/src/value.rs
@@ -80,8 +80,6 @@
 //! - **Record**: A [`Record`], which can possibly embed an
 //!   [`Embeddable`](records::Embeddable) Rust value.
 //! - **Record Type Descriptor**: A [descriptor of a record's type](RecordTypeDescriptor).
-//! - **Port**: A value that can handle [input/output](scheme_rs::ports::Port)
-//!   from the outside world.
 //! - **Cell**: A mutable reference to another Value. This type is completely
 //!   transparent and impossible to observe.
 
@@ -94,7 +92,6 @@ use crate::{
     gc::{Gc, GcInner, Trace},
     lists::{self, Pair, PairInner},
     num::{ComplexNumber, Number, NumberInner, SimpleNumber},
-    ports::{Port, PortInner},
     proc::{Procedure, ProcedureInner},
     records::{Record, RecordInner, RecordTypeDescriptor},
     registry::bridge,
@@ -187,7 +184,6 @@ impl Value {
                         Gc::increment_reference_count(untagged as *mut GcInner<PairInner>)
                     }
                 }
-                Tag::Port => Arc::increment_strong_count(untagged as *const PortInner),
                 Tag::Cell => {
                     Gc::increment_reference_count(untagged as *mut GcInner<Value>);
                 }
@@ -254,8 +250,6 @@ impl Value {
     pub fn type_name(&self) -> &'static str {
         self.unpacked_ref().type_name()
     }
-
-    // TODO: These will be cast_to and try_to
 
     /// Attempt to cast the value.
     pub fn cast_to<T>(&self) -> Option<T>
@@ -339,10 +333,6 @@ impl Value {
                     UnpackedValue::Pair(Pair(pair))
                 }
             }
-            Tag::Port => {
-                let port_inner = unsafe { Arc::from_raw(untagged as *const PortInner) };
-                UnpackedValue::Port(Port(port_inner))
-            }
             Tag::Cell => {
                 let cell = unsafe { Gc::from_raw(untagged as *mut GcInner<RwLock<Value>>) };
                 UnpackedValue::Cell(Cell(cell))
@@ -397,7 +387,6 @@ impl Value {
             UnpackedValue::RecordTypeDescriptor(rt) => Arc::as_ptr(rt).hash(state),
             UnpackedValue::Pair(p) => Gc::as_ptr(&p.0).hash(state),
             UnpackedValue::Vector(v) => Gc::as_ptr(&v.0).hash(state),
-            UnpackedValue::Port(p) => Arc::as_ptr(&p.0).hash(state),
             UnpackedValue::Cell(c) => c.0.read().eqv_hash(state),
         }
     }
@@ -421,7 +410,6 @@ impl Value {
             UnpackedValue::RecordTypeDescriptor(rt) => Arc::as_ptr(rt).hash(state),
             UnpackedValue::Pair(p) => Gc::as_ptr(&p.0).hash(state),
             UnpackedValue::Vector(v) => Gc::as_ptr(&v.0).hash(state),
-            UnpackedValue::Port(p) => Arc::as_ptr(&p.0).hash(state),
             UnpackedValue::Cell(c) => c.0.read().eqv_hash(state),
         }
     }
@@ -465,7 +453,6 @@ impl Value {
                     val.equal_hash(recursive, state);
                 }
             }
-            UnpackedValue::Port(p) => Arc::as_ptr(&p.0).hash(state),
             UnpackedValue::Cell(c) => c.0.read().eqv_hash(state),
         }
     }
@@ -634,7 +621,6 @@ pub(crate) enum Tag {
     Procedure = 10,
     Record = 11,
     RecordTypeDescriptor = 12,
-    Port = 14,
     Cell = 15,
 }
 
@@ -655,7 +641,6 @@ impl From<usize> for Tag {
             10 => Self::Procedure,
             11 => Self::Record,
             12 => Self::RecordTypeDescriptor,
-            14 => Self::Port,
             15 => Self::Cell,
             tag => panic!("Invalid tag: {tag}"),
         }
@@ -679,7 +664,6 @@ pub enum ValueType {
     Procedure,
     Record,
     RecordTypeDescriptor,
-    Port,
 }
 
 /// The external, unpacked, enumeration representation of a scheme value.
@@ -703,7 +687,6 @@ pub enum UnpackedValue {
     Record(Record),
     RecordTypeDescriptor(Arc<RecordTypeDescriptor>),
     Pair(Pair),
-    Port(Port),
     Cell(Cell),
 }
 
@@ -757,10 +740,6 @@ impl UnpackedValue {
                 let untagged = Gc::into_raw(pair.0);
                 Value::from_mut_ptr_and_tag(untagged, Tag::Pair)
             }
-            Self::Port(port) => {
-                let untagged = Arc::into_raw(port.0);
-                Value::from_ptr_and_tag(untagged, Tag::Port)
-            }
             Self::Cell(cell) => {
                 let untagged = Gc::into_raw(cell.0);
                 Value::from_mut_ptr_and_tag(untagged, Tag::Cell)
@@ -784,7 +763,6 @@ impl UnpackedValue {
             (Self::Syntax(a), Self::Syntax(b)) => Gc::ptr_eq(a, b),
             (Self::Record(a), Self::Record(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::RecordTypeDescriptor(a), Self::RecordTypeDescriptor(b)) => Arc::ptr_eq(a, b),
-            (Self::Port(a), Self::Port(b)) => Arc::ptr_eq(&a.0, &b.0),
             (Self::Cell(a), b) => a.0.read().unpacked_ref().eq(b),
             (a, Self::Cell(b)) => a.eq(&b.0.read().unpacked_ref()),
             _ => false,
@@ -814,7 +792,6 @@ impl UnpackedValue {
             (Self::Syntax(a), Self::Syntax(b)) => Gc::ptr_eq(a, b),
             (Self::Record(a), Self::Record(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::RecordTypeDescriptor(a), Self::RecordTypeDescriptor(b)) => Arc::ptr_eq(a, b),
-            (Self::Port(a), Self::Port(b)) => Arc::ptr_eq(&a.0, &b.0),
             (Self::Cell(a), b) => a.0.read().unpacked_ref().eqv(b),
             (a, Self::Cell(b)) => a.eqv(&b.0.read().unpacked_ref()),
             _ => false,
@@ -836,7 +813,6 @@ impl UnpackedValue {
             Self::Procedure(_) => "procedure",
             Self::Record(_) => "record",
             Self::RecordTypeDescriptor(_) => "rtd",
-            Self::Port(_) => "port",
             Self::Cell(cell) => cell.0.read().type_name(),
         }
     }
@@ -857,7 +833,6 @@ impl UnpackedValue {
             Self::Procedure(_) => ValueType::Procedure,
             Self::Record(_) => ValueType::Record,
             Self::RecordTypeDescriptor(_) => ValueType::RecordTypeDescriptor,
-            Self::Port(_) => ValueType::Port,
             Self::Cell(cell) => cell.0.read().type_of(),
         }
     }
@@ -1207,7 +1182,6 @@ impl_try_from_value_for!(Gc<Syntax>, Syntax, "syntax");
 impl_try_from_value_for!(Procedure, Procedure, "procedure");
 impl_try_from_value_for!(Pair, Pair, "pair");
 impl_try_from_value_for!(Record, Record, "record");
-impl_try_from_value_for!(Port, Port, "port");
 impl_try_from_value_for!(Arc<RecordTypeDescriptor>, RecordTypeDescriptor, "rt");
 
 macro_rules! impl_from_wrapped_for {
@@ -1496,7 +1470,6 @@ fn display_value(
         UnpackedValue::Record(record) => write!(f, "{record:?}"),
         UnpackedValue::Syntax(syntax) => write!(f, "#<syntax {syntax:#?}>"),
         UnpackedValue::RecordTypeDescriptor(rtd) => write!(f, "{rtd:?}"),
-        UnpackedValue::Port(_) => write!(f, "<port>"),
         UnpackedValue::Cell(cell) => display_value(&cell.0.read(), circular_values, f),
     }
 }
@@ -1528,7 +1501,6 @@ fn debug_value(
         UnpackedValue::Procedure(proc) => write!(f, "#<procedure {proc:?}>"),
         UnpackedValue::Record(record) => write!(f, "{record:#?}"),
         UnpackedValue::RecordTypeDescriptor(rtd) => write!(f, "{rtd:?}"),
-        UnpackedValue::Port(_) => write!(f, "<port>"),
         UnpackedValue::Cell(cell) => debug_value(&cell.0.read(), circular_values, f),
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -74,7 +74,6 @@
 //! - **String**: An array of [`chars`](std::char).
 //! - **Symbol**: A [`Symbol`].
 //! - **Vector**: A [`Vector`].
-//! - **Byte-vector**: A [`ByteVector`].
 //! - **Syntax**: A [`Syntax`].
 //! - **Procedure**: A [`Procedure`].
 //! - **Record**: A [`Record`], which can possibly embed an
@@ -166,7 +165,6 @@ impl Value {
         unsafe {
             match tag {
                 Tag::Number => Arc::increment_strong_count(untagged as *const NumberInner),
-                Tag::ByteVector => Arc::increment_strong_count(untagged as *const VectorInner<u8>),
                 Tag::Procedure => {
                     Gc::increment_reference_count(untagged as *mut GcInner<ProcedureInner>)
                 }
@@ -296,10 +294,6 @@ impl Value {
                 let untagged = (untagged as usize >> TAG_BITS) as u32;
                 UnpackedValue::Symbol(Symbol(untagged))
             }
-            Tag::ByteVector => {
-                let bvec = unsafe { Arc::from_raw(untagged as *const VectorInner<u8>) };
-                UnpackedValue::ByteVector(ByteVector(bvec))
-            }
             Tag::Procedure => {
                 let clos = unsafe { Gc::from_raw(untagged as *mut GcInner<ProcedureInner>) };
                 UnpackedValue::Procedure(Procedure(clos))
@@ -356,7 +350,6 @@ impl Value {
                 let (car, cdr) = pair.into();
                 lists::write_list(&car, &cdr, Value::display_fmt, circular_values, f)
             }
-            UnpackedValue::ByteVector(v) => vectors::write_bytevec(&v, f),
             UnpackedValue::Procedure(_) => write!(f, "<procedure>"),
             UnpackedValue::Record(record) => record.display_fmt(circular_values, f),
             UnpackedValue::RecordTypeDescriptor(rtd) => write!(f, "{rtd:?}"),
@@ -381,13 +374,6 @@ impl Value {
                 let (car, cdr) = pair.into();
                 lists::write_list(&car, &cdr, Value::debug_fmt, circular_values, f)
             }
-            UnpackedValue::ByteVector(v) => vectors::write_bytevec(&v, f),
-            /*
-            UnpackedValue::Syntax(syntax) => {
-                let span = syntax.span();
-                write!(f, "#<syntax:{span} {syntax:#?}>")
-            }
-            */
             UnpackedValue::Procedure(proc) => write!(f, "#<procedure {proc:?}>"),
             UnpackedValue::Record(record) => record.debug_fmt(circular_values, f),
             UnpackedValue::RecordTypeDescriptor(rtd) => write!(f, "{rtd:?}"),
@@ -426,7 +412,6 @@ impl Value {
             UnpackedValue::Character(c) => c.hash(state),
             UnpackedValue::Number(n) => Arc::as_ptr(&n.0).hash(state),
             UnpackedValue::Symbol(s) => s.hash(state),
-            UnpackedValue::ByteVector(v) => Arc::as_ptr(&v.0).hash(state),
             UnpackedValue::Procedure(c) => Gc::as_ptr(&c.0).hash(state),
             UnpackedValue::Record(r) => r.eq_hash(state),
             UnpackedValue::RecordTypeDescriptor(rt) => Arc::as_ptr(rt).hash(state),
@@ -446,7 +431,6 @@ impl Value {
             UnpackedValue::Character(c) => c.hash(state),
             UnpackedValue::Number(n) => n.hash(state),
             UnpackedValue::Symbol(s) => s.hash(state),
-            UnpackedValue::ByteVector(v) => Arc::as_ptr(&v.0).hash(state),
             UnpackedValue::Procedure(c) => Gc::as_ptr(&c.0).hash(state),
             UnpackedValue::Record(r) => r.eqv_hash(state),
             UnpackedValue::RecordTypeDescriptor(rt) => Arc::as_ptr(rt).hash(state),
@@ -474,7 +458,6 @@ impl Value {
             UnpackedValue::Character(c) => c.hash(state),
             UnpackedValue::Number(n) => n.hash(state),
             UnpackedValue::Symbol(s) => s.hash(state),
-            UnpackedValue::ByteVector(v) => v.hash(state),
             UnpackedValue::Procedure(c) => Gc::as_ptr(&c.0).hash(state),
             UnpackedValue::Record(r) => {
                 recursive.insert(self.clone());
@@ -647,7 +630,6 @@ pub(crate) enum Tag {
     Character = 3,
     Number = 4,
     Symbol = 6,
-    ByteVector = 8,
     Procedure = 10,
     Record = 11,
     RecordTypeDescriptor = 12,
@@ -663,7 +645,6 @@ impl From<usize> for Tag {
             3 => Self::Character,
             4 => Self::Number,
             6 => Self::Symbol,
-            8 => Self::ByteVector,
             10 => Self::Procedure,
             11 => Self::Record,
             12 => Self::RecordTypeDescriptor,
@@ -683,7 +664,6 @@ pub enum ValueType {
     Character,
     Number,
     Symbol,
-    ByteVector,
     Procedure,
     Record,
     RecordTypeDescriptor,
@@ -702,7 +682,6 @@ pub enum UnpackedValue {
     Character(char),
     Number(Number),
     Symbol(Symbol),
-    ByteVector(ByteVector),
     Procedure(Procedure),
     Record(Record),
     RecordTypeDescriptor(Arc<RecordTypeDescriptor>),
@@ -727,10 +706,6 @@ impl UnpackedValue {
             }
             Self::Symbol(sym) => {
                 Value::from_ptr_and_tag(((sym.0 as usize) << TAG_BITS) as *const (), Tag::Symbol)
-            }
-            Self::ByteVector(b_vec) => {
-                let untagged = Arc::into_raw(b_vec.0);
-                Value::from_ptr_and_tag(untagged, Tag::ByteVector)
             }
             Self::Procedure(clos) => {
                 let untagged = Gc::into_raw(clos.0);
@@ -764,7 +739,6 @@ impl UnpackedValue {
             (Self::Character(a), Self::Character(b)) => a == b,
             (Self::Null, Self::Null) => true,
             (Self::Pair(a), Self::Pair(b)) => Gc::ptr_eq(&a.0, &b.0),
-            (Self::ByteVector(a), Self::ByteVector(b)) => Arc::ptr_eq(&a.0, &b.0),
             (Self::Procedure(a), Self::Procedure(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::Record(a), Self::Record(b)) => a.eq(b),
             (Self::RecordTypeDescriptor(a), Self::RecordTypeDescriptor(b)) => Arc::ptr_eq(a, b),
@@ -790,7 +764,6 @@ impl UnpackedValue {
             (Self::Null, Self::Null) => true,
             // Everything else is pointer equivalence
             (Self::Pair(a), Self::Pair(b)) => Gc::ptr_eq(&a.0, &b.0),
-            (Self::ByteVector(a), Self::ByteVector(b)) => Arc::ptr_eq(&a.0, &b.0),
             (Self::Procedure(a), Self::Procedure(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::Record(a), Self::Record(b)) => a.eqv(b),
             (Self::RecordTypeDescriptor(a), Self::RecordTypeDescriptor(b)) => Arc::ptr_eq(a, b),
@@ -808,7 +781,6 @@ impl UnpackedValue {
             Self::Character(_) => Symbol::intern("character").to_str(),
             Self::Symbol(_) => Symbol::intern("symbol").to_str(),
             Self::Pair(_) | Self::Null => Symbol::intern("pair").to_str(),
-            Self::ByteVector(_) => Symbol::intern("bytevector").to_str(),
             Self::Procedure(_) => Symbol::intern("procedure").to_str(),
             Self::Record(record) => record.rtd().name.to_str(),
             Self::RecordTypeDescriptor(_) => Symbol::intern("rtd").to_str(),
@@ -825,7 +797,6 @@ impl UnpackedValue {
             Self::Character(_) => ValueType::Character,
             Self::Symbol(_) => ValueType::Symbol,
             Self::Pair(_) => ValueType::Pair,
-            Self::ByteVector(_) => ValueType::ByteVector,
             Self::Procedure(_) => ValueType::Procedure,
             Self::Record(_) => ValueType::Record,
             Self::RecordTypeDescriptor(_) => ValueType::RecordTypeDescriptor,
@@ -865,8 +836,7 @@ fn fast(ht: &mut HashMap<Value, Value>, obj1: &Value, obj2: &Value, k: i64) -> O
     }
     match (obj1.type_of(), obj2.type_of()) {
         (ValueType::Pair, ValueType::Pair) => pair_eq(ht, obj1, obj2, k),
-        (ValueType::ByteVector, ValueType::ByteVector) => bytevector_eq(obj1, obj2, k),
-        (ValueType::Record, ValueType::Record) => record_equal(ht, obj1, obj2, k),
+        (ValueType::Record, ValueType::Record) => record_equal(ht, obj1.cast_to()?, obj2.cast_to()?, k),
         _ => None,
     }
 }
@@ -882,12 +852,13 @@ fn slow(ht: &mut HashMap<Value, Value>, obj1: &Value, obj2: &Value, k: i64) -> O
             }
             pair_eq(ht, obj1, obj2, k)
         }
-        (ValueType::ByteVector, ValueType::ByteVector) => bytevector_eq(obj1, obj2, k),
+        // (ValueType::ByteVector, ValueType::ByteVector) => bytevector_eq(obj1, obj2, k),
         (ValueType::Record, ValueType::Record) => {
             if union_find(ht, obj1, obj2) {
-                return Some(0);
+                Some(0)
+            } else {
+                record_equal(ht, obj1.cast_to()?, obj2.cast_to()?, k)
             }
-            record_equal(ht, obj1, obj2, k)
         }
         _ => None,
     }
@@ -901,9 +872,9 @@ fn pair_eq(ht: &mut HashMap<Value, Value>, obj1: &Value, obj2: &Value, k: i64) -
     e(ht, &car_x, &car_y, k - 1).and_then(|k| e(ht, &cdr_x, &cdr_y, k))
 }
 
-fn vector_eq(ht: &mut HashMap<Value, Value>, vobj1: Vector, vobj2: Vector, k: i64) -> Option<i64> {
-    let vobj1 = vobj1.0.vec.read();
-    let vobj2 = vobj2.0.vec.read();
+fn vector_eq(ht: &mut HashMap<Value, Value>, vobj1: Embedded<VectorInner<Value>>, vobj2: Embedded<VectorInner<Value>>, k: i64) -> Option<i64> {
+    let vobj1 = vobj1.vec.read();
+    let vobj2 = vobj2.vec.read();
     if vobj1.len() != vobj2.len() {
         return None;
     }
@@ -914,20 +885,22 @@ fn vector_eq(ht: &mut HashMap<Value, Value>, vobj1: Vector, vobj2: Vector, k: i6
     Some(k)
 }
 
+/*
 fn bytevector_eq(obj1: &Value, obj2: &Value, k: i64) -> Option<i64> {
     let obj1: ByteVector = obj1.clone().try_into().unwrap();
     let obj2: ByteVector = obj2.clone().try_into().unwrap();
     (*obj1.0.vec.read() == *obj2.0.vec.read()).then_some(k)
 }
+*/
 
-fn record_equal(ht: &mut HashMap<Value, Value>, obj1: &Value, obj2: &Value, k: i64) -> Option<i64> {
-    if let Some(vobj1) = obj1.cast_to::<Vector>()
-        && let Some(vobj2) = obj2.cast_to::<Vector>()
-    {
-        vector_eq(ht, vobj1, vobj2, k)
+fn record_equal(ht: &mut HashMap<Value, Value>, obj1: Record, obj2: Record, k: i64) -> Option<i64> {
+    if let Some(vobj1) = obj1.cast::<VectorInner<Value>>() {
+        obj2.cast::<VectorInner<Value>>().map_or(None, |vobj2| vector_eq(ht, vobj1, vobj2, k))
     } else {
+        /*
         let obj1: Record = obj1.clone().try_into().unwrap();
         let obj2: Record = obj2.clone().try_into().unwrap();
+        */
         (obj1.equal(&obj2)).then_some(k)
     }
 }
@@ -1173,7 +1146,6 @@ impl From<bool> for Value {
 impl_try_from_value_for!(char, Character, "char");
 impl_try_from_value_for!(Number, Number, "number");
 impl_try_from_value_for!(Symbol, Symbol, "symbol");
-impl_try_from_value_for!(ByteVector, ByteVector, "byte-vector");
 impl_try_from_value_for!(Procedure, Procedure, "procedure");
 impl_try_from_value_for!(Pair, Pair, "pair");
 impl_try_from_value_for!(Record, Record, "record");
@@ -1195,7 +1167,6 @@ macro_rules! impl_from_wrapped_for {
     };
 }
 
-impl_from_wrapped_for!(Vec<u8>, ByteVector, ByteVector::immutable);
 impl_from_wrapped_for!((Value, Value), Pair, |(car, cdr)| Pair::immutable(car, cdr));
 
 impl From<UnpackedValue> for Option<(Value, Value)> {

--- a/src/value.rs
+++ b/src/value.rs
@@ -80,7 +80,6 @@
 //! - **Record**: A [`Record`], which can possibly embed an
 //!   [`Embeddable`](records::Embeddable) Rust value.
 //! - **Record Type Descriptor**: A [descriptor of a record's type](RecordTypeDescriptor).
-//! - **Hashtable**: A [`HashTable`].
 //! - **Port**: A value that can handle [input/output](scheme_rs::ports::Port)
 //!   from the outside world.
 //! - **Cell**: A mutable reference to another Value. This type is completely
@@ -93,7 +92,6 @@ use parking_lot::RwLock;
 use crate::{
     exceptions::Exception,
     gc::{Gc, GcInner, Trace},
-    hashtables::{HashTable, HashTableInner},
     lists::{self, Pair, PairInner},
     num::{ComplexNumber, Number, NumberInner, SimpleNumber},
     ports::{Port, PortInner},
@@ -190,9 +188,6 @@ impl Value {
                     }
                 }
                 Tag::Port => Arc::increment_strong_count(untagged as *const PortInner),
-                Tag::HashTable => {
-                    Gc::increment_reference_count(untagged as *mut GcInner<HashTableInner>)
-                }
                 Tag::Cell => {
                     Gc::increment_reference_count(untagged as *mut GcInner<Value>);
                 }
@@ -262,7 +257,7 @@ impl Value {
 
     // TODO: These will be cast_to and try_to
 
-    /// Attempt to cast the value into a Scheme primitive type.
+    /// Attempt to cast the value.
     pub fn cast_to<T>(&self) -> Option<T>
     where
         for<'a> &'a Self: Into<Option<T>>,
@@ -277,49 +272,13 @@ impl Value {
         self.into().is_some()
     }
 
-    /// Attempt to cast the value into a Scheme primitive type and return a
-    /// descriptive error on failure.
+    /// Attempt to cast the value and return a descriptive error on failure.
     pub fn try_to<T>(&self) -> Result<T, Exception>
     where
         T: for<'a> TryFrom<&'a Self, Error = Exception>,
     {
         self.try_into()
     }
-
-    /*
-    /// Attempt to cast the value into a Rust type that implements
-    /// [`SchemeCompatible`].
-    pub fn cast_to_rust_type<T: SchemeCompatible>(&self) -> Option<Gc<T>> {
-        let UnpackedValue::Record(record) = self.clone().unpack() else {
-            return None;
-        };
-        record.cast::<T>()
-    }
-
-    /// Attempt to cast the value into a Rust type and return a descriptive
-    /// error on failure.
-    pub fn try_to_rust_type<T: Embeddable>(&self) -> Result<Gc<T>, Exception> {
-        let type_name = T::rtd().name.to_str();
-        let this = self.clone().unpack();
-        let record = match this {
-            UnpackedValue::Record(record) => record,
-            e => return Err(Exception::type_error(&type_name, e.type_name())),
-        };
-
-        record
-            .cast::<T>()
-            .ok_or_else(|| Exception::type_error(&type_name, &record.rtd().name.to_str()))
-    }
-    */
-
-    /*
-    /// Automatically convert a `SchemeCompatible` type to a `Record` and then
-    /// into a `Value`.
-    pub fn embed<T: Embeddable>(t: T) -> Self {
-        // Self::from(Record::from_rust_type(t))
-        todo!()
-    }
-    */
 
     /// Unpack the value into an enum representation.
     pub fn unpack(self) -> UnpackedValue {
@@ -384,10 +343,6 @@ impl Value {
                 let port_inner = unsafe { Arc::from_raw(untagged as *const PortInner) };
                 UnpackedValue::Port(Port(port_inner))
             }
-            Tag::HashTable => {
-                let ht = unsafe { Gc::from_raw(untagged as *mut GcInner<HashTableInner>) };
-                UnpackedValue::HashTable(HashTable(ht))
-            }
             Tag::Cell => {
                 let cell = unsafe { Gc::from_raw(untagged as *mut GcInner<RwLock<Value>>) };
                 UnpackedValue::Cell(Cell(cell))
@@ -443,7 +398,6 @@ impl Value {
             UnpackedValue::Pair(p) => Gc::as_ptr(&p.0).hash(state),
             UnpackedValue::Vector(v) => Gc::as_ptr(&v.0).hash(state),
             UnpackedValue::Port(p) => Arc::as_ptr(&p.0).hash(state),
-            UnpackedValue::HashTable(ht) => Gc::as_ptr(&ht.0).hash(state),
             UnpackedValue::Cell(c) => c.0.read().eqv_hash(state),
         }
     }
@@ -468,7 +422,6 @@ impl Value {
             UnpackedValue::Pair(p) => Gc::as_ptr(&p.0).hash(state),
             UnpackedValue::Vector(v) => Gc::as_ptr(&v.0).hash(state),
             UnpackedValue::Port(p) => Arc::as_ptr(&p.0).hash(state),
-            UnpackedValue::HashTable(ht) => Gc::as_ptr(&ht.0).hash(state),
             UnpackedValue::Cell(c) => c.0.read().eqv_hash(state),
         }
     }
@@ -513,7 +466,6 @@ impl Value {
                 }
             }
             UnpackedValue::Port(p) => Arc::as_ptr(&p.0).hash(state),
-            UnpackedValue::HashTable(ht) => Gc::as_ptr(&ht.0).hash(state),
             UnpackedValue::Cell(c) => c.0.read().eqv_hash(state),
         }
     }
@@ -682,7 +634,6 @@ pub(crate) enum Tag {
     Procedure = 10,
     Record = 11,
     RecordTypeDescriptor = 12,
-    HashTable = 13,
     Port = 14,
     Cell = 15,
 }
@@ -704,7 +655,6 @@ impl From<usize> for Tag {
             10 => Self::Procedure,
             11 => Self::Record,
             12 => Self::RecordTypeDescriptor,
-            13 => Self::HashTable,
             14 => Self::Port,
             15 => Self::Cell,
             tag => panic!("Invalid tag: {tag}"),
@@ -729,7 +679,6 @@ pub enum ValueType {
     Procedure,
     Record,
     RecordTypeDescriptor,
-    HashTable,
     Port,
 }
 
@@ -755,7 +704,6 @@ pub enum UnpackedValue {
     RecordTypeDescriptor(Arc<RecordTypeDescriptor>),
     Pair(Pair),
     Port(Port),
-    HashTable(HashTable),
     Cell(Cell),
 }
 
@@ -813,10 +761,6 @@ impl UnpackedValue {
                 let untagged = Arc::into_raw(port.0);
                 Value::from_ptr_and_tag(untagged, Tag::Port)
             }
-            Self::HashTable(ht) => {
-                let untagged = Gc::into_raw(ht.0);
-                Value::from_ptr_and_tag(untagged, Tag::HashTable)
-            }
             Self::Cell(cell) => {
                 let untagged = Gc::into_raw(cell.0);
                 Value::from_mut_ptr_and_tag(untagged, Tag::Cell)
@@ -841,7 +785,6 @@ impl UnpackedValue {
             (Self::Record(a), Self::Record(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::RecordTypeDescriptor(a), Self::RecordTypeDescriptor(b)) => Arc::ptr_eq(a, b),
             (Self::Port(a), Self::Port(b)) => Arc::ptr_eq(&a.0, &b.0),
-            (Self::HashTable(a), Self::HashTable(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::Cell(a), b) => a.0.read().unpacked_ref().eq(b),
             (a, Self::Cell(b)) => a.eq(&b.0.read().unpacked_ref()),
             _ => false,
@@ -872,7 +815,6 @@ impl UnpackedValue {
             (Self::Record(a), Self::Record(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::RecordTypeDescriptor(a), Self::RecordTypeDescriptor(b)) => Arc::ptr_eq(a, b),
             (Self::Port(a), Self::Port(b)) => Arc::ptr_eq(&a.0, &b.0),
-            (Self::HashTable(a), Self::HashTable(b)) => Gc::ptr_eq(&a.0, &b.0),
             (Self::Cell(a), b) => a.0.read().unpacked_ref().eqv(b),
             (a, Self::Cell(b)) => a.eqv(&b.0.read().unpacked_ref()),
             _ => false,
@@ -895,7 +837,6 @@ impl UnpackedValue {
             Self::Record(_) => "record",
             Self::RecordTypeDescriptor(_) => "rtd",
             Self::Port(_) => "port",
-            Self::HashTable(_) => "hashtable",
             Self::Cell(cell) => cell.0.read().type_name(),
         }
     }
@@ -917,7 +858,6 @@ impl UnpackedValue {
             Self::Record(_) => ValueType::Record,
             Self::RecordTypeDescriptor(_) => ValueType::RecordTypeDescriptor,
             Self::Port(_) => ValueType::Port,
-            Self::HashTable(_) => ValueType::HashTable,
             Self::Cell(cell) => cell.0.read().type_of(),
         }
     }
@@ -1268,7 +1208,6 @@ impl_try_from_value_for!(Procedure, Procedure, "procedure");
 impl_try_from_value_for!(Pair, Pair, "pair");
 impl_try_from_value_for!(Record, Record, "record");
 impl_try_from_value_for!(Port, Port, "port");
-impl_try_from_value_for!(HashTable, HashTable, "hashtable");
 impl_try_from_value_for!(Arc<RecordTypeDescriptor>, RecordTypeDescriptor, "rt");
 
 macro_rules! impl_from_wrapped_for {
@@ -1558,7 +1497,6 @@ fn display_value(
         UnpackedValue::Syntax(syntax) => write!(f, "#<syntax {syntax:#?}>"),
         UnpackedValue::RecordTypeDescriptor(rtd) => write!(f, "{rtd:?}"),
         UnpackedValue::Port(_) => write!(f, "<port>"),
-        UnpackedValue::HashTable(hashtable) => write!(f, "{hashtable:?}"),
         UnpackedValue::Cell(cell) => display_value(&cell.0.read(), circular_values, f),
     }
 }
@@ -1591,7 +1529,6 @@ fn debug_value(
         UnpackedValue::Record(record) => write!(f, "{record:#?}"),
         UnpackedValue::RecordTypeDescriptor(rtd) => write!(f, "{rtd:?}"),
         UnpackedValue::Port(_) => write!(f, "<port>"),
-        UnpackedValue::HashTable(hashtable) => write!(f, "{hashtable:?}"),
         UnpackedValue::Cell(cell) => debug_value(&cell.0.read(), circular_values, f),
     }
 }

--- a/src/vectors.rs
+++ b/src/vectors.rs
@@ -133,7 +133,7 @@ impl TryFrom<Value> for Vector {
 
 impl From<&Value> for Option<Vector> {
     fn from(value: &Value) -> Self {
-        Some(Vector(value.cast_to()?))
+        Some(Vector(value.cast()?))
     }
 }
 
@@ -300,7 +300,7 @@ impl TryFrom<Value> for ByteVector {
 
 impl From<&Value> for Option<ByteVector> {
     fn from(value: &Value) -> Self {
-        Some(ByteVector(value.cast_to()?))
+        Some(ByteVector(value.cast()?))
     }
 }
 

--- a/src/vectors.rs
+++ b/src/vectors.rs
@@ -169,9 +169,43 @@ impl From<Vector> for Value {
     }
 }
 
+unsafe impl Embeddable for VectorInner<u8> {
+    fn rtd() -> Arc<crate::records::RecordTypeDescriptor>
+    where
+        Self: Sized,
+    {
+        rtd!(ty: VectorInner<u8>, name: "bytevector", sealed: true, opaque: true)
+    }
+
+    fn debug_fmt(
+        &self,
+        _circular_values: &mut IndexMap<Value, bool>,
+        fmt: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        write_bytevec(self, fmt)
+    }
+
+    fn equal(&self, rhs: &Record) -> bool
+    where
+        Self: Sized,
+    {
+        let Some(rhs) = rhs.cast::<Self>() else {
+            return false;
+        };
+        *self.vec.read() == *rhs.vec.read()
+    }
+
+    fn equal_hash(&self, _recursive: &mut IndexSet<Value>, hasher: &mut dyn std::hash::Hasher)
+    where
+        Self: Sized,
+    {
+        self.vec.read().hash(&mut DynHasher(hasher))
+    }
+}
+
 /// A vector of bytes
 #[derive(Clone, Trace)]
-pub struct ByteVector(pub(crate) Arc<VectorInner<u8>>);
+pub struct ByteVector(pub(crate) Embedded<VectorInner<u8>>);
 
 impl ByteVector {
     pub fn immutable(vec: Vec<u8>) -> Self {
@@ -179,7 +213,7 @@ impl ByteVector {
     }
 
     pub fn mutable(vec: Vec<u8>) -> Self {
-        Self(Arc::new(VectorInner {
+        Self(Embedded::new(VectorInner {
             vec: RwLock::new(vec),
             mutable: true,
         }))
@@ -231,7 +265,7 @@ impl ByteVector {
 
 impl From<Vec<u8>> for ByteVector {
     fn from(vec: Vec<u8>) -> Self {
-        Self(Arc::new(VectorInner {
+        Self(Embedded::new(VectorInner {
             vec: RwLock::new(vec),
             mutable: false,
         }))
@@ -256,6 +290,40 @@ impl PartialEq for ByteVector {
     }
 }
 
+impl TryFrom<Value> for ByteVector {
+    type Error = Exception;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        Ok(Self((&value).try_into()?))
+    }
+}
+
+impl From<&Value> for Option<ByteVector> {
+    fn from(value: &Value) -> Self {
+        Some(ByteVector(value.cast_to()?))
+    }
+}
+
+impl TryFrom<&Value> for ByteVector {
+    type Error = Exception;
+
+    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+        Ok(Self(value.try_into()?))
+    }
+}
+
+impl From<Vec<u8>> for Value {
+    fn from(value: Vec<u8>) -> Self {
+        Value::from(ByteVector::from(value))
+    }
+}
+
+impl From<ByteVector> for Value {
+    fn from(vec: ByteVector) -> Self {
+        Value::from(vec.0)
+    }
+}
+
 pub(crate) fn write_vec(
     v: &VectorInner<Value>,
     fmt: fn(&Value, &mut IndexMap<Value, bool>, &mut fmt::Formatter<'_>) -> fmt::Result,
@@ -275,10 +343,13 @@ pub(crate) fn write_vec(
     write!(f, ")")
 }
 
-pub(crate) fn write_bytevec(v: &ByteVector, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+pub(crate) fn write_bytevec(
+    v: &VectorInner<u8>,
+    f: &mut fmt::Formatter<'_>,
+) -> Result<(), fmt::Error> {
     write!(f, "#vu8(")?;
 
-    let bytes = v.0.vec.read();
+    let bytes = v.vec.read();
     for (i, byte) in bytes.iter().enumerate() {
         if i > 0 {
             write!(f, " ")?;
@@ -548,8 +619,8 @@ pub fn native_endianness() -> Result<Vec<Value>, Exception> {
 }
 
 #[bridge(name = "bytevector?", lib = "(rnrs bytevectors (6))")]
-pub fn bytevector_pred(arg: &Value) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(arg.type_of() == ValueType::ByteVector)])
+pub fn bytevector_pred(arg: &Value) -> bool {
+    arg.is_a::<Embedded<VectorInner<u8>>>()
 }
 
 #[bridge(name = "make-bytevector", lib = "(rnrs bytevectors (6))")]

--- a/src/vectors.rs
+++ b/src/vectors.rs
@@ -40,7 +40,7 @@ unsafe impl Embeddable for VectorInner<Value> {
         circular_values: &mut IndexMap<Value, bool>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> fmt::Result {
-        write_vec(&self, Value::display_fmt, circular_values, fmt)
+        write_vec(self, Value::display_fmt, circular_values, fmt)
     }
 
     fn debug_fmt(
@@ -48,7 +48,7 @@ unsafe impl Embeddable for VectorInner<Value> {
         circular_values: &mut IndexMap<Value, bool>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> fmt::Result {
-        write_vec(&self, Value::debug_fmt, circular_values, fmt)
+        write_vec(self, Value::debug_fmt, circular_values, fmt)
     }
 
     fn equal(&self, rhs: &Record) -> bool

--- a/src/vectors.rs
+++ b/src/vectors.rs
@@ -276,7 +276,7 @@ impl Indexer for VectorIndexer {
 
 #[bridge(name = "make-vector", lib = "(rnrs base builtins (6))")]
 pub fn make_vector(n: &Value, with: &[Value]) -> Result<Vec<Value>, Exception> {
-    let n: usize = n.try_to_scheme_type()?;
+    let n: usize = n.try_to()?;
 
     Ok(vec![Value::from(Vector(Gc::new(VectorInner {
         vec: RwLock::new(

--- a/src/vectors.rs
+++ b/src/vectors.rs
@@ -5,11 +5,11 @@ use crate::symbols::Symbol;
 use crate::{
     DynHasher,
     exceptions::Exception,
-    gc::{Gc, Trace},
+    gc::Trace,
     lists::{List, slice_to_list},
     records::{Embeddable, Embedded, Record},
     registry::bridge,
-    value::{Value, ValueType, write_value},
+    value::{Value, write_value},
 };
 use indexmap::{IndexMap, IndexSet};
 use parking_lot::{

--- a/src/vectors.rs
+++ b/src/vectors.rs
@@ -3,16 +3,19 @@
 #[cfg(target_endian = "little")]
 use crate::symbols::Symbol;
 use crate::{
+    DynHasher,
     exceptions::Exception,
     gc::{Gc, Trace},
     lists::{List, slice_to_list},
+    records::{Embeddable, Embedded, Record},
     registry::bridge,
     value::{Value, ValueType, write_value},
 };
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use parking_lot::{
     MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock, RwLockReadGuard, RwLockWriteGuard,
 };
+use scheme_rs_macros::rtd;
 use std::{clone::Clone, fmt, hash::Hash, ops::Range, sync::Arc};
 
 #[derive(Trace)]
@@ -24,9 +27,55 @@ pub(crate) struct VectorInner<T: Trace> {
     pub(crate) mutable: bool,
 }
 
+unsafe impl Embeddable for VectorInner<Value> {
+    fn rtd() -> Arc<crate::records::RecordTypeDescriptor>
+    where
+        Self: Sized,
+    {
+        rtd!(ty: VectorInner<Value>, name: "vector", sealed: true, opaque: true)
+    }
+
+    fn display_fmt(
+        &self,
+        circular_values: &mut IndexMap<Value, bool>,
+        fmt: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        write_vec(&self, Value::display_fmt, circular_values, fmt)
+    }
+
+    fn debug_fmt(
+        &self,
+        circular_values: &mut IndexMap<Value, bool>,
+        fmt: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        write_vec(&self, Value::debug_fmt, circular_values, fmt)
+    }
+
+    fn equal(&self, rhs: &Record) -> bool
+    where
+        Self: Sized,
+    {
+        let Some(rhs) = rhs.cast::<Self>() else {
+            return false;
+        };
+        *self.vec.read() == *rhs.vec.read()
+    }
+
+    fn equal_hash(&self, recursive: &mut IndexSet<Value>, hasher: &mut dyn std::hash::Hasher)
+    where
+        Self: Sized,
+    {
+        let v_read = self.vec.read();
+        hasher.write_usize(v_read.len());
+        for val in v_read.iter() {
+            val.equal_hash(recursive, &mut DynHasher(hasher));
+        }
+    }
+}
+
 /// A vector of values
 #[derive(Clone, Trace)]
-pub struct Vector(pub(crate) Gc<VectorInner<Value>>);
+pub struct Vector(pub(crate) Embedded<VectorInner<Value>>);
 
 impl Vector {
     pub fn immutable(vec: Vec<Value>) -> Self {
@@ -34,7 +83,7 @@ impl Vector {
     }
 
     pub fn mutable(vec: Vec<Value>) -> Self {
-        Self(Gc::new(VectorInner {
+        Self(Embedded::new(VectorInner {
             vec: RwLock::new(vec),
             mutable: true,
         }))
@@ -74,12 +123,49 @@ impl Vector {
     }
 }
 
+impl TryFrom<Value> for Vector {
+    type Error = Exception;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        Ok(Self((&value).try_into()?))
+    }
+}
+
+impl From<&Value> for Option<Vector> {
+    fn from(value: &Value) -> Self {
+        Some(Vector(value.cast_to()?))
+    }
+}
+
+impl TryFrom<&Value> for Vector {
+    type Error = Exception;
+
+    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+        Ok(Self(value.try_into()?))
+    }
+}
+
 impl From<Vec<Value>> for Vector {
     fn from(vec: Vec<Value>) -> Self {
-        Self(Gc::new(VectorInner {
+        Self(Embedded::new(VectorInner {
             vec: RwLock::new(vec),
             mutable: false,
         }))
+    }
+}
+
+impl From<Vec<Value>> for Value {
+    fn from(vec: Vec<Value>) -> Self {
+        Value::from(VectorInner {
+            vec: RwLock::new(vec),
+            mutable: false,
+        })
+    }
+}
+
+impl From<Vector> for Value {
+    fn from(vec: Vector) -> Self {
+        Value::from(vec.0)
     }
 }
 
@@ -171,15 +257,14 @@ impl PartialEq for ByteVector {
 }
 
 pub(crate) fn write_vec(
-    v: &Vector,
+    v: &VectorInner<Value>,
     fmt: fn(&Value, &mut IndexMap<Value, bool>, &mut fmt::Formatter<'_>) -> fmt::Result,
     circular_values: &mut IndexMap<Value, bool>,
     f: &mut fmt::Formatter<'_>,
 ) -> Result<(), fmt::Error> {
     write!(f, "#(")?;
 
-    let values = v.0.vec.read();
-
+    let values = v.vec.read();
     for (i, value) in values.iter().enumerate() {
         if i > 0 {
             write!(f, " ")?;
@@ -267,33 +352,38 @@ impl Indexer for VectorIndexer {
             .take(range.end - range.start)
             .cloned()
             .collect();
-        Vector(Gc::new(VectorInner {
+        Vector(Embedded::new(VectorInner {
             vec: RwLock::new(subvec),
             mutable: true,
         }))
     }
 }
 
+#[bridge(name = "vector?", lib = "(rnrs base builtins (6))")]
+pub fn vector_pred(arg: &Value) -> bool {
+    arg.is_a::<Vector>()
+}
+
 #[bridge(name = "make-vector", lib = "(rnrs base builtins (6))")]
 pub fn make_vector(n: &Value, with: &[Value]) -> Result<Vec<Value>, Exception> {
     let n: usize = n.try_to()?;
 
-    Ok(vec![Value::from(Vector(Gc::new(VectorInner {
+    Ok(vec![Value::from(VectorInner {
         vec: RwLock::new(
             (0..n)
                 .map(|_| with.first().cloned().unwrap_or_else(Value::null))
                 .collect::<Vec<_>>(),
         ),
         mutable: true,
-    })))])
+    })])
 }
 
 #[bridge(name = "vector", lib = "(rnrs base builtins (6))")]
 pub fn vector(args: &[Value]) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(Vector(Gc::new(VectorInner {
+    Ok(vec![Value::from(VectorInner {
         vec: RwLock::new(args.to_vec()),
         mutable: true,
-    })))])
+    })])
 }
 
 #[bridge(name = "vector-ref", lib = "(rnrs base builtins (6))")]


### PR DESCRIPTION
This PR creates a new layout for records, changing them to be a dynamically sized type. Rust types embedded in Records are a part of the record's memory, and do not have a separate allocation.

Besides improving the record layout, there are additional changes/improvements:
- `rtd!` now needs to take the type being embedded so it can properly create a VTable.
- `SchemeCompatible` has been renamed `Embeddable` and is now unsafe due to requiring a match with `rtd!`, using a RTD for a different type is undefined behavior.
Because of the above two points, we plan on creating an `Embeddable` derive macro that makes all of this much easier.
- Beyond improved layout, `Embeddable` allows for custom debug, eq/eqv/equal and eq_hash/eqv_hash/equal_hash functions allowing for a much higher degree of customization.
- The specialized `cast_to_rust_type` and `try_to_rust_type` functions have been removed, now there are just `cast` and `try_to`.
- Instead of converting to a `Gc<T>` using the `cast_to_rust_type`, you can use `cast` or `try_to` to an `Embedded<T>`. Embedded is a smart pointer to the embedded rust type.
- With this unification, TryInto works as expected for Embedded types, and they can now be used as arguments to bridge functions.