### PR TITLE
[1/5] Share dynamic state across nested re-entry into Scheme

### DIFF
--- a/benches/fib.rs
+++ b/benches/fib.rs
@@ -29,7 +29,7 @@ fn fib_benchmark(c: &mut Criterion) {
     let proc = fib_fn();
 
     c.bench_function("fib 10000", |b| {
-        b.iter(|| proc.call(&[], &mut ContBarrier::new()))
+        b.iter(|| proc.call(&[], &mut ContBarrier::root()))
     });
 }
 
@@ -42,7 +42,7 @@ fn fib_benchmark(c: &mut Criterion) {
     c.bench_function("fib 10000", |b| {
         b.to_async(&runtime).iter(|| {
             let val = proc.clone();
-            async move { val.call(&[], &mut ContBarrier::new()).await }
+            async move { val.call(&[], &mut ContBarrier::root()).await }
         })
     });
 }

--- a/benches/fib.rs
+++ b/benches/fib.rs
@@ -1,9 +1,4 @@
-use scheme_rs::{
-    env::TopLevelEnvironment,
-    proc::{ContBarrier, Procedure},
-    runtime::Runtime,
-    value::Expect1,
-};
+use scheme_rs::{env::TopLevelEnvironment, proc::Procedure, runtime::Runtime, value::Expect1};
 
 use criterion::*;
 use scheme_rs_macros::{maybe_async, maybe_await};
@@ -28,9 +23,7 @@ fn fib_fn() -> Procedure {
 fn fib_benchmark(c: &mut Criterion) {
     let proc = fib_fn();
 
-    c.bench_function("fib 10000", |b| {
-        b.iter(|| proc.call(&[], &mut ContBarrier::root()))
-    });
+    c.bench_function("fib 10000", |b| b.iter(|| proc.call(&[])));
 }
 
 #[cfg(feature = "async")]
@@ -42,7 +35,7 @@ fn fib_benchmark(c: &mut Criterion) {
     c.bench_function("fib 10000", |b| {
         b.to_async(&runtime).iter(|| {
             let val = proc.clone();
-            async move { val.call(&[], &mut ContBarrier::root()).await }
+            async move { val.call(&[]).await }
         })
     });
 }

--- a/benches/integrate.rs
+++ b/benches/integrate.rs
@@ -23,7 +23,7 @@ fn integrate_benchmark(c: &mut Criterion) {
     let proc = integrate_fn();
 
     c.bench_function("integrate", |b| {
-        b.iter(|| proc.call(&[], &mut ContBarrier::new()));
+        b.iter(|| proc.call(&[], &mut ContBarrier::root()));
     });
 }
 
@@ -36,7 +36,7 @@ fn integrate_benchmark(c: &mut Criterion) {
     c.bench_function("integrate", |b| {
         b.to_async(&runtime).iter(|| {
             let val = proc.clone();
-            async move { val.call(&[], &mut ContBarrier::new()).await }
+            async move { val.call(&[], &mut ContBarrier::root()).await }
         })
     });
 }

--- a/benches/integrate.rs
+++ b/benches/integrate.rs
@@ -1,9 +1,4 @@
-use scheme_rs::{
-    env::TopLevelEnvironment,
-    proc::{ContBarrier, Procedure},
-    runtime::Runtime,
-    value::Expect1,
-};
+use scheme_rs::{env::TopLevelEnvironment, proc::Procedure, runtime::Runtime, value::Expect1};
 
 use criterion::*;
 use scheme_rs_macros::{maybe_async, maybe_await};
@@ -23,7 +18,7 @@ fn integrate_benchmark(c: &mut Criterion) {
     let proc = integrate_fn();
 
     c.bench_function("integrate", |b| {
-        b.iter(|| proc.call(&[], &mut ContBarrier::root()));
+        b.iter(|| proc.call(&[]));
     });
 }
 
@@ -36,7 +31,7 @@ fn integrate_benchmark(c: &mut Criterion) {
     c.bench_function("integrate", |b| {
         b.to_async(&runtime).iter(|| {
             let val = proc.clone();
-            async move { val.call(&[], &mut ContBarrier::root()).await }
+            async move { val.call(&[]).await }
         })
     });
 }

--- a/benches/yin_yang.rs
+++ b/benches/yin_yang.rs
@@ -30,7 +30,7 @@ fn yin_yang_benchmark(c: &mut Criterion) {
     let proc = yin_yang_fn();
 
     c.bench_function("yin_yang", |b| {
-        b.iter(|| proc.call(&[], &mut ContBarrier::new()));
+        b.iter(|| proc.call(&[], &mut ContBarrier::root()));
     });
 }
 
@@ -43,7 +43,7 @@ fn yin_yang_benchmark(c: &mut Criterion) {
     c.bench_function("yin_yang", |b| {
         b.to_async(&runtime).iter(|| {
             let val = proc.clone();
-            async move { val.call(&[], &mut ContBarrier::new()).await }
+            async move { val.call(&[], &mut ContBarrier::root()).await }
         })
     });
 }

--- a/benches/yin_yang.rs
+++ b/benches/yin_yang.rs
@@ -1,9 +1,4 @@
-use scheme_rs::{
-    env::TopLevelEnvironment,
-    proc::{ContBarrier, Procedure},
-    runtime::Runtime,
-    value::Expect1,
-};
+use scheme_rs::{env::TopLevelEnvironment, proc::Procedure, runtime::Runtime, value::Expect1};
 
 use criterion::*;
 use scheme_rs_macros::{maybe_async, maybe_await};
@@ -30,7 +25,7 @@ fn yin_yang_benchmark(c: &mut Criterion) {
     let proc = yin_yang_fn();
 
     c.bench_function("yin_yang", |b| {
-        b.iter(|| proc.call(&[], &mut ContBarrier::root()));
+        b.iter(|| proc.call(&[]));
     });
 }
 
@@ -43,7 +38,7 @@ fn yin_yang_benchmark(c: &mut Criterion) {
     c.bench_function("yin_yang", |b| {
         b.to_async(&runtime).iter(|| {
             let val = proc.clone();
-            async move { val.call(&[], &mut ContBarrier::root()).await }
+            async move { val.call(&[]).await }
         })
     });
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1135,7 +1135,7 @@ pub(super) fn define_syntax(
     let mut mutable_vars = HashSet::default();
     let expr = maybe_await!(Expression::parse(ctxt, expanded, env, &mut mutable_vars))?;
     let proc = maybe_await!(Compiler::new(mutable_vars).compile(&ctxt.runtime, &expr))?;
-    let values = maybe_await!(proc.call(&[], &mut ContBarrier::new()))?;
+    let values = maybe_await!(proc.call(&[], &mut ContBarrier::nested()))?;
     let transformer: Procedure = values.expect1()?;
     env.def_keyword(binding, transformer);
     Ok(())

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -11,7 +11,7 @@ use crate::{
     exceptions::Exception,
     expand::{SyntaxRule, Template},
     gc::Trace,
-    proc::{ContBarrier, Procedure},
+    proc::Procedure,
     runtime::Runtime,
     symbols::Symbol,
     syntax::{Identifier, Span, Syntax},
@@ -1135,7 +1135,7 @@ pub(super) fn define_syntax(
     let mut mutable_vars = HashSet::default();
     let expr = maybe_await!(Expression::parse(ctxt, expanded, env, &mut mutable_vars))?;
     let proc = maybe_await!(Compiler::new(mutable_vars).compile(&ctxt.runtime, &expr))?;
-    let values = maybe_await!(proc.call(&[], &mut ContBarrier::nested()))?;
+    let values = maybe_await!(proc.call(&[]))?;
     let transformer: Procedure = values.expect1()?;
     env.def_keyword(binding, transformer);
     Ok(())

--- a/src/docs.md
+++ b/src/docs.md
@@ -99,7 +99,7 @@ anywhere.
 let [result] = factorial
     .call(
         &[Value::from(5)],
-        &mut ContBarrier::new(),
+        &mut ContBarrier::root(),
     )
     .unwrap()
     .try_into()

--- a/src/docs.md
+++ b/src/docs.md
@@ -85,6 +85,9 @@ callbacks that re-enter Scheme from within a running evaluation, sharing
 the caller's dynamic state under a fresh id; and spawning concurrent work
 (a thread, task, or future) gets a filtered snapshot of the ambient state
 automatically, handled internally by the threads and async libraries.
+Top-level evaluation (programs, REPL forms, and library bodies) runs
+against a root dynamic state owned by the `Runtime` itself, so dynamic
+state established while loading libraries persists for the Runtime's life.
 
 ```rust
 # use scheme_rs::{

--- a/src/docs.md
+++ b/src/docs.md
@@ -75,6 +75,17 @@ automatically garbage collected and implement `Send` and `Sync` and are
 `'static` so you can hold on to them for as long as you want and put them
 anywhere.
 
+Calling a procedure requires a [`ContBarrier`](proc::ContBarrier), which
+carries the current continuation barrier's identity and its dynamic state
+(exception handlers, current ports, and the like). There are three ways to
+get one: [`ContBarrier::root`](proc::ContBarrier::root) starts a fresh,
+empty dynamic state, for embedder entry points with no ambient Scheme
+state to inherit; [`ContBarrier::nested`](proc::ContBarrier::nested) is for
+callbacks that re-enter Scheme from within a running evaluation, sharing
+the caller's dynamic state under a fresh id; and spawning concurrent work
+(a thread, task, or future) gets a filtered snapshot of the ambient state
+automatically, handled internally by the threads and async libraries.
+
 ```rust
 # use scheme_rs::{
 # runtime::Runtime, env::TopLevelEnvironment, value::Value, proc::{ContBarrier, Procedure},

--- a/src/docs.md
+++ b/src/docs.md
@@ -75,23 +75,23 @@ automatically garbage collected and implement `Send` and `Sync` and are
 `'static` so you can hold on to them for as long as you want and put them
 anywhere.
 
-Calling a procedure requires a [`ContBarrier`](proc::ContBarrier), which
-carries the current continuation barrier's identity and its dynamic state
-(exception handlers, current ports, and the like). There are three ways to
-get one: [`ContBarrier::root`](proc::ContBarrier::root) starts a fresh,
-empty dynamic state, for embedder entry points with no ambient Scheme
-state to inherit; [`ContBarrier::nested`](proc::ContBarrier::nested) is for
-callbacks that re-enter Scheme from within a running evaluation, sharing
-the caller's dynamic state under a fresh id; and spawning concurrent work
-(a thread, task, or future) gets a filtered snapshot of the ambient state
-automatically, handled internally by the threads and async libraries.
+Calling a procedure runs it in the ambient dynamic extent (exception
+handlers, current ports, and the like): `call` shares the running task's
+dynamic state when called from within an evaluation and starts a fresh one
+otherwise. For explicit control — supplying host parameters (see
+`add_param`) or an explicit dynamic state — use
+[`Procedure::call_with_barrier`](proc::Procedure::call_with_barrier) with a
+[`ContBarrier`](proc::ContBarrier) constructed via
+[`ContBarrier::root`](proc::ContBarrier::root) (a fresh, empty dynamic
+state) or [`ContBarrier::nested`](proc::ContBarrier::nested) (the ambient
+dynamic state under a fresh id).
 Top-level evaluation (programs, REPL forms, and library bodies) runs
 against a root dynamic state owned by the `Runtime` itself, so dynamic
 state established while loading libraries persists for the Runtime's life.
 
 ```rust
 # use scheme_rs::{
-# runtime::Runtime, env::TopLevelEnvironment, value::Value, proc::{ContBarrier, Procedure},
+# runtime::Runtime, env::TopLevelEnvironment, value::Value, proc::Procedure,
 # };
 # let runtime = Runtime::new();
 # let env = TopLevelEnvironment::new_repl(&runtime);
@@ -111,10 +111,7 @@ state established while loading libraries persists for the Runtime's life.
 # .unwrap();
 # let factorial = factorial.cast::<Procedure>().unwrap();
 let [result] = factorial
-    .call(
-        &[Value::from(5)],
-        &mut ContBarrier::root(),
-    )
+    .call(&[Value::from(5)])
     .unwrap()
     .try_into()
     .unwrap();
@@ -299,7 +296,7 @@ pub fn call_with_var(
     
     // Call the thunk arg with the new dyn state:
     let thunk: Procedure = args[0].clone().try_into()?;
-    let result = thunk.call(&[], &mut new_barrier)?;
+    let result = thunk.call_with_barrier(&[], &mut new_barrier)?;
     
     // Return to the continuation:
     Ok(Application::new(k, None, result))

--- a/src/env.rs
+++ b/src/env.rs
@@ -24,7 +24,7 @@ use crate::{
     cps::compile::Compiler,
     exceptions::Exception,
     gc::{Gc, Trace},
-    proc::{Application, ContBarrier, Procedure},
+    proc::{Application, Procedure},
     runtime::Runtime,
     symbols::Symbol,
     syntax::{Identifier, Span, Syntax},
@@ -332,7 +332,8 @@ impl TopLevelEnvironment {
             &mut mutable_vars,
         ))?;
         let compiled = maybe_await!(Compiler::new(mutable_vars).compile(&rt, &body))?;
-        maybe_await!(Application::new(compiled, None, Vec::new()).eval(&mut ContBarrier::new()))
+        let mut barrier = rt.entry_barrier();
+        maybe_await!(Application::new(compiled, None, Vec::new()).eval(&mut barrier))
     }
 
     #[maybe_async]
@@ -354,7 +355,8 @@ impl TopLevelEnvironment {
             &mut mutable_vars,
         ))?;
         let compiled = maybe_await!(Compiler::new(mutable_vars).compile(&rt, &body))?;
-        maybe_await!(Application::new(compiled, None, Vec::new()).eval(&mut ContBarrier::new()))
+        let mut barrier = rt.entry_barrier();
+        maybe_await!(Application::new(compiled, None, Vec::new()).eval(&mut barrier))
     }
 
     #[maybe_async]
@@ -434,8 +436,8 @@ impl TopLevelEnvironment {
         };
         let rt = { self.0.read().rt.clone() };
         let proc = maybe_await!(Compiler::new(mutable_vars).compile(&rt, &defn_body))?;
-        let _ =
-            maybe_await!(Application::new(proc, None, Vec::new()).eval(&mut ContBarrier::new()))?;
+        let mut barrier = rt.entry_barrier();
+        let _ = maybe_await!(Application::new(proc, None, Vec::new()).eval(&mut barrier))?;
         self.0.write().state = LibraryState::Invoked;
         Ok(())
     }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -37,7 +37,7 @@ pub fn eval(
     let mut mutable_vars = HashSet::default();
     let expr = maybe_await!(Expression::parse(&ctxt, expr, &env, &mut mutable_vars))?;
     let proc = maybe_await!(Compiler::new(mutable_vars).compile(runtime, &expr))?;
-    let result = maybe_await!(proc.call(&[], &mut ContBarrier::nested()))?;
+    let result = maybe_await!(proc.call(&[]))?;
     Ok(Application::new(k, None, result))
 }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -37,7 +37,7 @@ pub fn eval(
     let mut mutable_vars = HashSet::default();
     let expr = maybe_await!(Expression::parse(&ctxt, expr, &env, &mut mutable_vars))?;
     let proc = maybe_await!(Compiler::new(mutable_vars).compile(runtime, &expr))?;
-    let result = maybe_await!(proc.call(&[], &mut ContBarrier::new()))?;
+    let result = maybe_await!(proc.call(&[], &mut ContBarrier::nested()))?;
     Ok(Application::new(k, None, result))
 }
 

--- a/src/futures.rs
+++ b/src/futures.rs
@@ -37,9 +37,12 @@ unsafe impl Embeddable for Future {
 #[bridge(name = "future", lib = "(async)")]
 pub async fn make_future(proc: Procedure) -> Result<Vec<Value>, Exception> {
     let state = spawn_state();
-    let future: Future = async move { proc.call(&[], &mut ContBarrier::from_state(state)).await }
-        .boxed()
-        .shared();
+    let future: Future = async move {
+        proc.call_with_barrier(&[], &mut ContBarrier::from_state(state))
+            .await
+    }
+    .boxed()
+    .shared();
     let future = Value::from(future);
     Ok(vec![future])
 }
@@ -48,10 +51,10 @@ pub async fn make_future(proc: Procedure) -> Result<Vec<Value>, Exception> {
 pub async fn spawn(task: &Value) -> Result<Vec<Value>, Exception> {
     let task: Procedure = task.clone().try_into()?;
     let state = spawn_state();
-    let task =
-        tokio::task::spawn(
-            async move { task.call(&[], &mut ContBarrier::from_state(state)).await },
-        );
+    let task = tokio::task::spawn(async move {
+        task.call_with_barrier(&[], &mut ContBarrier::from_state(state))
+            .await
+    });
     let future: Future = async move { task.await.unwrap() }.boxed().shared();
     let future = Value::from(future);
     Ok(vec![future])

--- a/src/futures.rs
+++ b/src/futures.rs
@@ -36,7 +36,8 @@ unsafe impl Embeddable for Future {
 
 #[bridge(name = "future", lib = "(async)")]
 pub async fn make_future(proc: Procedure) -> Result<Vec<Value>, Exception> {
-    let future: Future = async move { proc.call(&[], &mut ContBarrier::root()).await }
+    let state = crate::proc::spawn_state();
+    let future: Future = async move { proc.call(&[], &mut ContBarrier::from_state(state)).await }
         .boxed()
         .shared();
     let future = Value::from(future);
@@ -46,7 +47,11 @@ pub async fn make_future(proc: Procedure) -> Result<Vec<Value>, Exception> {
 #[bridge(name = "spawn", lib = "(async)")]
 pub async fn spawn(task: &Value) -> Result<Vec<Value>, Exception> {
     let task: Procedure = task.clone().try_into()?;
-    let task = tokio::task::spawn(async move { task.call(&[], &mut ContBarrier::root()).await });
+    let state = crate::proc::spawn_state();
+    let task =
+        tokio::task::spawn(
+            async move { task.call(&[], &mut ContBarrier::from_state(state)).await },
+        );
     let future: Future = async move { task.await.unwrap() }.boxed().shared();
     let future = Value::from(future);
     Ok(vec![future])

--- a/src/futures.rs
+++ b/src/futures.rs
@@ -36,7 +36,7 @@ unsafe impl Embeddable for Future {
 
 #[bridge(name = "future", lib = "(async)")]
 pub async fn make_future(proc: Procedure) -> Result<Vec<Value>, Exception> {
-    let future: Future = async move { proc.call(&[], &mut ContBarrier::new()).await }
+    let future: Future = async move { proc.call(&[], &mut ContBarrier::root()).await }
         .boxed()
         .shared();
     let future = Value::from(future);
@@ -46,7 +46,7 @@ pub async fn make_future(proc: Procedure) -> Result<Vec<Value>, Exception> {
 #[bridge(name = "spawn", lib = "(async)")]
 pub async fn spawn(task: &Value) -> Result<Vec<Value>, Exception> {
     let task: Procedure = task.clone().try_into()?;
-    let task = tokio::task::spawn(async move { task.call(&[], &mut ContBarrier::new()).await });
+    let task = tokio::task::spawn(async move { task.call(&[], &mut ContBarrier::root()).await });
     let future: Future = async move { task.await.unwrap() }.boxed().shared();
     let future = Value::from(future);
     Ok(vec![future])

--- a/src/futures.rs
+++ b/src/futures.rs
@@ -15,7 +15,7 @@ use tokio::{
 use crate::{
     exceptions::Exception,
     ports::{BufferMode, Port},
-    proc::{ContBarrier, Procedure},
+    proc::{ContBarrier, Procedure, spawn_state},
     records::{Embeddable, Embedded, RecordTypeDescriptor, rtd},
     strings::WideString,
     value::Value,
@@ -36,7 +36,7 @@ unsafe impl Embeddable for Future {
 
 #[bridge(name = "future", lib = "(async)")]
 pub async fn make_future(proc: Procedure) -> Result<Vec<Value>, Exception> {
-    let state = crate::proc::spawn_state();
+    let state = spawn_state();
     let future: Future = async move { proc.call(&[], &mut ContBarrier::from_state(state)).await }
         .boxed()
         .shared();
@@ -47,7 +47,7 @@ pub async fn make_future(proc: Procedure) -> Result<Vec<Value>, Exception> {
 #[bridge(name = "spawn", lib = "(async)")]
 pub async fn spawn(task: &Value) -> Result<Vec<Value>, Exception> {
     let task: Procedure = task.clone().try_into()?;
-    let state = crate::proc::spawn_state();
+    let state = spawn_state();
     let task =
         tokio::task::spawn(
             async move { task.call(&[], &mut ContBarrier::from_state(state)).await },

--- a/src/hashtables.rs
+++ b/src/hashtables.rs
@@ -67,27 +67,29 @@ impl HashTableInner {
 
     #[cfg(not(feature = "async"))]
     pub fn hash(&self, val: Value) -> Result<u64, Exception> {
-        self.hash.call(&[val], &mut ContBarrier::new())?.expect1()
+        self.hash
+            .call(&[val], &mut ContBarrier::nested())?
+            .expect1()
     }
 
     #[cfg(feature = "async")]
     pub fn hash(&self, val: Value) -> Result<u64, Exception> {
         self.hash
-            .call_sync(&[val], &mut ContBarrier::new())?
+            .call_sync(&[val], &mut ContBarrier::nested())?
             .expect1()
     }
 
     #[cfg(not(feature = "async"))]
     pub fn eq(&self, lhs: Value, rhs: Value) -> Result<bool, Exception> {
         self.eq
-            .call(&[lhs, rhs], &mut ContBarrier::new())?
+            .call(&[lhs, rhs], &mut ContBarrier::nested())?
             .expect1()
     }
 
     #[cfg(feature = "async")]
     pub fn eq(&self, lhs: Value, rhs: Value) -> Result<bool, Exception> {
         self.eq
-            .call_sync(&[lhs, rhs], &mut ContBarrier::new())?
+            .call_sync(&[lhs, rhs], &mut ContBarrier::nested())?
             .expect1()
     }
 
@@ -178,11 +180,11 @@ impl HashTableInner {
             if entry.hash == hash && self.eq(key.clone(), entry.key.clone())? {
                 #[cfg(not(feature = "async"))]
                 let updated =
-                    proc.call(slice::from_ref(&entry.val), &mut ContBarrier::new())?[0].clone();
+                    proc.call(slice::from_ref(&entry.val), &mut ContBarrier::nested())?[0].clone();
 
                 #[cfg(feature = "async")]
                 let updated = proc
-                    .call_sync(slice::from_ref(&entry.val), &mut ContBarrier::new())?[0]
+                    .call_sync(slice::from_ref(&entry.val), &mut ContBarrier::nested())?[0]
                     .clone();
 
                 entry.val = updated;
@@ -191,10 +193,11 @@ impl HashTableInner {
         }
 
         #[cfg(not(feature = "async"))]
-        let updated = proc.call(slice::from_ref(default), &mut ContBarrier::new())?[0].clone(); // 
+        let updated = proc.call(slice::from_ref(default), &mut ContBarrier::nested())?[0].clone(); // 
 
         #[cfg(feature = "async")]
-        let updated = proc.call_sync(slice::from_ref(default), &mut ContBarrier::new())?[0].clone();
+        let updated =
+            proc.call_sync(slice::from_ref(default), &mut ContBarrier::nested())?[0].clone();
 
         table.insert_unique(
             hash,

--- a/src/hashtables.rs
+++ b/src/hashtables.rs
@@ -13,7 +13,7 @@ use std::{
 use crate::{
     exceptions::Exception,
     gc::Trace,
-    proc::{ContBarrier, Procedure},
+    proc::Procedure,
     records::{Embeddable, Embedded, RecordTypeDescriptor},
     registry::bridge,
     strings::WideString,
@@ -67,30 +67,22 @@ impl HashTableInner {
 
     #[cfg(not(feature = "async"))]
     pub fn hash(&self, val: Value) -> Result<u64, Exception> {
-        self.hash
-            .call(&[val], &mut ContBarrier::nested())?
-            .expect1()
+        self.hash.call(&[val])?.expect1()
     }
 
     #[cfg(feature = "async")]
     pub fn hash(&self, val: Value) -> Result<u64, Exception> {
-        self.hash
-            .call_sync(&[val], &mut ContBarrier::nested())?
-            .expect1()
+        self.hash.call_sync(&[val])?.expect1()
     }
 
     #[cfg(not(feature = "async"))]
     pub fn eq(&self, lhs: Value, rhs: Value) -> Result<bool, Exception> {
-        self.eq
-            .call(&[lhs, rhs], &mut ContBarrier::nested())?
-            .expect1()
+        self.eq.call(&[lhs, rhs])?.expect1()
     }
 
     #[cfg(feature = "async")]
     pub fn eq(&self, lhs: Value, rhs: Value) -> Result<bool, Exception> {
-        self.eq
-            .call_sync(&[lhs, rhs], &mut ContBarrier::nested())?
-            .expect1()
+        self.eq.call_sync(&[lhs, rhs])?.expect1()
     }
 
     /// Equivalent to `hashtable-ref`
@@ -179,13 +171,10 @@ impl HashTableInner {
         for entry in table.iter_hash_mut(hash) {
             if entry.hash == hash && self.eq(key.clone(), entry.key.clone())? {
                 #[cfg(not(feature = "async"))]
-                let updated =
-                    proc.call(slice::from_ref(&entry.val), &mut ContBarrier::nested())?[0].clone();
+                let updated = proc.call(slice::from_ref(&entry.val))?[0].clone();
 
                 #[cfg(feature = "async")]
-                let updated = proc
-                    .call_sync(slice::from_ref(&entry.val), &mut ContBarrier::nested())?[0]
-                    .clone();
+                let updated = proc.call_sync(slice::from_ref(&entry.val))?[0].clone();
 
                 entry.val = updated;
                 return Ok(());
@@ -193,11 +182,10 @@ impl HashTableInner {
         }
 
         #[cfg(not(feature = "async"))]
-        let updated = proc.call(slice::from_ref(default), &mut ContBarrier::nested())?[0].clone(); // 
+        let updated = proc.call(slice::from_ref(default))?[0].clone(); // 
 
         #[cfg(feature = "async")]
-        let updated =
-            proc.call_sync(slice::from_ref(default), &mut ContBarrier::nested())?[0].clone();
+        let updated = proc.call_sync(slice::from_ref(default))?[0].clone();
 
         table.insert_unique(
             hash,

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -687,14 +687,11 @@ mod __impl {
     pub(super) fn proc_to_read_fn(read: Procedure) -> ReadFn {
         Box::new(move |_, buff, start, count| {
             let [read] = read
-                .call(
-                    &[
-                        Value::from(buff.clone()),
-                        Value::from(start),
-                        Value::from(count),
-                    ],
-                    &mut ContBarrier::nested(),
-                )
+                .call(&[
+                    Value::from(buff.clone()),
+                    Value::from(start),
+                    Value::from(count),
+                ])
                 .map_err(|err| err.add_condition(IoReadError::new()))?
                 .try_into()
                 .map_err(|_| {
@@ -712,14 +709,11 @@ mod __impl {
     pub(super) fn proc_to_write_fn(write: Procedure) -> WriteFn {
         Box::new(move |_, buff, start, count| {
             let _ = write
-                .call(
-                    &[
-                        Value::from(buff.clone()),
-                        Value::from(start),
-                        Value::from(count),
-                    ],
-                    &mut ContBarrier::nested(),
-                )
+                .call(&[
+                    Value::from(buff.clone()),
+                    Value::from(start),
+                    Value::from(count),
+                ])
                 .map_err(|err| err.add_condition(IoReadError::new()))?;
             Ok(())
         })
@@ -728,7 +722,7 @@ mod __impl {
     pub(super) fn proc_to_get_pos_fn(get_pos: Procedure) -> GetPosFn {
         Box::new(move |_| {
             let [pos] = get_pos
-                .call(&[], &mut ContBarrier::nested())
+                .call(&[])
                 .map_err(|err| err.add_condition(IoError::new()))?
                 .try_into()
                 .map_err(|_| {
@@ -744,7 +738,7 @@ mod __impl {
     pub(super) fn proc_to_set_pos_fn(set_pos: Procedure) -> SetPosFn {
         Box::new(move |_, pos| {
             let _ = set_pos
-                .call(&[Value::from(pos)], &mut ContBarrier::nested())
+                .call(&[Value::from(pos)])
                 .map_err(|err| err.add_condition(IoError::new()))?;
             Ok(())
         })
@@ -753,7 +747,7 @@ mod __impl {
     pub(super) fn proc_to_close_fn(close: Procedure) -> CloseFn {
         Box::new(move |_| {
             let _ = close
-                .call(&[], &mut ContBarrier::nested())
+                .call(&[])
                 .map_err(|err| err.add_condition(IoError::new()))?;
             Ok(())
         })
@@ -930,14 +924,11 @@ mod __impl {
             let read = read.clone();
             Box::pin(async move {
                 let [read] = read
-                    .call(
-                        &[
-                            Value::from(buff.clone()),
-                            Value::from(start),
-                            Value::from(count),
-                        ],
-                        &mut ContBarrier::nested(),
-                    )
+                    .call(&[
+                        Value::from(buff.clone()),
+                        Value::from(start),
+                        Value::from(count),
+                    ])
                     .await
                     .map_err(|err| err.add_condition(IoReadError::new()))?
                     .try_into()
@@ -961,14 +952,11 @@ mod __impl {
             let write = write.clone();
             Box::pin(async move {
                 let _ = write
-                    .call(
-                        &[
-                            Value::from(buff.clone()),
-                            Value::from(start),
-                            Value::from(count),
-                        ],
-                        &mut ContBarrier::nested(),
-                    )
+                    .call(&[
+                        Value::from(buff.clone()),
+                        Value::from(start),
+                        Value::from(count),
+                    ])
                     .await
                     .map_err(|err| err.add_condition(IoReadError::new()))?;
                 Ok(())
@@ -981,7 +969,7 @@ mod __impl {
             let get_pos = get_pos.clone();
             Box::pin(async move {
                 let [pos] = get_pos
-                    .call(&[], &mut ContBarrier::nested())
+                    .call(&[])
                     .await
                     .map_err(|err| err.add_condition(IoError::new()))?
                     .try_into()
@@ -1003,7 +991,7 @@ mod __impl {
             let set_pos = set_pos.clone();
             Box::pin(async move {
                 let _ = set_pos
-                    .call(&[Value::from(pos)], &mut ContBarrier::nested())
+                    .call(&[Value::from(pos)])
                     .await
                     .map_err(|err| err.add_condition(IoError::new()))?;
                 Ok(())
@@ -1016,7 +1004,7 @@ mod __impl {
             let close = close.clone();
             Box::pin(async move {
                 let _ = close
-                    .call(&[], &mut ContBarrier::nested())
+                    .call(&[])
                     .await
                     .map_err(|err| err.add_condition(IoError::new()))?;
                 Ok(())
@@ -1809,14 +1797,11 @@ impl CustomTextualPortData {
             && let len = self.output_buffer.len()
             && len != 0
         {
-            maybe_await!(write.call(
-                &[
-                    Value::from(self.output_buffer.clone()),
-                    Value::from(0usize),
-                    Value::from(len)
-                ],
-                &mut ContBarrier::nested()
-            ))?;
+            maybe_await!(write.call(&[
+                Value::from(self.output_buffer.clone()),
+                Value::from(0usize),
+                Value::from(len)
+            ]))?;
             self.output_buffer.clear();
         }
 
@@ -1831,14 +1816,11 @@ impl CustomTextualPortData {
                     (self.chars_read, self.input_buffer.len() - self.chars_read)
                 }
             };
-            let read: usize = maybe_await!(read.call(
-                &[
-                    Value::from(self.input_buffer.clone()),
-                    Value::from(start),
-                    Value::from(count)
-                ],
-                &mut ContBarrier::nested()
-            ))?
+            let read: usize = maybe_await!(read.call(&[
+                Value::from(self.input_buffer.clone()),
+                Value::from(start),
+                Value::from(count)
+            ]))?
             .expect1()?;
 
             if read == 0 {
@@ -1893,11 +1875,11 @@ impl CustomTextualPortData {
             && let Some(set_pos) = port_info.set_pos.as_ref()
             && self.chars_read > 0
         {
-            let curr_pos: u64 = maybe_await!(get_pos.call(&[], &mut ContBarrier::nested()))?
+            let curr_pos: u64 = maybe_await!(get_pos.call(&[]))?
                 .expect1()
                 .map_err(|err: Exception| err.add_condition(IoWriteError::new()))?;
             let seek_to = curr_pos - (self.chars_read as u64 - self.input_pos as u64);
-            maybe_await!(set_pos.call(&[Value::from(seek_to)], &mut ContBarrier::nested()))?;
+            maybe_await!(set_pos.call(&[Value::from(seek_to)]))?;
             self.chars_read = 0;
             self.input_pos = 0;
         }
@@ -1908,14 +1890,11 @@ impl CustomTextualPortData {
                     {
                         self.output_buffer.0.chars.write()[0] = chr;
                     }
-                    maybe_await!(write.call(
-                        &[
-                            Value::from(self.output_buffer.clone()),
-                            Value::from(0usize),
-                            Value::from(1usize)
-                        ],
-                        &mut ContBarrier::nested()
-                    ))?;
+                    maybe_await!(write.call(&[
+                        Value::from(self.output_buffer.clone()),
+                        Value::from(0usize),
+                        Value::from(1usize)
+                    ]))?;
                 }
             }
             BufferMode::Line => {
@@ -1932,14 +1911,11 @@ impl CustomTextualPortData {
                         }
                     }
                     let len = self.output_buffer.len();
-                    maybe_await!(write.call(
-                        &[
-                            Value::from(self.output_buffer.clone()),
-                            Value::from(0usize),
-                            Value::from(len)
-                        ],
-                        &mut ContBarrier::nested()
-                    ))?;
+                    maybe_await!(write.call(&[
+                        Value::from(self.output_buffer.clone()),
+                        Value::from(0usize),
+                        Value::from(len)
+                    ]))?;
                     self.output_buffer.clear();
                 }
             }
@@ -1947,14 +1923,11 @@ impl CustomTextualPortData {
                 for chr in s.chars() {
                     let len = self.output_buffer.len();
                     if len >= BUFFER_SIZE {
-                        maybe_await!(write.call(
-                            &[
-                                Value::from(self.output_buffer.clone()),
-                                Value::from(0usize),
-                                Value::from(len)
-                            ],
-                            &mut ContBarrier::nested()
-                        ))?;
+                        maybe_await!(write.call(&[
+                            Value::from(self.output_buffer.clone()),
+                            Value::from(0usize),
+                            Value::from(len)
+                        ]))?;
                         self.output_buffer.clear();
                     }
                     self.output_buffer.0.chars.write().push(chr);
@@ -1975,14 +1948,11 @@ impl CustomTextualPortData {
             return Err(Exception::io_error("port is closed"));
         }
 
-        maybe_await!(write.call(
-            &[
-                Value::from(self.output_buffer.clone()),
-                Value::from(0usize),
-                Value::from(self.output_buffer.len()),
-            ],
-            &mut ContBarrier::nested()
-        ))?;
+        maybe_await!(write.call(&[
+            Value::from(self.output_buffer.clone()),
+            Value::from(0usize),
+            Value::from(self.output_buffer.len()),
+        ]))?;
         self.output_buffer.clear();
 
         Ok(())
@@ -1998,7 +1968,7 @@ impl CustomTextualPortData {
             return Err(Exception::io_error("port is closed"));
         }
 
-        maybe_await!(get_pos.call(&[], &mut ContBarrier::nested()))?.expect1()
+        maybe_await!(get_pos.call(&[]))?.expect1()
     }
 
     #[maybe_async]
@@ -2015,21 +1985,18 @@ impl CustomTextualPortData {
 
         // Reset the buffers
         if let Some(write) = port_info.write.as_ref() {
-            maybe_await!(write.call(
-                &[
-                    Value::from(self.output_buffer.clone()),
-                    Value::from(0usize),
-                    Value::from(self.output_buffer.len()),
-                ],
-                &mut ContBarrier::nested()
-            ))?;
+            maybe_await!(write.call(&[
+                Value::from(self.output_buffer.clone()),
+                Value::from(0usize),
+                Value::from(self.output_buffer.len()),
+            ]))?;
             self.output_buffer.clear();
         }
 
         self.chars_read = 0;
         self.input_pos = 0;
 
-        maybe_await!(set_pos.call(&[Value::from(pos)], &mut ContBarrier::nested()))?;
+        maybe_await!(set_pos.call(&[Value::from(pos)]))?;
 
         Ok(())
     }
@@ -2046,7 +2013,7 @@ impl CustomTextualPortData {
         maybe_await!(self.flush(port_info))?;
 
         if let Some(close) = port_info.close.as_ref() {
-            maybe_await!(close.call(&[], &mut ContBarrier::nested()))?;
+            maybe_await!(close.call(&[]))?;
         }
 
         Ok(())

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -693,7 +693,7 @@ mod __impl {
                         Value::from(start),
                         Value::from(count),
                     ],
-                    &mut ContBarrier::new(),
+                    &mut ContBarrier::nested(),
                 )
                 .map_err(|err| err.add_condition(IoReadError::new()))?
                 .try_into()
@@ -718,7 +718,7 @@ mod __impl {
                         Value::from(start),
                         Value::from(count),
                     ],
-                    &mut ContBarrier::new(),
+                    &mut ContBarrier::nested(),
                 )
                 .map_err(|err| err.add_condition(IoReadError::new()))?;
             Ok(())
@@ -728,7 +728,7 @@ mod __impl {
     pub(super) fn proc_to_get_pos_fn(get_pos: Procedure) -> GetPosFn {
         Box::new(move |_| {
             let [pos] = get_pos
-                .call(&[], &mut ContBarrier::new())
+                .call(&[], &mut ContBarrier::nested())
                 .map_err(|err| err.add_condition(IoError::new()))?
                 .try_into()
                 .map_err(|_| {
@@ -744,7 +744,7 @@ mod __impl {
     pub(super) fn proc_to_set_pos_fn(set_pos: Procedure) -> SetPosFn {
         Box::new(move |_, pos| {
             let _ = set_pos
-                .call(&[Value::from(pos)], &mut ContBarrier::new())
+                .call(&[Value::from(pos)], &mut ContBarrier::nested())
                 .map_err(|err| err.add_condition(IoError::new()))?;
             Ok(())
         })
@@ -753,7 +753,7 @@ mod __impl {
     pub(super) fn proc_to_close_fn(close: Procedure) -> CloseFn {
         Box::new(move |_| {
             let _ = close
-                .call(&[], &mut ContBarrier::new())
+                .call(&[], &mut ContBarrier::nested())
                 .map_err(|err| err.add_condition(IoError::new()))?;
             Ok(())
         })
@@ -936,7 +936,7 @@ mod __impl {
                             Value::from(start),
                             Value::from(count),
                         ],
-                        &mut ContBarrier::new(),
+                        &mut ContBarrier::nested(),
                     )
                     .await
                     .map_err(|err| err.add_condition(IoReadError::new()))?
@@ -967,7 +967,7 @@ mod __impl {
                             Value::from(start),
                             Value::from(count),
                         ],
-                        &mut ContBarrier::new(),
+                        &mut ContBarrier::nested(),
                     )
                     .await
                     .map_err(|err| err.add_condition(IoReadError::new()))?;
@@ -981,7 +981,7 @@ mod __impl {
             let get_pos = get_pos.clone();
             Box::pin(async move {
                 let [pos] = get_pos
-                    .call(&[], &mut ContBarrier::new())
+                    .call(&[], &mut ContBarrier::nested())
                     .await
                     .map_err(|err| err.add_condition(IoError::new()))?
                     .try_into()
@@ -1003,7 +1003,7 @@ mod __impl {
             let set_pos = set_pos.clone();
             Box::pin(async move {
                 let _ = set_pos
-                    .call(&[Value::from(pos)], &mut ContBarrier::new())
+                    .call(&[Value::from(pos)], &mut ContBarrier::nested())
                     .await
                     .map_err(|err| err.add_condition(IoError::new()))?;
                 Ok(())
@@ -1016,7 +1016,7 @@ mod __impl {
             let close = close.clone();
             Box::pin(async move {
                 let _ = close
-                    .call(&[], &mut ContBarrier::new())
+                    .call(&[], &mut ContBarrier::nested())
                     .await
                     .map_err(|err| err.add_condition(IoError::new()))?;
                 Ok(())
@@ -1815,7 +1815,7 @@ impl CustomTextualPortData {
                     Value::from(0usize),
                     Value::from(len)
                 ],
-                &mut ContBarrier::new()
+                &mut ContBarrier::nested()
             ))?;
             self.output_buffer.clear();
         }
@@ -1837,7 +1837,7 @@ impl CustomTextualPortData {
                     Value::from(start),
                     Value::from(count)
                 ],
-                &mut ContBarrier::new()
+                &mut ContBarrier::nested()
             ))?
             .expect1()?;
 
@@ -1893,11 +1893,11 @@ impl CustomTextualPortData {
             && let Some(set_pos) = port_info.set_pos.as_ref()
             && self.chars_read > 0
         {
-            let curr_pos: u64 = maybe_await!(get_pos.call(&[], &mut ContBarrier::new()))?
+            let curr_pos: u64 = maybe_await!(get_pos.call(&[], &mut ContBarrier::nested()))?
                 .expect1()
                 .map_err(|err: Exception| err.add_condition(IoWriteError::new()))?;
             let seek_to = curr_pos - (self.chars_read as u64 - self.input_pos as u64);
-            maybe_await!(set_pos.call(&[Value::from(seek_to)], &mut ContBarrier::new()))?;
+            maybe_await!(set_pos.call(&[Value::from(seek_to)], &mut ContBarrier::nested()))?;
             self.chars_read = 0;
             self.input_pos = 0;
         }
@@ -1914,7 +1914,7 @@ impl CustomTextualPortData {
                             Value::from(0usize),
                             Value::from(1usize)
                         ],
-                        &mut ContBarrier::new()
+                        &mut ContBarrier::nested()
                     ))?;
                 }
             }
@@ -1938,7 +1938,7 @@ impl CustomTextualPortData {
                             Value::from(0usize),
                             Value::from(len)
                         ],
-                        &mut ContBarrier::new()
+                        &mut ContBarrier::nested()
                     ))?;
                     self.output_buffer.clear();
                 }
@@ -1953,7 +1953,7 @@ impl CustomTextualPortData {
                                 Value::from(0usize),
                                 Value::from(len)
                             ],
-                            &mut ContBarrier::new()
+                            &mut ContBarrier::nested()
                         ))?;
                         self.output_buffer.clear();
                     }
@@ -1981,7 +1981,7 @@ impl CustomTextualPortData {
                 Value::from(0usize),
                 Value::from(self.output_buffer.len()),
             ],
-            &mut ContBarrier::new()
+            &mut ContBarrier::nested()
         ))?;
         self.output_buffer.clear();
 
@@ -1998,7 +1998,7 @@ impl CustomTextualPortData {
             return Err(Exception::io_error("port is closed"));
         }
 
-        maybe_await!(get_pos.call(&[], &mut ContBarrier::new()))?.expect1()
+        maybe_await!(get_pos.call(&[], &mut ContBarrier::nested()))?.expect1()
     }
 
     #[maybe_async]
@@ -2021,7 +2021,7 @@ impl CustomTextualPortData {
                     Value::from(0usize),
                     Value::from(self.output_buffer.len()),
                 ],
-                &mut ContBarrier::new()
+                &mut ContBarrier::nested()
             ))?;
             self.output_buffer.clear();
         }
@@ -2029,7 +2029,7 @@ impl CustomTextualPortData {
         self.chars_read = 0;
         self.input_pos = 0;
 
-        maybe_await!(set_pos.call(&[Value::from(pos)], &mut ContBarrier::new()))?;
+        maybe_await!(set_pos.call(&[Value::from(pos)], &mut ContBarrier::nested()))?;
 
         Ok(())
     }
@@ -2046,7 +2046,7 @@ impl CustomTextualPortData {
         maybe_await!(self.flush(port_info))?;
 
         if let Some(close) = port_info.close.as_ref() {
-            maybe_await!(close.call(&[], &mut ContBarrier::new()))?;
+            maybe_await!(close.call(&[], &mut ContBarrier::nested()))?;
         }
 
         Ok(())

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -1012,20 +1012,14 @@ impl DynState {
     /// entries (current ports) carry over as copies; control entries
     /// (winders, prompts, exception handlers) belong to the spawning
     /// thread's stack and do not cross. Continuation marks start fresh —
-    /// the child begins a fresh initial continuation. This is an allowlist:
-    /// entries not listed here default to *not* crossing the spawn boundary;
-    /// reconsider when adding a `DynStackElem` variant.
+    /// the child begins a fresh initial continuation. Which entries cross
+    /// is decided per-variant by [`DynStackElem::crosses_spawn`].
     fn spawn_snapshot(&self) -> Self {
         Self {
             dyn_stack: self
                 .dyn_stack
                 .iter()
-                .filter(|elem| {
-                    matches!(
-                        elem,
-                        DynStackElem::CurrentInputPort(_) | DynStackElem::CurrentOutputPort(_)
-                    )
-                })
+                .filter(|elem| elem.crosses_spawn())
                 .cloned()
                 .collect(),
             cont_marks: vec![HashMap::new()],
@@ -1385,6 +1379,22 @@ pub(crate) enum DynStackElem {
     ExceptionHandler(Procedure),
     CurrentInputPort(Port),
     CurrentOutputPort(Port),
+}
+
+impl DynStackElem {
+    /// Whether this entry crosses a spawn boundary into a child thread or
+    /// task. Binding entries (current ports) do; control entries (winders,
+    /// prompts, exception handlers) belong to the spawning stack and do
+    /// not. Exhaustive on purpose: adding a variant forces this decision.
+    fn crosses_spawn(&self) -> bool {
+        match self {
+            DynStackElem::CurrentInputPort(_) | DynStackElem::CurrentOutputPort(_) => true,
+            DynStackElem::Prompt(_)
+            | DynStackElem::PromptBarrier(_)
+            | DynStackElem::Winder(_)
+            | DynStackElem::ExceptionHandler(_) => false,
+        }
+    }
 }
 
 pub(crate) unsafe extern "C" fn pop_dyn_stack(

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -879,7 +879,7 @@ impl Application {
     /// that remains are values. This is the main trampoline of the evaluation
     /// engine. Publishes the barrier's dynamic state as the task's ambient
     /// state for the duration.
-    #[cfg(all(feature = "async", feature = "tokio"))]
+    #[cfg(feature = "async")]
     pub async fn eval(self, barrier: &mut ContBarrier<'_>) -> Result<Vec<Value>, Exception> {
         let state = barrier.state.clone();
         AMBIENT_STATE.scope(state, self.eval_inner(barrier)).await
@@ -887,18 +887,7 @@ impl Application {
 
     /// Evaluate the application — and all subsequent applications — until all
     /// that remains are values. This is the main trampoline of the evaluation
-    /// engine. Publishes the barrier's dynamic state as the task's ambient
-    /// state for the duration.
-    #[cfg(all(feature = "async", not(feature = "tokio")))]
-    pub async fn eval(self, barrier: &mut ContBarrier<'_>) -> Result<Vec<Value>, Exception> {
-        // Best-effort without task-locals; correct for single-threaded executors.
-        let _guard = publish_ambient(barrier.state.clone());
-        self.eval_inner(barrier).await
-    }
-
-    /// Evaluate the application — and all subsequent applications — until all
-    /// that remains are values. This is the main trampoline of the evaluation
-    /// engine. Publishes the barrier's dynamic state as the task's ambient
+    /// engine. Publishes the barrier's dynamic state as the thread's ambient
     /// state for the duration.
     #[cfg(not(feature = "async"))]
     pub fn eval(self, barrier: &mut ContBarrier<'_>) -> Result<Vec<Value>, Exception> {
@@ -1020,7 +1009,7 @@ impl DynState {
     }
 }
 
-#[cfg(feature = "tokio")]
+#[cfg(feature = "async")]
 tokio::task_local! {
     /// The dynamic state of the current tokio task. Survives work-stealing
     /// migration between worker threads.
@@ -1036,7 +1025,7 @@ std::thread_local! {
 /// The dynamic state of the task/thread we are currently running on, if any
 /// evaluation is in progress.
 pub(crate) fn ambient_state() -> Option<Gc<RwLock<DynState>>> {
-    #[cfg(feature = "tokio")]
+    #[cfg(feature = "async")]
     if let Ok(state) = AMBIENT_STATE.try_with(Clone::clone) {
         return Some(state);
     }

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -953,43 +953,65 @@ type Param<'a> = &'a mut (dyn Any + Send + Sync);
 #[cfg(not(feature = "async"))]
 type Param<'a> = &'a mut dyn Any;
 
+/// The dynamic state of a running task: the dynamic stack (winders,
+/// exception handlers, current ports) and continuation marks. Kept behind a
+/// `Gc<RwLock<..>>` handle, separate from the barrier's identity.
+#[derive(Clone, Debug, Trace)]
+pub(crate) struct DynState {
+    dyn_stack: Vec<DynStackElem>,
+    cont_marks: Vec<HashMap<Symbol, Value>>,
+}
+
+impl DynState {
+    fn new() -> Self {
+        Self {
+            dyn_stack: Vec::new(),
+            // Procedures returned by the JIT compiler are delimited
+            // continuations (of sorts), and therefore we need to preallocate
+            // the initial marks for them since there's no mechanism to
+            // allocate for them when they're run.
+            cont_marks: vec![HashMap::new()],
+        }
+    }
+}
+
 /// A continuation barrier. Escape procedures created within a continuation
 /// barrier cannot be called within another barrier.
 ///
-/// This structure also contains the dynamic state of the running program
-/// including winders, exception handlers, continuation marks, and parameters.
+/// The barrier separates *identity* (the `id`, fresh at every Rust re-entry
+/// frame, which is what stops escape procedures from jumping across a Rust
+/// frame) from the *dynamic state* of the running task, which is kept
+/// separate so that it can outlive and be shared across individual barriers.
 pub struct ContBarrier<'a> {
-    /// The id of the barrier. Checked when calling an escape procedure
+    /// The id of the barrier. Checked when calling an escape procedure.
     id: usize,
-    /// The active dynamic stack
-    dyn_stack: Vec<DynStackElem>,
-    /// The active [continuation marks](https://srfi.schemers.org/srfi-157/srfi-157.html)
-    cont_marks: Vec<HashMap<Symbol, Value>>,
-    /// The active installed mutable parameters
+    /// The dynamic state of the running task.
+    state: Gc<RwLock<DynState>>,
+    /// Host-injected mutable variables (see `add_param`). Unrelated to
+    /// Scheme parameter objects; per-entry by nature (borrowed &mut).
     params: HashMap<Symbol, Param<'a>>,
 }
 
 impl<'a> ContBarrier<'a> {
-    pub fn new() -> Self {
+    fn next_id() -> usize {
         static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+        NEXT_ID.fetch_add(1, Ordering::Relaxed)
+    }
 
+    pub fn new() -> Self {
         Self {
-            id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
-            dyn_stack: Vec::new(),
-            // Procedures returned by the JIT compiler are delimited
-            // continuations (of sorts), and therefore we need to preallocate
-            // the initial marks for them since there's no mechanism to allocate
-            // for them when they're run.
-            cont_marks: vec![HashMap::new()],
+            id: Self::next_id(),
+            state: Gc::new(RwLock::new(DynState::new())),
             params: HashMap::new(),
         }
     }
 
     pub fn save(&self) -> SavedDynamicState {
+        let state = self.state.read().clone();
         SavedDynamicState {
             id: self.id,
-            dyn_stack: self.dyn_stack.clone(),
-            cont_marks: self.cont_marks.clone(),
+            dyn_stack: state.dyn_stack,
+            cont_marks: state.cont_marks,
         }
     }
 
@@ -1047,15 +1069,17 @@ impl<'a> ContBarrier<'a> {
     }
 
     pub(crate) fn push_marks(&mut self) {
-        self.cont_marks.push(HashMap::new());
+        self.state.write().cont_marks.push(HashMap::new());
     }
 
     pub(crate) fn pop_marks(&mut self) {
-        self.cont_marks.pop();
+        self.state.write().cont_marks.pop();
     }
 
     pub(crate) fn current_marks(&self, tag: Symbol) -> Vec<Value> {
-        self.cont_marks
+        self.state
+            .read()
+            .cont_marks
             .iter()
             .rev()
             .flat_map(|marks| marks.get(&tag).cloned())
@@ -1063,7 +1087,17 @@ impl<'a> ContBarrier<'a> {
     }
 
     pub(crate) fn set_continuation_mark(&mut self, tag: Symbol, val: Value) {
-        self.cont_marks.last_mut().unwrap().insert(tag, val);
+        self.state
+            .write()
+            .cont_marks
+            .last_mut()
+            .unwrap()
+            .insert(tag, val);
+    }
+
+    /// Replace the continuation marks wholesale (continuation reinstatement).
+    pub(crate) fn set_cont_marks(&mut self, marks: Vec<HashMap<Symbol, Value>>) {
+        self.state.write().cont_marks = marks;
     }
 
     // TODO: We should certainly try to optimize these functions. Linear
@@ -1071,14 +1105,17 @@ impl<'a> ContBarrier<'a> {
     // will ever get very large.
 
     pub fn current_exception_handler(&self) -> Option<Procedure> {
-        self.dyn_stack.iter().rev().find_map(|elem| match elem {
+        let state = self.state.read();
+        state.dyn_stack.iter().rev().find_map(|elem| match elem {
             DynStackElem::ExceptionHandler(proc) => Some(proc.clone()),
             _ => None,
         })
     }
 
     pub fn current_input_port(&self) -> Port {
-        self.dyn_stack
+        let state = self.state.read();
+        state
+            .dyn_stack
             .iter()
             .rev()
             .find_map(|elem| match elem {
@@ -1099,7 +1136,9 @@ impl<'a> ContBarrier<'a> {
     }
 
     pub fn current_output_port(&self) -> Port {
-        self.dyn_stack
+        let state = self.state.read();
+        state
+            .dyn_stack
             .iter()
             .rev()
             .find_map(|elem| match elem {
@@ -1122,23 +1161,24 @@ impl<'a> ContBarrier<'a> {
     }
 
     pub(crate) fn push_dyn_stack(&mut self, elem: DynStackElem) {
-        self.dyn_stack.push(elem);
+        self.state.write().dyn_stack.push(elem);
     }
 
     pub(crate) fn pop_dyn_stack(&mut self) -> Option<DynStackElem> {
-        self.dyn_stack.pop()
+        self.state.write().dyn_stack.pop()
     }
 
-    pub(crate) fn dyn_stack_last(&self) -> Option<&DynStackElem> {
-        self.dyn_stack.last()
+    /// Returns an owned clone: the stack lives behind a lock now.
+    pub(crate) fn dyn_stack_last(&self) -> Option<DynStackElem> {
+        self.state.read().dyn_stack.last().cloned()
     }
 
     pub(crate) fn dyn_stack_len(&self) -> usize {
-        self.dyn_stack.len()
+        self.state.read().dyn_stack.len()
     }
 
     pub(crate) fn dyn_stack_is_empty(&self) -> bool {
-        self.dyn_stack.is_empty()
+        self.state.read().dyn_stack.is_empty()
     }
 }
 
@@ -1190,9 +1230,12 @@ impl SavedDynamicState {
 impl From<SavedDynamicState> for ContBarrier<'_> {
     fn from(value: SavedDynamicState) -> Self {
         ContBarrier {
-            dyn_stack: value.dyn_stack,
-            cont_marks: value.cont_marks,
-            ..Default::default()
+            id: Self::next_id(),
+            state: Gc::new(RwLock::new(DynState {
+                dyn_stack: value.dyn_stack,
+                cont_marks: value.cont_marks,
+            })),
+            params: HashMap::new(),
         }
     }
 }
@@ -1310,7 +1353,7 @@ fn escape_procedure(
         return Err(Exception::error("attempt to cross continuation barrier"));
     }
 
-    barrier.cont_marks = saved_barrier_read.cont_marks.clone();
+    barrier.set_cont_marks(saved_barrier_read.cont_marks.clone());
 
     // Clone the continuation
     let k: Procedure = k.try_into().unwrap();
@@ -1319,7 +1362,7 @@ fn escape_procedure(
 
     // Simple optimization: check if we're in the same dyn stack
     if barrier.dyn_stack_len() == saved_barrier_read.dyn_stack_len()
-        && barrier.dyn_stack_last() == saved_barrier_read.dyn_stack_last()
+        && barrier.dyn_stack_last().as_ref() == saved_barrier_read.dyn_stack_last()
     {
         Ok(Application::new(k, None, args))
     } else {
@@ -1361,7 +1404,7 @@ unsafe extern "C" fn unwind(
 
         while !barrier.dyn_stack_is_empty()
             && (barrier.dyn_stack_len() > dest_stack_read.dyn_stack_len()
-                || barrier.dyn_stack_last()
+                || barrier.dyn_stack_last().as_ref()
                     != dest_stack_read.dyn_stack_get(barrier.dyn_stack_len() - 1))
         {
             match barrier.pop_dyn_stack() {
@@ -1910,7 +1953,7 @@ fn delimited_continuation(
         .unwrap();
     let saved_barrier_read = saved_barrier.as_ref();
     // Restore continuation marks
-    barrier.cont_marks = saved_barrier_read.cont_marks.clone();
+    barrier.set_cont_marks(saved_barrier_read.cont_marks.clone());
 
     let args = args.iter().chain(rest_args).cloned().collect::<Vec<_>>();
 

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -110,6 +110,7 @@ use parking_lot::RwLock;
 use scheme_rs_macros::{cps_bridge, maybe_async, maybe_await, maybe_await_boxed};
 use std::{
     any::Any,
+    cell::RefCell,
     collections::HashMap,
     fmt,
     ops::DerefMut,
@@ -851,7 +852,7 @@ impl Application {
     /// Evaluate the application - and all subsequent application - until all that
     /// remains are values. This is the main trampoline of the evaluation engine.
     #[maybe_async]
-    pub fn eval(mut self, barrier: &mut ContBarrier<'_>) -> Result<Vec<Value>, Exception> {
+    fn eval_inner(mut self, barrier: &mut ContBarrier<'_>) -> Result<Vec<Value>, Exception> {
         loop {
             let op = match self.op {
                 OpType::Proc(proc) => proc,
@@ -864,9 +865,41 @@ impl Application {
         }
     }
 
+    /// Evaluate the application — and all subsequent applications — until all
+    /// that remains are values. This is the main trampoline of the evaluation
+    /// engine. Publishes the barrier's dynamic state as the task's ambient
+    /// state for the duration.
+    #[cfg(all(feature = "async", feature = "tokio"))]
+    pub async fn eval(self, barrier: &mut ContBarrier<'_>) -> Result<Vec<Value>, Exception> {
+        let state = barrier.state.clone();
+        AMBIENT_STATE.scope(state, self.eval_inner(barrier)).await
+    }
+
+    /// Evaluate the application — and all subsequent applications — until all
+    /// that remains are values. This is the main trampoline of the evaluation
+    /// engine. Publishes the barrier's dynamic state as the task's ambient
+    /// state for the duration.
+    #[cfg(all(feature = "async", not(feature = "tokio")))]
+    pub async fn eval(self, barrier: &mut ContBarrier<'_>) -> Result<Vec<Value>, Exception> {
+        // Best-effort without task-locals; correct for single-threaded executors.
+        let _guard = publish_ambient(barrier.state.clone());
+        self.eval_inner(barrier).await
+    }
+
+    /// Evaluate the application — and all subsequent applications — until all
+    /// that remains are values. This is the main trampoline of the evaluation
+    /// engine. Publishes the barrier's dynamic state as the task's ambient
+    /// state for the duration.
+    #[cfg(not(feature = "async"))]
+    pub fn eval(self, barrier: &mut ContBarrier<'_>) -> Result<Vec<Value>, Exception> {
+        let _guard = publish_ambient(barrier.state.clone());
+        self.eval_inner(barrier)
+    }
+
     #[cfg(feature = "async")]
     /// Just like [eval] but throws an error if we encounter an async function.
     pub fn eval_sync(mut self, barrier: &mut ContBarrier) -> Result<Vec<Value>, Exception> {
+        let _guard = publish_ambient(barrier.state.clone());
         loop {
             let op = match self.op {
                 OpType::Proc(proc) => proc,
@@ -963,7 +996,7 @@ pub(crate) struct DynState {
 }
 
 impl DynState {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             dyn_stack: Vec::new(),
             // Procedures returned by the JIT compiler are delimited
@@ -972,6 +1005,44 @@ impl DynState {
             // allocate for them when they're run.
             cont_marks: vec![HashMap::new()],
         }
+    }
+}
+
+#[cfg(feature = "tokio")]
+tokio::task_local! {
+    /// The dynamic state of the current tokio task. Survives work-stealing
+    /// migration between worker threads.
+    static AMBIENT_STATE: Gc<RwLock<DynState>>;
+}
+
+std::thread_local! {
+    /// Fallback ambient state for sync builds, OS threads, and eval_sync.
+    static AMBIENT_STATE_TL: RefCell<Option<Gc<RwLock<DynState>>>> =
+        const { RefCell::new(None) };
+}
+
+/// The dynamic state of the task/thread we are currently running on, if any
+/// evaluation is in progress.
+pub(crate) fn ambient_state() -> Option<Gc<RwLock<DynState>>> {
+    #[cfg(feature = "tokio")]
+    if let Ok(state) = AMBIENT_STATE.try_with(Clone::clone) {
+        return Some(state);
+    }
+    AMBIENT_STATE_TL.with(|s| s.borrow().clone())
+}
+
+/// Publish `state` as this thread's ambient dynamic state; restores the
+/// previous value on drop. Used by the sync trampoline; the async
+/// trampoline uses AMBIENT_STATE.scope instead.
+pub(crate) struct AmbientGuard(Option<Gc<RwLock<DynState>>>);
+
+pub(crate) fn publish_ambient(state: Gc<RwLock<DynState>>) -> AmbientGuard {
+    AMBIENT_STATE_TL.with(|s| AmbientGuard(s.borrow_mut().replace(state)))
+}
+
+impl Drop for AmbientGuard {
+    fn drop(&mut self) {
+        AMBIENT_STATE_TL.with(|s| *s.borrow_mut() = self.0.take());
     }
 }
 
@@ -1002,6 +1073,34 @@ impl<'a> ContBarrier<'a> {
         Self {
             id: Self::next_id(),
             state: Gc::new(RwLock::new(DynState::new())),
+            params: HashMap::new(),
+        }
+    }
+
+    /// A barrier with a fresh, empty dynamic state. Only for true entry
+    /// points: an embedder calling into Scheme from a context with no
+    /// ambient dynamic state.
+    pub fn root() -> ContBarrier<'static> {
+        Self::from_state(Gc::new(RwLock::new(DynState::new())))
+    }
+
+    /// A barrier for nested re-entry into Scheme (callbacks, macro
+    /// transformers, library invocation): shares the dynamic state of the
+    /// task we are running on, under a fresh id. The fresh id keeps escape
+    /// procedures from jumping across the intervening Rust frame; the shared
+    /// state means the callee observes the caller's exception handlers and
+    /// current ports.
+    pub fn nested() -> ContBarrier<'static> {
+        match ambient_state() {
+            Some(state) => Self::from_state(state),
+            None => Self::root(),
+        }
+    }
+
+    pub(crate) fn from_state(state: Gc<RwLock<DynState>>) -> ContBarrier<'static> {
+        ContBarrier {
+            id: Self::next_id(),
+            state,
             params: HashMap::new(),
         }
     }

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -851,18 +851,28 @@ impl Application {
 
     /// Evaluate the application - and all subsequent application - until all that
     /// remains are values. This is the main trampoline of the evaluation engine.
+    ///
+    /// The trampoline owns the continuation-mark balance for its run: it
+    /// pushes the baseline frame that the terminal (halt) continuation pops
+    /// on a successful exit, and truncates back to the entry depth on every
+    /// exit. On success the truncate is a no-op; on a halt_err exit (uncaught
+    /// raise, failed cross-barrier escape, missing prompt tag) it discards
+    /// the baseline frame plus one leaked frame per pending continuation
+    /// whose invocation — and therefore whose pop — never happened.
     #[maybe_async]
     fn eval_inner(mut self, barrier: &mut ContBarrier<'_>) -> Result<Vec<Value>, Exception> {
-        loop {
+        barrier.push_marks();
+        let restore_depth = barrier.marks_depth() - 1;
+        let result = loop {
             let op = match self.op {
                 OpType::Proc(proc) => proc,
-                OpType::HaltOk => return Ok(self.args),
-                OpType::HaltErr => {
-                    return Err(Exception(self.args.pop().unwrap()));
-                }
+                OpType::HaltOk => break Ok(self.args),
+                OpType::HaltErr => break Err(Exception(self.args.pop().unwrap())),
             };
             self = maybe_await!(op.0.apply(self.k, self.args, barrier));
-        }
+        };
+        barrier.truncate_marks(restore_depth);
+        result
     }
 
     /// Evaluate the application — and all subsequent applications — until all
@@ -900,16 +910,18 @@ impl Application {
     /// Just like [eval] but throws an error if we encounter an async function.
     pub fn eval_sync(mut self, barrier: &mut ContBarrier) -> Result<Vec<Value>, Exception> {
         let _guard = publish_ambient(barrier.state.clone());
-        loop {
+        barrier.push_marks();
+        let restore_depth = barrier.marks_depth() - 1;
+        let result = loop {
             let op = match self.op {
                 OpType::Proc(proc) => proc,
-                OpType::HaltOk => return Ok(self.args),
-                OpType::HaltErr => {
-                    return Err(Exception(self.args.pop().unwrap()));
-                }
+                OpType::HaltOk => break Ok(self.args),
+                OpType::HaltErr => break Err(Exception(self.args.pop().unwrap())),
             };
             self = op.0.apply_sync(self.k, self.args, barrier);
-        }
+        };
+        barrier.truncate_marks(restore_depth);
+        result
     }
 }
 
@@ -1083,19 +1095,10 @@ impl<'a> ContBarrier<'a> {
     /// state means the callee observes the caller's exception handlers and
     /// current ports.
     pub fn nested() -> ContBarrier<'static> {
-        let Some(state) = ambient_state() else {
-            return Self::root();
-        };
-        let mut barrier = Self::from_state(state);
-        // A fresh barrier's cont_marks starts pre-seeded with one baseline
-        // frame (see DynState::new), which the entry continuation (halt, or
-        // the callee being a continuation itself) consumes exactly once on
-        // the way out. A nested barrier shares the ambient cont_marks stack
-        // instead of getting a fresh one, so it must push that baseline
-        // frame itself; otherwise its terminal pop would consume a frame
-        // that belongs to the ambient computation.
-        barrier.push_marks();
-        barrier
+        match ambient_state() {
+            Some(state) => Self::from_state(state),
+            None => Self::root(),
+        }
     }
 
     pub(crate) fn from_state(state: Gc<RwLock<DynState>>) -> ContBarrier<'static> {
@@ -1174,6 +1177,17 @@ impl<'a> ContBarrier<'a> {
 
     pub(crate) fn pop_marks(&mut self) {
         self.state.write().cont_marks.pop();
+    }
+
+    pub(crate) fn marks_depth(&self) -> usize {
+        self.state.read().cont_marks.len()
+    }
+
+    /// Truncate continuation marks back to `depth`, discarding frames left
+    /// behind by pending continuations when the trampoline exits early
+    /// (halt_err). No-op on balanced exits.
+    pub(crate) fn truncate_marks(&mut self, depth: usize) {
+        self.state.write().cont_marks.truncate(depth);
     }
 
     pub(crate) fn current_marks(&self, tag: Symbol) -> Vec<Value> {

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -1112,8 +1112,8 @@ impl<'a> ContBarrier<'a> {
     }
 
     /// A barrier for nested re-entry into Scheme (callbacks, macro
-    /// transformers, library invocation): shares the dynamic state of the
-    /// task we are running on, under a fresh id. The fresh id keeps escape
+    /// transformers, `eval`): shares the dynamic state of the task we are
+    /// running on, under a fresh id. The fresh id keeps escape
     /// procedures from jumping across the intervening Rust frame; the shared
     /// state means the callee observes the caller's exception handlers and
     /// current ports.

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -1069,14 +1069,6 @@ impl<'a> ContBarrier<'a> {
         NEXT_ID.fetch_add(1, Ordering::Relaxed)
     }
 
-    pub fn new() -> Self {
-        Self {
-            id: Self::next_id(),
-            state: Gc::new(RwLock::new(DynState::new())),
-            params: HashMap::new(),
-        }
-    }
-
     /// A barrier with a fresh, empty dynamic state. Only for true entry
     /// points: an embedder calling into Scheme from a context with no
     /// ambient dynamic state.
@@ -1091,10 +1083,19 @@ impl<'a> ContBarrier<'a> {
     /// state means the callee observes the caller's exception handlers and
     /// current ports.
     pub fn nested() -> ContBarrier<'static> {
-        match ambient_state() {
-            Some(state) => Self::from_state(state),
-            None => Self::root(),
-        }
+        let Some(state) = ambient_state() else {
+            return Self::root();
+        };
+        let mut barrier = Self::from_state(state);
+        // A fresh barrier's cont_marks starts pre-seeded with one baseline
+        // frame (see DynState::new), which the entry continuation (halt, or
+        // the callee being a continuation itself) consumes exactly once on
+        // the way out. A nested barrier shares the ambient cont_marks stack
+        // instead of getting a fresh one, so it must push that baseline
+        // frame itself; otherwise its terminal pop would consume a frame
+        // that belongs to the ambient computation.
+        barrier.push_marks();
+        barrier
     }
 
     pub(crate) fn from_state(state: Gc<RwLock<DynState>>) -> ContBarrier<'static> {
@@ -1281,12 +1282,6 @@ impl<'a> ContBarrier<'a> {
     }
 }
 
-impl Default for ContBarrier<'_> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl<'a, 'b, 'c> From<&'b mut ContBarrier<'a>> for ContBarrier<'c>
 where
     'b: 'c,
@@ -1449,7 +1444,16 @@ fn escape_procedure(
     let saved_barrier_read = saved_barrier.as_ref();
 
     if saved_barrier_read.id != barrier.id {
-        return Err(Exception::error("attempt to cross continuation barrier"));
+        // Don't raise this through the (possibly shared, since barriers now
+        // share dynamic state) exception-handler search: a handler found
+        // that way could belong to an ancestor barrier and need to escape
+        // right back out through this same check. Halt this barrier's local
+        // trampoline directly instead, so the error surfaces as a plain
+        // Result::Err to whichever Rust frame owns this barrier — letting it
+        // re-raise, if at all, from a barrier where escaping is possible.
+        return Ok(Application::halt_err(Value::from(Exception::error(
+            "attempt to cross continuation barrier",
+        ))));
     }
 
     barrier.set_cont_marks(saved_barrier_read.cont_marks.clone());

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -1007,6 +1007,28 @@ impl DynState {
             cont_marks: vec![HashMap::new()],
         }
     }
+
+    /// The dynamic state a newly spawned thread/task starts with: binding
+    /// entries (current ports) carry over as copies; control entries
+    /// (winders, prompts, exception handlers) belong to the spawning
+    /// thread's stack and do not cross. Continuation marks start fresh —
+    /// the child begins a fresh initial continuation.
+    fn spawn_snapshot(&self) -> Self {
+        Self {
+            dyn_stack: self
+                .dyn_stack
+                .iter()
+                .filter(|elem| {
+                    matches!(
+                        elem,
+                        DynStackElem::CurrentInputPort(_) | DynStackElem::CurrentOutputPort(_)
+                    )
+                })
+                .cloned()
+                .collect(),
+            cont_marks: vec![HashMap::new()],
+        }
+    }
 }
 
 #[cfg(feature = "async")]
@@ -1030,6 +1052,16 @@ pub(crate) fn ambient_state() -> Option<Gc<RwLock<DynState>>> {
         return Some(state);
     }
     AMBIENT_STATE_TL.with(|s| s.borrow().clone())
+}
+
+/// The dynamic state for a child thread/task spawned right now: a filtered
+/// snapshot of the ambient state (empty if there is none).
+pub(crate) fn spawn_state() -> Gc<RwLock<DynState>> {
+    let snapshot = match ambient_state() {
+        Some(state) => state.read().spawn_snapshot(),
+        None => DynState::new(),
+    };
+    Gc::new(RwLock::new(snapshot))
 }
 
 /// Publish `state` as this thread's ambient dynamic state; restores the
@@ -2154,5 +2186,55 @@ unsafe extern "C" fn wind_delim(
             None,
             args,
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spawn_snapshot_keeps_ports_drops_control_resets_marks() {
+        let runtime = Runtime::new();
+        let out_port = Port::new(
+            "<stdout>",
+            #[cfg(not(feature = "async"))]
+            std::io::stdout(),
+            #[cfg(feature = "tokio")]
+            tokio::io::stdout(),
+            BufferMode::None,
+            Some(Transcoder::native()),
+        );
+        let in_port = Port::new(
+            "<stdin>",
+            #[cfg(not(feature = "async"))]
+            std::io::stdin(),
+            #[cfg(feature = "tokio")]
+            tokio::io::stdin(),
+            BufferMode::Line,
+            Some(Transcoder::native()),
+        );
+        let mut marked = HashMap::new();
+        marked.insert(Symbol::intern("mark"), Value::from(true));
+        let state = DynState {
+            dyn_stack: vec![
+                DynStackElem::ExceptionHandler(halt_continuation(runtime)),
+                DynStackElem::CurrentOutputPort(out_port),
+                DynStackElem::CurrentInputPort(in_port),
+            ],
+            cont_marks: vec![HashMap::new(), marked],
+        };
+
+        let snapshot = state.spawn_snapshot();
+
+        assert!(matches!(
+            snapshot.dyn_stack.as_slice(),
+            [
+                DynStackElem::CurrentOutputPort(_),
+                DynStackElem::CurrentInputPort(_)
+            ]
+        ));
+        assert_eq!(snapshot.cont_marks.len(), 1);
+        assert!(snapshot.cont_marks[0].is_empty());
     }
 }

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -696,9 +696,29 @@ impl Procedure {
         self.0.is_continuation()
     }
 
+    /// Call this procedure in the ambient dynamic extent: the barrier is
+    /// constructed automatically (sharing the running task's dynamic state
+    /// when called from within an evaluation, fresh otherwise). Use
+    /// [`Procedure::call_with_barrier`] to supply host parameters or an
+    /// explicit dynamic state.
+    #[maybe_async]
+    pub fn call(&self, args: &[Value]) -> Result<Vec<Value>, Exception> {
+        maybe_await!(self.call_with_barrier(args, &mut ContBarrier::nested()))
+    }
+
+    /// Call this procedure in the ambient dynamic extent: the barrier is
+    /// constructed automatically (sharing the running task's dynamic state
+    /// when called from within an evaluation, fresh otherwise). Use
+    /// [`Procedure::call_sync_with_barrier`] to supply host parameters or
+    /// an explicit dynamic state.
+    #[cfg(feature = "async")]
+    pub fn call_sync(&self, args: &[Value]) -> Result<Vec<Value>, Exception> {
+        self.call_sync_with_barrier(args, &mut ContBarrier::nested())
+    }
+
     /// Applies `args` to the procedure and returns the values it evaluates to.
     #[maybe_async]
-    pub fn call(
+    pub fn call_with_barrier(
         &self,
         args: &[Value],
         barrier: &mut ContBarrier<'_>,
@@ -708,7 +728,7 @@ impl Procedure {
     }
 
     #[cfg(feature = "async")]
-    pub fn call_sync(
+    pub fn call_sync_with_barrier(
         &self,
         args: &[Value],
         barrier: &mut ContBarrier<'_>,

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -1012,7 +1012,9 @@ impl DynState {
     /// entries (current ports) carry over as copies; control entries
     /// (winders, prompts, exception handlers) belong to the spawning
     /// thread's stack and do not cross. Continuation marks start fresh —
-    /// the child begins a fresh initial continuation.
+    /// the child begins a fresh initial continuation. This is an allowlist:
+    /// entries not listed here default to *not* crossing the spawn boundary;
+    /// reconsider when adding a `DynStackElem` variant.
     fn spawn_snapshot(&self) -> Self {
         Self {
             dyn_stack: self

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -951,3 +951,31 @@ unsafe extern "C" fn call_known_3x1(
         }
     }
 }
+
+#[cfg(all(test, not(feature = "async")))]
+mod tests {
+    use super::*;
+    use crate::env::{ImportPolicy, TopLevelEnvironment};
+
+    #[test]
+    fn uncaught_error_leaves_root_cont_marks_balanced() {
+        let rt = Runtime::new();
+        let env = TopLevelEnvironment::new_repl(&rt);
+        // An uncaught error inside several pending non-tail calls: each
+        // pending continuation has pushed a cont_marks frame that its
+        // invocation would normally pop, and the HaltErr exit skips all of
+        // those pops. The trampoline must rebalance the root state itself.
+        let program = "
+            (import (rnrs))
+            (define (fail n)
+              (if (= n 0)
+                  (error 'boom \"uncaught\")
+                  (+ 1 (fail (- n 1)))))
+            (fail 5)";
+        assert!(env.eval(ImportPolicy::Allow, program).is_err());
+        let depth_after_first = rt.entry_barrier().marks_depth();
+        assert!(env.eval(ImportPolicy::Allow, program).is_err());
+        let depth_after_second = rt.entry_barrier().marks_depth();
+        assert_eq!(depth_after_first, depth_after_second);
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -131,7 +131,8 @@ impl Runtime {
             &mut mutable_vars
         ))?;
         let proc = maybe_await!(Compiler::new(mutable_vars).compile(self, &body))?;
-        maybe_await!(Application::new(proc, None, Vec::new()).eval(&mut ContBarrier::default()))
+        let mut barrier = self.entry_barrier();
+        maybe_await!(Application::new(proc, None, Vec::new()).eval(&mut barrier))
     }
 
     /// Define a library from Rust code. Useful if file system access is disabled.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -15,7 +15,7 @@ use crate::{
     num,
     ports::{BufferMode, Port, Transcoder},
     proc::{
-        Application, ContBarrier, ContinuationPtr, FuncPtr, ProcDebugInfo, Procedure,
+        Application, ContBarrier, ContinuationPtr, DynState, FuncPtr, ProcDebugInfo, Procedure,
         ProcedureInner, UserPtr,
     },
     records::Embedded,
@@ -158,6 +158,17 @@ impl Runtime {
         self.0.read().registry.clone()
     }
 
+    /// The root dynamic state shared by all top-level evaluation on this runtime.
+    pub(crate) fn root_dyn_state(&self) -> Gc<RwLock<DynState>> {
+        self.0.read().dyn_state.clone()
+    }
+
+    /// A barrier for top-level evaluation (programs, REPL forms, library
+    /// invocation) against this runtime's root dynamic state.
+    pub(crate) fn entry_barrier(&self) -> ContBarrier<'static> {
+        ContBarrier::from_state(self.root_dyn_state())
+    }
+
     #[maybe_async]
     pub(crate) fn compile_expr(&self, expr: Cps, escaping: Escaping) -> Procedure {
         let (completion_tx, completion_rx) = completion();
@@ -214,6 +225,10 @@ pub(crate) struct RuntimeInner {
     pub(crate) globals_pool: HashSet<Global>,
     pub(crate) debug_info: DebugInfo,
     pub(crate) source_cache: SourceCache,
+    /// The root dynamic state for programs run on this runtime. Top-level
+    /// library bodies are invoked against this state, so dynamic-state
+    /// changes made at library load time persist for the Runtime's life.
+    dyn_state: Gc<RwLock<DynState>>,
 }
 
 impl Default for RuntimeInner {
@@ -247,6 +262,7 @@ impl RuntimeInner {
             globals_pool: HashSet::new(),
             debug_info: DebugInfo::default(),
             source_cache: SourceCache::default(),
+            dyn_state: Gc::new(RwLock::new(DynState::new())),
         }
     }
 }

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -287,7 +287,7 @@ impl Syntax {
 
         // Call the transformer with the input:
         let transformer_output =
-            maybe_await!(transformer.call(&[Value::from(input)], &mut ContBarrier::new()))?;
+            maybe_await!(transformer.call(&[Value::from(input)], &mut ContBarrier::nested()))?;
 
         let output: Value = transformer_output.expect1()?;
         let mut output = Syntax::wrap(output, self.span());

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     exceptions::{CompoundCondition, Exception, Message, SyntaxViolation, Who},
     gc::Trace,
     ports::Port,
-    proc::{ContBarrier, Procedure},
+    proc::Procedure,
     records::{Embeddable, Embedded, RecordTypeDescriptor, rtd},
     registry::bridge,
     symbols::Symbol,
@@ -286,8 +286,7 @@ impl Syntax {
         input.add_scope(intro_scope);
 
         // Call the transformer with the input:
-        let transformer_output =
-            maybe_await!(transformer.call(&[Value::from(input)], &mut ContBarrier::nested()))?;
+        let transformer_output = maybe_await!(transformer.call(&[Value::from(input)]))?;
 
         let output: Value = transformer_output.expect1()?;
         let mut output = Syntax::wrap(output, self.span());

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -46,12 +46,12 @@ pub fn spawn(thunk: Procedure) -> Result<Vec<Value>, Exception> {
 
         #[cfg(not(feature = "async"))]
         {
-            *cell_write = thunk.call(&[], &mut ContBarrier::new());
+            *cell_write = thunk.call(&[], &mut ContBarrier::root());
         }
 
         #[cfg(feature = "async")]
         {
-            *cell_write = thunk.call_sync(&[], &mut ContBarrier::new());
+            *cell_write = thunk.call_sync(&[], &mut ContBarrier::root());
         }
     });
     let id = join_handle.thread().id();

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -47,12 +47,12 @@ pub fn spawn(thunk: Procedure) -> Result<Vec<Value>, Exception> {
 
         #[cfg(not(feature = "async"))]
         {
-            *cell_write = thunk.call(&[], &mut ContBarrier::from_state(state));
+            *cell_write = thunk.call_with_barrier(&[], &mut ContBarrier::from_state(state));
         }
 
         #[cfg(feature = "async")]
         {
-            *cell_write = thunk.call_sync(&[], &mut ContBarrier::from_state(state));
+            *cell_write = thunk.call_sync_with_barrier(&[], &mut ContBarrier::from_state(state));
         }
     });
     let id = join_handle.thread().id();

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -13,7 +13,7 @@ use scheme_rs_macros::bridge;
 use crate::{
     exceptions::Exception,
     gc::{Gc, Trace},
-    proc::{ContBarrier, Procedure},
+    proc::{ContBarrier, Procedure, spawn_state},
     records::{Embeddable, Embedded, RecordTypeDescriptor, rtd},
     value::Value,
 };
@@ -41,7 +41,7 @@ unsafe impl Embeddable for JoinHandle {
 pub fn spawn(thunk: Procedure) -> Result<Vec<Value>, Exception> {
     let cell = Gc::new(Mutex::new(Ok(Vec::new())));
     let cell_cloned = cell.clone();
-    let state = crate::proc::spawn_state();
+    let state = spawn_state();
     let join_handle = thread::spawn(move || {
         let mut cell_write = cell_cloned.lock();
 

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -41,17 +41,18 @@ unsafe impl Embeddable for JoinHandle {
 pub fn spawn(thunk: Procedure) -> Result<Vec<Value>, Exception> {
     let cell = Gc::new(Mutex::new(Ok(Vec::new())));
     let cell_cloned = cell.clone();
+    let state = crate::proc::spawn_state();
     let join_handle = thread::spawn(move || {
         let mut cell_write = cell_cloned.lock();
 
         #[cfg(not(feature = "async"))]
         {
-            *cell_write = thunk.call(&[], &mut ContBarrier::root());
+            *cell_write = thunk.call(&[], &mut ContBarrier::from_state(state));
         }
 
         #[cfg(feature = "async")]
         {
-            *cell_write = thunk.call_sync(&[], &mut ContBarrier::root());
+            *cell_write = thunk.call_sync(&[], &mut ContBarrier::from_state(state));
         }
     });
     let id = join_handle.thread().id();

--- a/tests/dynamic_state_inheritance.rs
+++ b/tests/dynamic_state_inheritance.rs
@@ -1,0 +1,3 @@
+mod common;
+
+common::run_test!(dynamic_state_inheritance);

--- a/tests/dynamic_state_inheritance.scm
+++ b/tests/dynamic_state_inheritance.scm
@@ -1,0 +1,43 @@
+(import (rnrs) (test) (threads (1)))
+
+;; 1. RED: a hashtable hash function must observe the exception handler
+;; installed by its caller. Today the hash function runs in a fresh, empty
+;; ContBarrier, so raise-continuable finds no handler and the operation
+;; fails; the guard below then produces 'no-handler-seen.
+(define ht
+  (make-hashtable
+   (lambda (k) (raise-continuable 'need-hash))
+   eq?))
+
+(define handler-result
+  (guard (e (#t 'no-handler-seen))
+    (with-exception-handler
+      (lambda (c) 42)
+      (lambda ()
+        (hashtable-set! ht 'a 1)
+        (hashtable-ref ht 'a #f)))))
+
+(assert-equal? handler-result 1)
+
+;; 2. GUARD: escape procedures still cannot cross the Rust re-entry frame.
+;; The fresh barrier id at the callback boundary must keep rejecting jumps.
+(assert-equal?
+ (call/cc
+  (lambda (k)
+    (let ((ht2 (make-hashtable (lambda (key) (k 'escaped)) eq?)))
+      (guard (e (#t 'blocked))
+        (hashtable-set! ht2 'x 1)
+        'not-blocked))))
+ 'blocked)
+
+;; 3. GUARD: a spawned thread must not run the parent's winders. Each parent
+;; winder fires exactly once, from the parent.
+(define order '())
+(dynamic-wind
+    (lambda () (set! order (cons 'in order)))
+    (lambda ()
+      (join (spawn (lambda ()
+                     (guard (e (#t 'caught))
+                       (error 'child "boom"))))))
+    (lambda () (set! order (cons 'out order))))
+(assert-equal? order '(out in))


### PR DESCRIPTION
## Problem

Every re-entry from Rust into Scheme constructs an empty `ContBarrier`, so the
dynamic state resets at each boundary: a hashtable hash function
does not observe the caller's `with-exception-handler`, custom port callbacks
do not observe a redirected `current-output-port`, and so on. 

## Change

Split the barrier into identity and state. The `id` (the escape-procedure
jump guard) stays per-entry and is still fresh at every Rust frame. The dynamic state
moves behind `Gc<RwLock<DynState>>` and is shared by nested re-entries: a
callback runs in its caller's dynamic extent, because it *is* in its caller's
dynamic extent.

`ContBarrier::new()` is removed in favor of constructors that make each
site's intent explicit (and un-reintroducible by accident):

- `nested()`: callbacks, transformers, `eval`: share the ambient task's
  state under a fresh id. The ambient handle is a tokio task_local
  (thread_local for sync builds/OS threads) published by the eval trampoline.
- `Runtime::entry_barrier()`: programs, REPL forms, and library invocation
  run against a per-Runtime root state, so dynamic-state effects at library
  load time persist for the Runtime's life.
- `root()` — fresh empty state for embedder entry with no ambient context.
- Spawns (threads/tasks/futures) get a filtered snapshot at creation:
  binding entries (current ports) copy over; control entries (winders,
  prompts, exception handlers) belong to the creator's stack and don't cross
  (SRFI-18/226 model: fresh initial continuation + inherited bindings,
  uncaught exceptions delivered through the join/await channel). Futures
  snapshot at creation, not first poll.

Embedders normally don't touch any of this: `Procedure::call` now constructs
its own `nested()` barrier, so calling a Scheme procedure from Rust does the
right thing inside and outside evaluations without knowing barriers exist;
`call_with_barrier` keeps the explicit form (host params via `add_param`,
spawn snapshots). Which dyn-stack entries cross a spawn is an exhaustive
per-variant match, so adding a variant forces that decision at compile time.

Sharing the state surfaced a latent imbalance worth calling out: a `HaltErr`
exit skips the pending continuations' `cont_marks` pops, leaking one frame per in-flight
call. The trampoline now pushes the baseline frame and pops it on entry/exit.

## Why now

Needed for parameters, otherwise you wouldn't be able to import/export parameters, depend on them in scheme->rust->scheme code, or use them as global state.

## Notes for review

- JIT codegen should be unaffected
- An end-to-end spawn test (child writes to the parent's
  `with-output-to-file` port) is deferred until #315 lands; the snapshot
  filter is pinned by a unit test meanwhile.
- Lock cost: one parking_lot RwLock round-trip per dyn-stack/marks operation,
  same pattern as the existing `Gc<RwLock<RuntimeInner>>`.  I can bench it if you want.

Happy to reshape any of it if you want to discuss.
