### PR TITLE
[AI coded] Pure threading: thread the barrier through every re-entry (alt to #319/#323)

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1020,11 +1020,18 @@ impl Definition {
         env: &Environment,
         form: &Syntax,
         mutable_vars: &mut HashSet<Local>,
+        barrier: &mut ContBarrier<'_>,
     ) -> Result<Self, Exception> {
         match syn {
             [_, Syntax::Identifier { ident, .. }, expr, end] if end.is_null() => Ok(Definition {
                 var: maybe_await!(env.lookup_var(ident.bind()))?.unwrap(),
-                expr: maybe_await!(Expression::parse(ctxt, expr.clone(), env, mutable_vars))?,
+                expr: maybe_await!(Expression::parse(
+                    ctxt,
+                    expr.clone(),
+                    env,
+                    mutable_vars,
+                    barrier
+                ))?,
             }),
             [_, Syntax::List { list, .. }, body @ .., end] if end.is_null() => {
                 if body.is_empty() {
@@ -1104,7 +1111,8 @@ impl Definition {
                             &body,
                             &new_env,
                             form,
-                            mutable_vars
+                            mutable_vars,
+                            barrier
                         ))?;
 
                         Ok(Definition {
@@ -1130,12 +1138,19 @@ pub(super) fn define_syntax(
     binding: Binding,
     expr: Syntax,
     env: &Environment,
+    barrier: &mut ContBarrier<'_>,
 ) -> Result<(), Exception> {
-    let expanded = maybe_await!(expr.expand(env))?;
+    let expanded = maybe_await!(expr.expand(env, barrier))?;
     let mut mutable_vars = HashSet::default();
-    let expr = maybe_await!(Expression::parse(ctxt, expanded, env, &mut mutable_vars))?;
+    let expr = maybe_await!(Expression::parse(
+        ctxt,
+        expanded,
+        env,
+        &mut mutable_vars,
+        barrier
+    ))?;
     let proc = maybe_await!(Compiler::new(mutable_vars).compile(&ctxt.runtime, &expr))?;
-    let values = maybe_await!(proc.call(&[], &mut ContBarrier::new()))?;
+    let values = maybe_await!(proc.call(&[], barrier))?;
     let transformer: Procedure = values.expect1()?;
     env.def_keyword(binding, transformer);
     Ok(())
@@ -1168,9 +1183,16 @@ impl Expression {
         form: Syntax,
         env: &Environment,
         mutable_vars: &mut HashSet<Local>,
+        barrier: &mut ContBarrier<'_>,
     ) -> Result<Self, Exception> {
-        let expanded = maybe_await!(form.expand(env))?;
-        maybe_await!(Self::parse_expanded(ctxt, expanded, env, mutable_vars))
+        let expanded = maybe_await!(form.expand(env, barrier))?;
+        maybe_await!(Self::parse_expanded(
+            ctxt,
+            expanded,
+            env,
+            mutable_vars,
+            barrier
+        ))
     }
 
     #[cfg(not(feature = "async"))]
@@ -1179,8 +1201,9 @@ impl Expression {
         form: Syntax,
         env: &Environment,
         mutable_vars: &mut HashSet<Local>,
+        barrier: &mut ContBarrier<'_>,
     ) -> Result<Self, Exception> {
-        Self::parse_expanded_inner(ctxt, form, env, mutable_vars)
+        Self::parse_expanded_inner(ctxt, form, env, mutable_vars, barrier)
     }
 
     #[cfg(feature = "async")]
@@ -1189,8 +1212,15 @@ impl Expression {
         form: Syntax,
         env: &'a Environment,
         mutable_vars: &'a mut HashSet<Local>,
+        barrier: &'a mut ContBarrier<'_>,
     ) -> BoxFuture<'a, Result<Self, Exception>> {
-        Box::pin(Self::parse_expanded_inner(ctxt, form, env, mutable_vars))
+        Box::pin(Self::parse_expanded_inner(
+            ctxt,
+            form,
+            env,
+            mutable_vars,
+            barrier,
+        ))
     }
 
     #[maybe_async]
@@ -1199,6 +1229,7 @@ impl Expression {
         form: Syntax,
         env: &Environment,
         mutable_vars: &mut HashSet<Local>,
+        barrier: &mut ContBarrier<'_>,
     ) -> Result<Self, Exception> {
         match &form {
             syn if syn.is_null() => Err(error::unexpected_empty_list(&form, None)),
@@ -1241,31 +1272,53 @@ impl Expression {
                     if let Some(primitive) = env.lookup_primitive(binding) {
                         match primitive {
                             Primitive::Begin => {
-                                maybe_await!(Body::parse(ctxt, tail, env, mutable_vars))
+                                maybe_await!(Body::parse(ctxt, tail, env, mutable_vars, barrier))
                                     .map(Expression::Begin)
                             }
-                            Primitive::Lambda => {
-                                maybe_await!(Lambda::parse(ctxt, tail, env, &form, mutable_vars))
-                                    .map(Expression::Lambda)
-                            }
-                            Primitive::Let => {
-                                maybe_await!(Let::parse(ctxt, tail, env, &form, mutable_vars))
-                                    .map(Expression::Let)
-                            }
-                            Primitive::LetRec => {
-                                maybe_await!(LetRec::parse(ctxt, tail, env, &form, mutable_vars))
-                                    .map(Expression::LetRec)
-                            }
-                            Primitive::If => {
-                                maybe_await!(If::parse(ctxt, tail, env, &form, mutable_vars))
-                                    .map(Expression::If)
-                            }
+                            Primitive::Lambda => maybe_await!(Lambda::parse(
+                                ctxt,
+                                tail,
+                                env,
+                                &form,
+                                mutable_vars,
+                                barrier
+                            ))
+                            .map(Expression::Lambda),
+                            Primitive::Let => maybe_await!(Let::parse(
+                                ctxt,
+                                tail,
+                                env,
+                                &form,
+                                mutable_vars,
+                                barrier
+                            ))
+                            .map(Expression::Let),
+                            Primitive::LetRec => maybe_await!(LetRec::parse(
+                                ctxt,
+                                tail,
+                                env,
+                                &form,
+                                mutable_vars,
+                                barrier
+                            ))
+                            .map(Expression::LetRec),
+                            Primitive::If => maybe_await!(If::parse(
+                                ctxt,
+                                tail,
+                                env,
+                                &form,
+                                mutable_vars,
+                                barrier
+                            ))
+                            .map(Expression::If),
                             Primitive::And => {
-                                maybe_await!(And::parse(ctxt, tail, env, mutable_vars))
+                                maybe_await!(And::parse(ctxt, tail, env, mutable_vars, barrier))
                                     .map(Expression::And)
                             }
-                            Primitive::Or => maybe_await!(Or::parse(ctxt, tail, env, mutable_vars))
-                                .map(Expression::Or),
+                            Primitive::Or => {
+                                maybe_await!(Or::parse(ctxt, tail, env, mutable_vars, barrier))
+                                    .map(Expression::Or)
+                            }
                             Primitive::Quote => Quote::parse(tail, &form).map(Expression::Quote),
                             Primitive::Syntax => SyntaxQuote::parse(ctxt, tail, env, &form)
                                 .map(Expression::SyntaxQuote),
@@ -1274,13 +1327,19 @@ impl Expression {
                                 tail,
                                 env,
                                 &form,
-                                mutable_vars
+                                mutable_vars,
+                                barrier
                             ))
                             .map(Expression::SyntaxCase),
-                            Primitive::Set => {
-                                maybe_await!(Set::parse(ctxt, tail, env, &form, mutable_vars))
-                                    .map(Expression::Set)
-                            }
+                            Primitive::Set => maybe_await!(Set::parse(
+                                ctxt,
+                                tail,
+                                env,
+                                &form,
+                                mutable_vars,
+                                barrier
+                            ))
+                            .map(Expression::Set),
                             Primitive::LetSyntax if !tail.is_empty() => {
                                 let (form, env) = maybe_await!(parse_let_syntax(
                                     ctxt,
@@ -1289,8 +1348,9 @@ impl Expression {
                                     &tail[1..],
                                     env,
                                     &mut Vec::new(),
+                                    barrier,
                                 ))?;
-                                maybe_await!(Body::parse(ctxt, &form, &env, mutable_vars))
+                                maybe_await!(Body::parse(ctxt, &form, &env, mutable_vars, barrier))
                                     .map(Expression::Begin)
                             }
                             Primitive::LetRecSyntax if !tail.is_empty() => {
@@ -1301,8 +1361,9 @@ impl Expression {
                                     &tail[1..],
                                     env,
                                     &mut Vec::new(),
+                                    barrier,
                                 ))?;
-                                maybe_await!(Body::parse(ctxt, &form, &env, mutable_vars))
+                                maybe_await!(Body::parse(ctxt, &form, &env, mutable_vars, barrier))
                                     .map(Expression::Begin)
                             }
                             Primitive::Import => Err(error::unexpected_import(&form)),
@@ -1316,7 +1377,8 @@ impl Expression {
                             tail,
                             env,
                             &form,
-                            mutable_vars
+                            mutable_vars,
+                            barrier
                         ))
                         .map(Expression::Apply)
                     } else {
@@ -1325,11 +1387,18 @@ impl Expression {
                 }
                 [expr, args @ .., end] if end.is_null() => maybe_await!(Apply::parse(
                     ctxt,
-                    maybe_await!(Expression::parse(ctxt, expr.clone(), env, mutable_vars))?,
+                    maybe_await!(Expression::parse(
+                        ctxt,
+                        expr.clone(),
+                        env,
+                        mutable_vars,
+                        barrier
+                    ))?,
                     args,
                     env,
                     &form,
                     mutable_vars,
+                    barrier,
                 ))
                 .map(Expression::Apply),
                 _ => Err(error::bad_form(&form, None)),
@@ -1409,6 +1478,7 @@ impl Apply {
         env: &Environment,
         form: &Syntax,
         mutable_vars: &mut HashSet<Local>,
+        barrier: &mut ContBarrier<'_>,
     ) -> Result<Self, Exception> {
         let mut parsed_args = Vec::new();
         for arg in args {
@@ -1416,7 +1486,8 @@ impl Apply {
                 ctxt,
                 arg.clone(),
                 env,
-                mutable_vars
+                mutable_vars,
+                barrier
             ))?);
         }
         Ok(Apply {
@@ -1442,13 +1513,30 @@ impl Lambda {
         env: &Environment,
         form: &Syntax,
         mutable_vars: &mut HashSet<Local>,
+        barrier: &mut ContBarrier<'_>,
     ) -> Result<Self, Exception> {
         match sexprs {
             [null, body @ ..] if null.is_null() => {
-                maybe_await!(parse_lambda(ctxt, &[], body, env, form, mutable_vars))
+                maybe_await!(parse_lambda(
+                    ctxt,
+                    &[],
+                    body,
+                    env,
+                    form,
+                    mutable_vars,
+                    barrier
+                ))
             }
             [Syntax::List { list: args, .. }, body @ ..] => {
-                maybe_await!(parse_lambda(ctxt, args, body, env, form, mutable_vars))
+                maybe_await!(parse_lambda(
+                    ctxt,
+                    args,
+                    body,
+                    env,
+                    form,
+                    mutable_vars,
+                    barrier
+                ))
             }
             [ident @ Syntax::Identifier { .. }, body @ ..] => {
                 maybe_await!(parse_lambda(
@@ -1458,6 +1546,7 @@ impl Lambda {
                     env,
                     form,
                     mutable_vars,
+                    barrier,
                 ))
             }
             _ => Err(error::expected_more_arguments(form)),
@@ -1473,6 +1562,7 @@ fn parse_lambda(
     env: &Environment,
     form: &Syntax,
     mutable_vars: &mut HashSet<Local>,
+    barrier: &mut ContBarrier<'_>,
 ) -> Result<Lambda, Exception> {
     let mut bound = HashSet::<&Identifier>::default();
     let mut fixed = Vec::new();
@@ -1536,7 +1626,8 @@ fn parse_lambda(
         &body,
         &new_contour,
         form,
-        mutable_vars
+        mutable_vars,
+        barrier
     ))?;
 
     Ok(Lambda {
@@ -1560,13 +1651,22 @@ impl Let {
         env: &Environment,
         form: &Syntax,
         mutable_vars: &mut HashSet<Local>,
+        barrier: &mut ContBarrier<'_>,
     ) -> Result<Self, Exception> {
         match syn {
             [empty, body @ ..] if empty.is_null() => {
-                maybe_await!(parse_let(ctxt, &[], body, env, form, mutable_vars))
+                maybe_await!(parse_let(ctxt, &[], body, env, form, mutable_vars, barrier))
             }
             [Syntax::List { list: bindings, .. }, body @ ..] => {
-                maybe_await!(parse_let(ctxt, bindings, body, env, form, mutable_vars))
+                maybe_await!(parse_let(
+                    ctxt,
+                    bindings,
+                    body,
+                    env,
+                    form,
+                    mutable_vars,
+                    barrier
+                ))
             }
             // Named let:
             [
@@ -1580,7 +1680,8 @@ impl Let {
                 body,
                 env,
                 form,
-                mutable_vars
+                mutable_vars,
+                barrier
             )),
             [Syntax::Identifier { ident, .. }, empty, body @ ..] if empty.is_null() => {
                 maybe_await!(parse_named_let(
@@ -1590,7 +1691,8 @@ impl Let {
                     body,
                     env,
                     form,
-                    mutable_vars
+                    mutable_vars,
+                    barrier
                 ))
             }
             _ => Err(error::expected_more_arguments(form)),
@@ -1606,6 +1708,7 @@ fn parse_let(
     env: &Environment,
     form: &Syntax,
     mutable_vars: &mut HashSet<Local>,
+    barrier: &mut ContBarrier<'_>,
 ) -> Result<Let, Exception> {
     let mut previously_bound = HashSet::default();
     let mut parsed_bindings = Vec::new();
@@ -1624,7 +1727,8 @@ fn parse_let(
                     env,
                     &previously_bound,
                     form,
-                    mutable_vars
+                    mutable_vars,
+                    barrier
                 ))?;
                 previously_bound.insert(binding.ident);
                 let mut var = binding.ident.clone();
@@ -1648,7 +1752,8 @@ fn parse_let(
         &body,
         &new_contour,
         form,
-        mutable_vars
+        mutable_vars,
+        barrier
     ))?;
 
     Ok(Let {
@@ -1658,6 +1763,7 @@ fn parse_let(
 }
 
 #[maybe_async]
+#[allow(clippy::too_many_arguments)]
 fn parse_named_let(
     ctxt: &ParseContext,
     name: &Identifier,
@@ -1666,6 +1772,7 @@ fn parse_named_let(
     env: &Environment,
     form: &Syntax,
     mutable_vars: &mut HashSet<Local>,
+    barrier: &mut ContBarrier<'_>,
 ) -> Result<Let, Exception> {
     let mut previously_bound = HashSet::default();
     let mut formals = Vec::new();
@@ -1692,7 +1799,8 @@ fn parse_named_let(
                     env,
                     &previously_bound,
                     form,
-                    mutable_vars
+                    mutable_vars,
+                    barrier
                 ))?;
                 previously_bound.insert(binding.ident);
                 args.push(binding.expr);
@@ -1721,7 +1829,8 @@ fn parse_named_let(
         &body,
         &body_contour,
         form,
-        mutable_vars
+        mutable_vars,
+        barrier
     ))?;
 
     let let_rec = LetRec {
@@ -1760,6 +1869,7 @@ impl<'a> LetBinding<'a> {
         previously_bound: &HashSet<&'a Identifier>,
         form: &'a Syntax,
         mutable_vars: &mut HashSet<Local>,
+        barrier: &mut ContBarrier<'_>,
     ) -> Result<LetBinding<'a>, Exception> {
         if let Some([subform @ Syntax::Identifier { ident, .. }, expr, end]) = binding.as_list()
             && end.is_null()
@@ -1768,7 +1878,13 @@ impl<'a> LetBinding<'a> {
                 return Err(error::name_previously_bound(form, subform));
             }
 
-            let expr = maybe_await!(Expression::parse(ctxt, expr.clone(), env, mutable_vars))?;
+            let expr = maybe_await!(Expression::parse(
+                ctxt,
+                expr.clone(),
+                env,
+                mutable_vars,
+                barrier
+            ))?;
 
             Ok(LetBinding { ident, expr })
         } else {
@@ -1791,6 +1907,7 @@ impl Set {
         env: &Environment,
         form: &Syntax,
         mutable_vars: &mut HashSet<Local>,
+        barrier: &mut ContBarrier<'_>,
     ) -> Result<Self, Exception> {
         match exprs {
             [] | [_] => Err(error::expected_more_arguments(form)),
@@ -1819,7 +1936,8 @@ impl Set {
                     ctxt,
                     expr.clone(),
                     env,
-                    mutable_vars
+                    mutable_vars,
+                    barrier
                 ))?),
             }),
             [arg1, _] => Err(error::expected_identifier(form, Some(arg1))),
@@ -1843,6 +1961,7 @@ impl If {
         env: &Environment,
         form: &Syntax,
         mutable_vars: &mut HashSet<Local>,
+        barrier: &mut ContBarrier<'_>,
     ) -> Result<Self, Exception> {
         match exprs {
             [cond, success] => Ok(If {
@@ -1850,13 +1969,15 @@ impl If {
                     ctxt,
                     cond.clone(),
                     env,
-                    mutable_vars
+                    mutable_vars,
+                    barrier
                 ))?),
                 success: Arc::new(maybe_await!(Expression::parse(
                     ctxt,
                     success.clone(),
                     env,
-                    mutable_vars
+                    mutable_vars,
+                    barrier
                 ))?),
                 failure: None,
             }),
@@ -1865,19 +1986,22 @@ impl If {
                     ctxt,
                     cond.clone(),
                     env,
-                    mutable_vars
+                    mutable_vars,
+                    barrier
                 ))?),
                 success: Arc::new(maybe_await!(Expression::parse(
                     ctxt,
                     success.clone(),
                     env,
-                    mutable_vars
+                    mutable_vars,
+                    barrier
                 ))?),
                 failure: Some(Arc::new(maybe_await!(Expression::parse(
                     ctxt,
                     failure.clone(),
                     env,
-                    mutable_vars
+                    mutable_vars,
+                    barrier
                 ))?)),
             }),
             [] => Err(error::expected_more_arguments(form)),
@@ -1927,6 +2051,7 @@ impl Definitions {
         form: &Syntax,
         env: &Environment,
         mutable_vars: &mut HashSet<Local>,
+        barrier: &mut ContBarrier<'_>,
     ) -> Result<Self, Exception> {
         let ctxt = ParseContext {
             runtime: runtime.clone(),
@@ -1942,7 +2067,8 @@ impl Definitions {
                     true,
                     env,
                     form,
-                    mutable_vars
+                    mutable_vars,
+                    barrier
                 ))
             }
             _ => Err(error::bad_form(form, None)),
@@ -1956,6 +2082,7 @@ impl Definitions {
         env: &Environment,
         form: &Syntax,
         mutable_vars: &mut HashSet<Local>,
+        barrier: &mut ContBarrier<'_>,
     ) -> Result<Self, Exception> {
         maybe_await!(Self::parse_helper(
             ctxt,
@@ -1963,7 +2090,8 @@ impl Definitions {
             false,
             env,
             form,
-            mutable_vars
+            mutable_vars,
+            barrier
         ))
     }
 
@@ -1977,8 +2105,9 @@ impl Definitions {
         env: &Environment,
         form: &Syntax,
         mutable_vars: &mut HashSet<Local>,
+        barrier: &mut ContBarrier<'_>,
     ) -> Result<Self, Exception> {
-        Self::parse_helper_inner(ctxt, body, permissive, env, form, mutable_vars)
+        Self::parse_helper_inner(ctxt, body, permissive, env, form, mutable_vars, barrier)
     }
 
     /// Parse the body. body is expected to be a list of valid syntax objects, and should not include
@@ -1991,6 +2120,7 @@ impl Definitions {
         env: &'a Environment,
         form: &'a Syntax,
         mutable_vars: &'a mut HashSet<Local>,
+        barrier: &'a mut ContBarrier<'_>,
     ) -> BoxFuture<'a, Result<Self, Exception>> {
         Box::pin(Self::parse_helper_inner(
             ctxt,
@@ -1999,6 +2129,7 @@ impl Definitions {
             env,
             form,
             mutable_vars,
+            barrier,
         ))
     }
 
@@ -2010,6 +2141,7 @@ impl Definitions {
         env: &Environment,
         form: &Syntax,
         mutable_vars: &mut HashSet<Local>,
+        barrier: &mut ContBarrier<'_>,
     ) -> Result<Self, Exception> {
         let mut defs = Vec::new();
         let mut exprs = Vec::new();
@@ -2024,6 +2156,7 @@ impl Definitions {
             &mut defs,
             &mut exprs,
             &mut introduced_scopes,
+            barrier,
         ))?;
 
         let mut defs_parsed = Vec::new();
@@ -2056,6 +2189,7 @@ impl Definitions {
                 &env,
                 &def,
                 mutable_vars,
+                barrier,
             ))?;
             defs_parsed.push(def);
         }
@@ -2080,6 +2214,7 @@ impl Definitions {
                 expr,
                 &env,
                 mutable_vars,
+                barrier,
             ))?);
         }
 
@@ -2120,6 +2255,7 @@ impl LetRec {
         env: &Environment,
         form: &Syntax,
         mutable_vars: &mut HashSet<Local>,
+        barrier: &mut ContBarrier<'_>,
     ) -> Result<Self, Exception> {
         let (bindings, body): (&[Syntax], &[Syntax]) = match syn {
             [empty, body @ ..] if empty.is_null() => (&[], body),
@@ -2165,7 +2301,13 @@ impl LetRec {
                 expr.add_scope(new_scope);
                 parsed_bindings.push((
                     *var,
-                    maybe_await!(Expression::parse(ctxt, expr, &new_contour, mutable_vars))?,
+                    maybe_await!(Expression::parse(
+                        ctxt,
+                        expr,
+                        &new_contour,
+                        mutable_vars,
+                        barrier
+                    ))?,
                 ));
             }
         }
@@ -2177,7 +2319,8 @@ impl LetRec {
             &body,
             &new_contour,
             form,
-            mutable_vars
+            mutable_vars,
+            barrier
         ))?;
 
         Ok(LetRec {
@@ -2203,10 +2346,17 @@ impl Body {
         body: &[Syntax],
         env: &Environment,
         mutable_vars: &mut HashSet<Local>,
+        barrier: &mut ContBarrier<'_>,
     ) -> Result<Self, Exception> {
         let mut exprs = Vec::new();
         for sexpr in body {
-            let parsed = maybe_await!(Expression::parse(ctxt, sexpr.clone(), env, mutable_vars))?;
+            let parsed = maybe_await!(Expression::parse(
+                ctxt,
+                sexpr.clone(),
+                env,
+                mutable_vars,
+                barrier
+            ))?;
             exprs.push(parsed);
         }
         Ok(Self { exprs })
@@ -2224,6 +2374,7 @@ fn splice_in(
     defs: &mut Vec<(Syntax, Environment)>,
     exprs: &mut Vec<(Syntax, Environment)>,
     introduced_scopes: &mut Vec<Scope>,
+    barrier: &mut ContBarrier<'_>,
 ) -> Result<(), Exception> {
     splice_in_inner(
         ctxt,
@@ -2234,6 +2385,7 @@ fn splice_in(
         defs,
         exprs,
         introduced_scopes,
+        barrier,
     )
 }
 
@@ -2248,6 +2400,7 @@ fn splice_in<'a>(
     defs: &'a mut Vec<(Syntax, Environment)>,
     exprs: &'a mut Vec<(Syntax, Environment)>,
     introduced_scopes: &'a mut Vec<Scope>,
+    barrier: &'a mut ContBarrier<'_>,
 ) -> BoxFuture<'a, Result<(), Exception>> {
     Box::pin(splice_in_inner(
         ctxt,
@@ -2258,6 +2411,7 @@ fn splice_in<'a>(
         defs,
         exprs,
         introduced_scopes,
+        barrier,
     ))
 }
 
@@ -2272,12 +2426,13 @@ fn splice_in_inner(
     defs: &mut Vec<(Syntax, Environment)>,
     exprs: &mut Vec<(Syntax, Environment)>,
     introduced_scopes: &mut Vec<Scope>,
+    barrier: &mut ContBarrier<'_>,
 ) -> Result<(), Exception> {
     if body.is_empty() {
         return Err(error::expected_body(form));
     }
     for unexpanded in body {
-        let expanded = maybe_await!(unexpanded.clone().expand(env))?;
+        let expanded = maybe_await!(unexpanded.clone().expand(env, barrier))?;
         let is_def = {
             if let Some([Syntax::Identifier { ident, .. }, tail @ .., end]) = expanded.as_list()
                 && end.is_null()
@@ -2299,6 +2454,7 @@ fn splice_in_inner(
                             defs,
                             exprs,
                             introduced_scopes,
+                            barrier,
                         ))?;
                         continue;
                     }
@@ -2306,7 +2462,7 @@ fn splice_in_inner(
                         Some(Primitive::DefineSyntax),
                         [Syntax::Identifier { ident: name, .. }, expr],
                     ) => {
-                        maybe_await!(define_syntax(ctxt, name.bind(), expr.clone(), env))?;
+                        maybe_await!(define_syntax(ctxt, name.bind(), expr.clone(), env, barrier))?;
                         continue;
                     }
                     (Some(Primitive::DefineSyntax), _) => {
@@ -2319,7 +2475,8 @@ fn splice_in_inner(
                             bindings,
                             form,
                             env,
-                            introduced_scopes
+                            introduced_scopes,
+                            barrier
                         ))?;
                         if !form.is_empty() {
                             maybe_await!(splice_in(
@@ -2330,7 +2487,8 @@ fn splice_in_inner(
                                 &expanded,
                                 defs,
                                 exprs,
-                                introduced_scopes
+                                introduced_scopes,
+                                barrier
                             ))?;
                         }
                         continue;
@@ -2342,7 +2500,8 @@ fn splice_in_inner(
                             bindings,
                             form,
                             env,
-                            introduced_scopes
+                            introduced_scopes,
+                            barrier
                         ))?;
                         if !form.is_empty() {
                             maybe_await!(splice_in(
@@ -2353,7 +2512,8 @@ fn splice_in_inner(
                                 &expanded,
                                 defs,
                                 exprs,
-                                introduced_scopes
+                                introduced_scopes,
+                                barrier
                             ))?;
                         }
                         continue;
@@ -2412,6 +2572,7 @@ fn parse_let_syntax(
     exprs: &[Syntax],
     env: &Environment,
     introduced_scopes: &mut Vec<Scope>,
+    barrier: &mut ContBarrier<'_>,
 ) -> Result<(Vec<Syntax>, Environment), Exception> {
     let new_scope = Scope::new();
     let new_env = env.new_lexical_contour(new_scope);
@@ -2442,7 +2603,7 @@ fn parse_let_syntax(
                 expr.add_scope(new_scope);
             }
             let bind = name.new_bind();
-            maybe_await!(define_syntax(ctxt, bind, expr, &new_env))?;
+            maybe_await!(define_syntax(ctxt, bind, expr, &new_env, barrier))?;
         } else {
             return Err(error::bad_form(bindings, Some(binding)));
         }
@@ -2476,10 +2637,17 @@ impl And {
         exprs: &[Syntax],
         env: &Environment,
         mutable_vars: &mut HashSet<Local>,
+        barrier: &mut ContBarrier<'_>,
     ) -> Result<Self, Exception> {
         let mut output = Vec::new();
         for expr in exprs {
-            let expr = maybe_await!(Expression::parse(ctxt, expr.clone(), env, mutable_vars))?;
+            let expr = maybe_await!(Expression::parse(
+                ctxt,
+                expr.clone(),
+                env,
+                mutable_vars,
+                barrier
+            ))?;
             output.push(expr);
         }
         Ok(Self::new(output))
@@ -2502,10 +2670,17 @@ impl Or {
         exprs: &[Syntax],
         env: &Environment,
         mutable_vars: &mut HashSet<Local>,
+        barrier: &mut ContBarrier<'_>,
     ) -> Result<Self, Exception> {
         let mut output = Vec::new();
         for expr in exprs {
-            let expr = maybe_await!(Expression::parse(ctxt, expr.clone(), env, mutable_vars))?;
+            let expr = maybe_await!(Expression::parse(
+                ctxt,
+                expr.clone(),
+                env,
+                mutable_vars,
+                barrier
+            ))?;
             output.push(expr);
         }
         Ok(Self::new(output))
@@ -2541,6 +2716,7 @@ impl SyntaxCase {
         env: &Environment,
         form: &Syntax,
         mutable_vars: &mut HashSet<Local>,
+        barrier: &mut ContBarrier<'_>,
     ) -> Result<Self, Exception> {
         let (arg, keywords, mut rules, ellipsis) = match exprs {
             [
@@ -2603,6 +2779,7 @@ impl SyntaxCase {
                             env,
                             mutable_vars,
                             ellipsis,
+                            barrier,
                         ))?);
                         rules = tail;
                     }
@@ -2616,6 +2793,7 @@ impl SyntaxCase {
                             env,
                             mutable_vars,
                             ellipsis,
+                            barrier,
                         ))?);
                         rules = tail;
                     }
@@ -2629,7 +2807,8 @@ impl SyntaxCase {
                 ctxt,
                 arg.clone(),
                 env,
-                mutable_vars
+                mutable_vars,
+                barrier
             ))?),
             rules: syntax_rules,
         })

--- a/src/env.rs
+++ b/src/env.rs
@@ -324,15 +324,20 @@ impl TopLevelEnvironment {
         let rt = { self.0.read().rt.clone() };
         let ctxt = ParseContext::new(&rt, import_policy);
         let mut mutable_vars = HashSet::default();
+        // Top-level entry: genuinely fresh dynamic state, threaded through
+        // both compilation (macro expansion may invoke transformers) and
+        // evaluation.
+        let mut barrier = ContBarrier::new();
         let body = maybe_await!(Definitions::parse(
             &ctxt,
             body,
             &Environment::Top(self.clone()),
             &sexprs,
             &mut mutable_vars,
+            &mut barrier,
         ))?;
         let compiled = maybe_await!(Compiler::new(mutable_vars).compile(&rt, &body))?;
-        maybe_await!(Application::new(compiled, None, Vec::new()).eval(&mut ContBarrier::new()))
+        maybe_await!(Application::new(compiled, None, Vec::new()).eval(&mut barrier))
     }
 
     #[maybe_async]
@@ -346,15 +351,19 @@ impl TopLevelEnvironment {
         sexpr.add_scope(self.0.read().scope);
         let mut mutable_vars = HashSet::default();
         let body = std::slice::from_ref(&sexpr);
+        // Top-level entry: genuinely fresh dynamic state, threaded through
+        // both compilation and evaluation.
+        let mut barrier = ContBarrier::new();
         let body = maybe_await!(Definitions::parse(
             &ctxt,
             body,
             &Environment::Top(self.clone()),
             &sexpr,
             &mut mutable_vars,
+            &mut barrier,
         ))?;
         let compiled = maybe_await!(Compiler::new(mutable_vars).compile(&rt, &body))?;
-        maybe_await!(Application::new(compiled, None, Vec::new()).eval(&mut ContBarrier::new()))
+        maybe_await!(Application::new(compiled, None, Vec::new()).eval(&mut barrier))
     }
 
     #[maybe_async]
@@ -403,11 +412,16 @@ impl TopLevelEnvironment {
         let rt = { self.0.read().rt.clone() };
         let env = Environment::from(self.clone());
         let mut mutable_vars = HashSet::default();
+        // Top-level entry: library expansion (macro transformers may run
+        // here) gets its own fresh dynamic state, distinct from the state
+        // used when the library is later invoked (see `maybe_invoke`).
+        let mut barrier = ContBarrier::new();
         let expanded = maybe_await!(Definitions::parse_lib_body(
             &rt,
             &body,
             &env,
-            &mut mutable_vars
+            &mut mutable_vars,
+            &mut barrier
         ))?;
         self.0.write().state = LibraryState::Expanded {
             expanded,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -26,7 +26,7 @@ pub fn eval(
     k: Procedure,
     args: &[Value],
     _rest_args: &[Value],
-    _barrier: &mut ContBarrier<'_>,
+    barrier: &mut ContBarrier<'_>,
 ) -> Result<Application, Exception> {
     let [expression, environment] = args else {
         unreachable!()
@@ -35,9 +35,15 @@ pub fn eval(
     let expr = Syntax::datum_to_syntax(&env.get_scope_set(), expression.clone(), &Span::default());
     let ctxt = ParseContext::new(runtime, false);
     let mut mutable_vars = HashSet::default();
-    let expr = maybe_await!(Expression::parse(&ctxt, expr, &env, &mut mutable_vars))?;
+    let expr = maybe_await!(Expression::parse(
+        &ctxt,
+        expr,
+        &env,
+        &mut mutable_vars,
+        barrier
+    ))?;
     let proc = maybe_await!(Compiler::new(mutable_vars).compile(runtime, &expr))?;
-    let result = maybe_await!(proc.call(&[], &mut ContBarrier::new()))?;
+    let result = maybe_await!(proc.call(&[], barrier))?;
     Ok(Application::new(k, None, result))
 }
 

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -4,7 +4,7 @@ use crate::{
     env::{Binding, Environment, Local, Scope, add_binding},
     exceptions::Exception,
     gc::{Gc, Trace},
-    proc::Procedure,
+    proc::{ContBarrier, Procedure},
     records::{Embeddable, Embedded, RecordTypeDescriptor, rtd},
     symbols::Symbol,
     syntax::{Identifier, Span, Syntax},
@@ -70,6 +70,7 @@ impl SyntaxRule {
         env: &Environment,
         mutable_vars: &mut HashSet<Local>,
         ellipsis: Symbol,
+        barrier: &mut ContBarrier<'_>,
     ) -> Result<Self, Exception> {
         let mut variables = HashMap::default();
         let pattern_scope = Scope::new();
@@ -91,7 +92,8 @@ impl SyntaxRule {
                 &ctxt,
                 fender,
                 &env,
-                mutable_vars
+                mutable_vars,
+                barrier
             ))?)
         } else {
             None
@@ -102,7 +104,8 @@ impl SyntaxRule {
             &ctxt,
             output_expression,
             &env,
-            mutable_vars
+            mutable_vars,
+            barrier
         ))?;
         Ok(Self {
             pattern,

--- a/src/futures.rs
+++ b/src/futures.rs
@@ -15,8 +15,10 @@ use tokio::{
 use crate::{
     exceptions::Exception,
     ports::{BufferMode, Port},
-    proc::{ContBarrier, Procedure},
+    proc::{Application, ContBarrier, Procedure},
     records::{Embeddable, Embedded, RecordTypeDescriptor, rtd},
+    registry::cps_bridge,
+    runtime::Runtime,
     strings::WideString,
     value::Value,
 };
@@ -34,22 +36,44 @@ unsafe impl Embeddable for Future {
     }
 }
 
-#[bridge(name = "future", lib = "(async)")]
-pub async fn make_future(proc: Procedure) -> Result<Vec<Value>, Exception> {
-    let future: Future = async move { proc.call(&[], &mut ContBarrier::new()).await }
+// `future` and `spawn` both start a new dynamic extent (a future body may
+// run interleaved with, or after, whatever called `future`/`spawn`), so
+// they need a spawn snapshot rather than the caller's barrier itself:
+// promoted from `#[bridge]` to `#[cps_bridge]` to reach it.
+
+#[cps_bridge(def = "future proc", lib = "(async)")]
+pub async fn make_future(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let proc: Procedure = args[0].clone().try_into()?;
+    let mut snapshot = barrier.spawn_snapshot();
+    let future: Future = async move { proc.call(&[], &mut snapshot).await }
         .boxed()
         .shared();
     let future = Value::from(future);
-    Ok(vec![future])
+    Ok(Application::new(k, None, vec![future]))
 }
 
-#[bridge(name = "spawn", lib = "(async)")]
-pub async fn spawn(task: &Value) -> Result<Vec<Value>, Exception> {
-    let task: Procedure = task.clone().try_into()?;
-    let task = tokio::task::spawn(async move { task.call(&[], &mut ContBarrier::new()).await });
+#[cps_bridge(def = "spawn task", lib = "(async)")]
+pub async fn spawn(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let task: Procedure = args[0].clone().try_into()?;
+    let mut snapshot = barrier.spawn_snapshot();
+    let task = tokio::task::spawn(async move { task.call(&[], &mut snapshot).await });
     let future: Future = async move { task.await.unwrap() }.boxed().shared();
     let future = Value::from(future);
-    Ok(vec![future])
+    Ok(Application::new(k, None, vec![future]))
 }
 
 #[bridge(name = "await", lib = "(async)")]

--- a/src/hashtables.rs
+++ b/src/hashtables.rs
@@ -13,9 +13,10 @@ use std::{
 use crate::{
     exceptions::Exception,
     gc::Trace,
-    proc::{ContBarrier, Procedure},
+    proc::{Application, ContBarrier, Procedure},
     records::{Embeddable, Embedded, RecordTypeDescriptor},
-    registry::bridge,
+    registry::{bridge, cps_bridge},
+    runtime::Runtime,
     strings::WideString,
     symbols::Symbol,
     value::{Expect1, Value},
@@ -66,52 +67,66 @@ impl HashTableInner {
     }
 
     #[cfg(not(feature = "async"))]
-    pub fn hash(&self, val: Value) -> Result<u64, Exception> {
-        self.hash.call(&[val], &mut ContBarrier::new())?.expect1()
+    pub fn hash(&self, val: Value, barrier: &mut ContBarrier<'_>) -> Result<u64, Exception> {
+        self.hash.call(&[val], barrier)?.expect1()
     }
 
     #[cfg(feature = "async")]
-    pub fn hash(&self, val: Value) -> Result<u64, Exception> {
-        self.hash
-            .call_sync(&[val], &mut ContBarrier::new())?
-            .expect1()
+    pub fn hash(&self, val: Value, barrier: &mut ContBarrier<'_>) -> Result<u64, Exception> {
+        self.hash.call_sync(&[val], barrier)?.expect1()
     }
 
     #[cfg(not(feature = "async"))]
-    pub fn eq(&self, lhs: Value, rhs: Value) -> Result<bool, Exception> {
-        self.eq
-            .call(&[lhs, rhs], &mut ContBarrier::new())?
-            .expect1()
+    pub fn eq(
+        &self,
+        lhs: Value,
+        rhs: Value,
+        barrier: &mut ContBarrier<'_>,
+    ) -> Result<bool, Exception> {
+        self.eq.call(&[lhs, rhs], barrier)?.expect1()
     }
 
     #[cfg(feature = "async")]
-    pub fn eq(&self, lhs: Value, rhs: Value) -> Result<bool, Exception> {
-        self.eq
-            .call_sync(&[lhs, rhs], &mut ContBarrier::new())?
-            .expect1()
+    pub fn eq(
+        &self,
+        lhs: Value,
+        rhs: Value,
+        barrier: &mut ContBarrier<'_>,
+    ) -> Result<bool, Exception> {
+        self.eq.call_sync(&[lhs, rhs], barrier)?.expect1()
     }
 
     /// Equivalent to `hashtable-ref`
-    pub fn get(&self, key: &Value, default: &Value) -> Result<Value, Exception> {
+    pub fn get(
+        &self,
+        key: &Value,
+        default: &Value,
+        barrier: &mut ContBarrier<'_>,
+    ) -> Result<Value, Exception> {
         let table = self.table.read();
-        let hash = self.hash(key.clone())?;
+        let hash = self.hash(key.clone(), barrier)?;
         for entry in table.iter_hash(hash) {
-            if entry.hash == hash && self.eq(key.clone(), entry.key.clone())? {
+            if entry.hash == hash && self.eq(key.clone(), entry.key.clone(), barrier)? {
                 return Ok(entry.val.clone());
             }
         }
         Ok(default.clone())
     }
 
-    pub fn set(&self, key: &Value, val: &Value) -> Result<(), Exception> {
+    pub fn set(
+        &self,
+        key: &Value,
+        val: &Value,
+        barrier: &mut ContBarrier<'_>,
+    ) -> Result<(), Exception> {
         if !self.mutable {
             return Err(Exception::error("hashtable is immutable"));
         }
 
         let mut table = self.table.write();
-        let hash = self.hash(key.clone())?;
+        let hash = self.hash(key.clone(), barrier)?;
         for entry in table.iter_hash_mut(hash) {
-            if entry.hash == hash && self.eq(key.clone(), entry.key.clone())? {
+            if entry.hash == hash && self.eq(key.clone(), entry.key.clone(), barrier)? {
                 entry.val = val.clone();
                 return Ok(());
             }
@@ -131,19 +146,19 @@ impl HashTableInner {
         Ok(())
     }
 
-    pub fn delete(&self, key: &Value) -> Result<(), Exception> {
+    pub fn delete(&self, key: &Value, barrier: &mut ContBarrier<'_>) -> Result<(), Exception> {
         if !self.mutable {
             return Err(Exception::error("hashtable is immutable"));
         }
 
         let mut table = self.table.write();
-        let hash = self.hash(key.clone())?;
+        let hash = self.hash(key.clone(), barrier)?;
         let buckets = table.iter_hash_buckets(hash).collect::<Vec<_>>();
         for bucket in buckets.into_iter() {
             if let Ok(entry) = table.get_bucket_entry(bucket)
                 && let inner = entry.get()
                 && inner.hash == hash
-                && self.eq(key.clone(), inner.key.clone())?
+                && self.eq(key.clone(), inner.key.clone(), barrier)?
             {
                 entry.remove();
                 return Ok(());
@@ -153,11 +168,11 @@ impl HashTableInner {
         Ok(())
     }
 
-    pub fn contains(&self, key: &Value) -> Result<bool, Exception> {
+    pub fn contains(&self, key: &Value, barrier: &mut ContBarrier<'_>) -> Result<bool, Exception> {
         let table = self.table.write();
-        let hash = self.hash(key.clone())?;
+        let hash = self.hash(key.clone(), barrier)?;
         for entry in table.iter_hash(hash) {
-            if entry.hash == hash && self.eq(key.clone(), entry.key.clone())? {
+            if entry.hash == hash && self.eq(key.clone(), entry.key.clone(), barrier)? {
                 return Ok(true);
             }
         }
@@ -165,7 +180,13 @@ impl HashTableInner {
         Ok(false)
     }
 
-    pub fn update(&self, key: &Value, proc: &Procedure, default: &Value) -> Result<(), Exception> {
+    pub fn update(
+        &self,
+        key: &Value,
+        proc: &Procedure,
+        default: &Value,
+        barrier: &mut ContBarrier<'_>,
+    ) -> Result<(), Exception> {
         use std::slice;
 
         if !self.mutable {
@@ -173,17 +194,14 @@ impl HashTableInner {
         }
 
         let mut table = self.table.write();
-        let hash = self.hash(key.clone())?;
+        let hash = self.hash(key.clone(), barrier)?;
         for entry in table.iter_hash_mut(hash) {
-            if entry.hash == hash && self.eq(key.clone(), entry.key.clone())? {
+            if entry.hash == hash && self.eq(key.clone(), entry.key.clone(), barrier)? {
                 #[cfg(not(feature = "async"))]
-                let updated =
-                    proc.call(slice::from_ref(&entry.val), &mut ContBarrier::new())?[0].clone();
+                let updated = proc.call(slice::from_ref(&entry.val), barrier)?[0].clone();
 
                 #[cfg(feature = "async")]
-                let updated = proc
-                    .call_sync(slice::from_ref(&entry.val), &mut ContBarrier::new())?[0]
-                    .clone();
+                let updated = proc.call_sync(slice::from_ref(&entry.val), barrier)?[0].clone();
 
                 entry.val = updated;
                 return Ok(());
@@ -191,10 +209,10 @@ impl HashTableInner {
         }
 
         #[cfg(not(feature = "async"))]
-        let updated = proc.call(slice::from_ref(default), &mut ContBarrier::new())?[0].clone(); // 
+        let updated = proc.call(slice::from_ref(default), barrier)?[0].clone();
 
         #[cfg(feature = "async")]
-        let updated = proc.call_sync(slice::from_ref(default), &mut ContBarrier::new())?[0].clone();
+        let updated = proc.call_sync(slice::from_ref(default), barrier)?[0].clone();
 
         table.insert_unique(
             hash,
@@ -285,24 +303,40 @@ impl HashTable {
         self.0.size()
     }
 
-    pub fn get(&self, key: &Value, default: &Value) -> Result<Value, Exception> {
-        self.0.get(key, default)
+    pub fn get(
+        &self,
+        key: &Value,
+        default: &Value,
+        barrier: &mut ContBarrier<'_>,
+    ) -> Result<Value, Exception> {
+        self.0.get(key, default, barrier)
     }
 
-    pub fn set(&self, key: &Value, val: &Value) -> Result<(), Exception> {
-        self.0.set(key, val)
+    pub fn set(
+        &self,
+        key: &Value,
+        val: &Value,
+        barrier: &mut ContBarrier<'_>,
+    ) -> Result<(), Exception> {
+        self.0.set(key, val, barrier)
     }
 
-    pub fn delete(&self, key: &Value) -> Result<(), Exception> {
-        self.0.delete(key)
+    pub fn delete(&self, key: &Value, barrier: &mut ContBarrier<'_>) -> Result<(), Exception> {
+        self.0.delete(key, barrier)
     }
 
-    pub fn contains(&self, key: &Value) -> Result<bool, Exception> {
-        self.0.contains(key)
+    pub fn contains(&self, key: &Value, barrier: &mut ContBarrier<'_>) -> Result<bool, Exception> {
+        self.0.contains(key, barrier)
     }
 
-    pub fn update(&self, key: &Value, proc: &Procedure, default: &Value) -> Result<(), Exception> {
-        self.0.update(key, proc, default)
+    pub fn update(
+        &self,
+        key: &Value,
+        proc: &Procedure,
+        default: &Value,
+        barrier: &mut ContBarrier<'_>,
+    ) -> Result<(), Exception> {
+        self.0.update(key, proc, default, barrier)
     }
 
     pub fn copy(&self, mutable: bool) -> Self {
@@ -432,41 +466,99 @@ pub fn hashtable_size(hashtable: HashTable) -> usize {
     hashtable.size()
 }
 
-#[bridge(name = "hashtable-ref", lib = "(rnrs hashtables builtins (6))")]
+// hashtable-ref, hashtable-set!, hashtable-delete!, hashtable-contains?, and
+// hashtable-update! call the table's hash/eq (and, for update!, the update
+// procedure) as ordinary Scheme calls, so unlike the rest of this file they
+// need the caller's barrier: promoted from `#[bridge]` to `#[cps_bridge]` to
+// get it. This loses the "known function" fast path the plain-arg bridges
+// above get (`#[bridge]` can shortcut functions of <=3 non-variadic args
+// straight to typed Rust args; `cps_bridge` always goes through the general
+// `(runtime, env, k, args, rest_args, barrier)` calling convention).
+
+#[cps_bridge(
+    def = "hashtable-ref hashtable key default",
+    lib = "(rnrs hashtables builtins (6))"
+)]
 pub fn hashtable_ref(
-    hashtable: HashTable,
-    key: &Value,
-    default: &Value,
-) -> Result<Value, Exception> {
-    hashtable.get(key, default)
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier,
+) -> Result<Application, Exception> {
+    let hashtable: HashTable = (&args[0]).try_into()?;
+    let val = hashtable.get(&args[1], &args[2], barrier)?;
+    Ok(Application::new(k, None, vec![val]))
 }
 
-#[bridge(name = "hashtable-set!", lib = "(rnrs hashtables builtins (6))")]
-pub fn hashtable_set_bang(hashtable: HashTable, key: &Value, obj: &Value) -> Result<(), Exception> {
-    hashtable.set(key, obj)?;
-    Ok(())
+#[cps_bridge(
+    def = "hashtable-set! hashtable key obj",
+    lib = "(rnrs hashtables builtins (6))"
+)]
+pub fn hashtable_set_bang(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier,
+) -> Result<Application, Exception> {
+    let hashtable: HashTable = (&args[0]).try_into()?;
+    hashtable.set(&args[1], &args[2], barrier)?;
+    Ok(Application::new(k, None, Vec::new()))
 }
 
-#[bridge(name = "hashtable-delete!", lib = "(rnrs hashtables builtins (6))")]
-pub fn hashtable_delete_bang(hashtable: HashTable, key: &Value) -> Result<(), Exception> {
-    hashtable.delete(key)?;
-    Ok(())
+#[cps_bridge(
+    def = "hashtable-delete! hashtable key",
+    lib = "(rnrs hashtables builtins (6))"
+)]
+pub fn hashtable_delete_bang(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier,
+) -> Result<Application, Exception> {
+    let hashtable: HashTable = (&args[0]).try_into()?;
+    hashtable.delete(&args[1], barrier)?;
+    Ok(Application::new(k, None, Vec::new()))
 }
 
-#[bridge(name = "hashtable-contains?", lib = "(rnrs hashtables builtins (6))")]
-pub fn hashtable_contains_pred(hashtable: HashTable, key: &Value) -> Result<bool, Exception> {
-    Ok(hashtable.contains(key)?)
+#[cps_bridge(
+    def = "hashtable-contains? hashtable key",
+    lib = "(rnrs hashtables builtins (6))"
+)]
+pub fn hashtable_contains_pred(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier,
+) -> Result<Application, Exception> {
+    let hashtable: HashTable = (&args[0]).try_into()?;
+    let contains = hashtable.contains(&args[1], barrier)?;
+    Ok(Application::new(k, None, vec![Value::from(contains)]))
 }
 
-#[bridge(name = "hashtable-update!", lib = "(rnrs hashtables builtins (6))")]
+#[cps_bridge(
+    def = "hashtable-update! hashtable key proc default",
+    lib = "(rnrs hashtables builtins (6))"
+)]
 pub fn hashtable_update_bang(
-    hashtable: HashTable,
-    key: &Value,
-    proc: Procedure,
-    default: &Value,
-) -> Result<Vec<Value>, Exception> {
-    hashtable.update(key, &proc, default)?;
-    Ok(Vec::new())
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier,
+) -> Result<Application, Exception> {
+    let hashtable: HashTable = (&args[0]).try_into()?;
+    let proc: Procedure = args[2].clone().try_into()?;
+    hashtable.update(&args[1], &proc, &args[3], barrier)?;
+    Ok(Application::new(k, None, Vec::new()))
 }
 
 #[bridge(name = "hashtable-copy", lib = "(rnrs hashtables builtins (6))")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use scheme_rs::{
     env::TopLevelEnvironment,
     exceptions::Exception,
     ports::{BufferMode, IntoPort, Port, Prompt, ReadFn, Transcoder},
+    proc::ContBarrier,
     runtime::Runtime,
     syntax::{Span, Syntax},
 };
@@ -68,9 +69,9 @@ pub struct TextStoringPrompt {
 impl IntoPort for TextStoringPrompt {
     fn read_fn() -> Option<ReadFn> {
         let prompt_read_fn = Prompt::<InputHelper, FileHistory>::read_fn().unwrap();
-        Some(Box::new(move |any, buff, start, count| {
+        Some(Box::new(move |any, buff, start, count, barrier| {
             let this = any.downcast_mut::<Self>().unwrap();
-            let written = (prompt_read_fn)(&mut this.prompt, buff, start, count)?;
+            let written = (prompt_read_fn)(&mut this.prompt, buff, start, count, barrier)?;
             this.text
                 .lock()
                 .push_str(str::from_utf8(&buff.as_slice()[start..(start + written)]).unwrap());
@@ -82,11 +83,12 @@ impl IntoPort for TextStoringPrompt {
 #[cfg(feature = "async")]
 impl IntoPort for TextStoringPrompt {
     fn read_fn() -> Option<ReadFn> {
-        Some(Box::new(move |any, buff, start, count| {
+        Some(Box::new(move |any, buff, start, count, barrier| {
             Box::pin(async move {
                 let prompt_read_fn = Prompt::read_fn().unwrap();
                 let this = any.downcast_mut::<Self>().unwrap();
-                let written = (prompt_read_fn)(&mut this.prompt, buff, start, count).await?;
+                let written =
+                    (prompt_read_fn)(&mut this.prompt, buff, start, count, barrier).await?;
                 this.text
                     .lock()
                     .push_str(str::from_utf8(&buff.as_slice()[start..(start + written)]).unwrap());
@@ -173,7 +175,10 @@ fn entry(runtime: &Runtime) -> Result<(), Exception> {
 
     let mut n_results = 1;
     loop {
-        let sexpr = match maybe_await!(input_port.get_sexpr(span)) {
+        // The prompt port's read closure is native (readline-backed) and
+        // ignores the barrier, so a fresh one per line is fine here - it
+        // can never actually reach Scheme.
+        let sexpr = match maybe_await!(input_port.get_sexpr(span, &mut ContBarrier::new())) {
             Ok(Some((sexpr, new_span))) => {
                 span = new_span;
                 sexpr

--- a/src/num.rs
+++ b/src/num.rs
@@ -26,6 +26,7 @@ use crate::{
     exceptions::Exception,
     gc::Trace,
     ports::{BufferMode, Port, Transcoder},
+    proc::{ContBarrier, ErasedBarrier},
     registry::bridge,
     strings::WideString,
     syntax::{Span, lex::Lexer},
@@ -2529,7 +2530,11 @@ pub fn string_to_number(s: WideString, rest_args: &[Value]) -> Result<Vec<Value>
     let mut data = port.0.data.lock().unwrap();
     #[cfg(feature = "tokio")]
     let mut data = port.0.data.lock().await;
-    let mut lexer = Lexer::new(&mut data, info, Span::default());
+    // Fresh in-memory Cursor port: its closures are native and ignore the
+    // barrier, so a fresh one is correct here, not just expedient.
+    let mut barrier = ContBarrier::new();
+    let erased = ErasedBarrier::new(&mut barrier);
+    let mut lexer = Lexer::new(&mut data, info, Span::default(), erased);
     let Some(number) = maybe_await!(lexer.number(radix)).ok().flatten() else {
         return Ok(vec![Value::from(false)]);
     };

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -25,7 +25,9 @@ use crate::{
     enumerations::{EnumerationSet, EnumerationType},
     exceptions::{Assertion, Error, Exception, raise},
     gc::{Gc, GcInner, Trace},
-    proc::{Application, ContBarrier, DynStackElem, FuncPtr, Procedure, pop_dyn_stack},
+    proc::{
+        Application, ContBarrier, DynStackElem, ErasedBarrier, FuncPtr, Procedure, pop_dyn_stack,
+    },
     records::{Embeddable, Embedded, RecordTypeDescriptor},
     runtime::{Runtime, RuntimeInner},
     strings::WideString,
@@ -152,16 +154,23 @@ struct Decoder<'a, D> {
     decode: D,
     char_idx: usize,
     pos: Either<usize, Exception>,
+    barrier: ErasedBarrier,
 }
 
 impl<'a, D> Decoder<'a, D> {
-    fn new(data: &'a mut BinaryPortData, info: &'a BinaryPortInfo, decode: D) -> Self {
+    fn new(
+        data: &'a mut BinaryPortData,
+        info: &'a BinaryPortInfo,
+        decode: D,
+        barrier: ErasedBarrier,
+    ) -> Self {
         Self {
             data,
             info,
             decode,
             char_idx: 0,
             pos: Either::Left(0),
+            barrier,
         }
     }
 }
@@ -177,7 +186,7 @@ where
             Either::Right(ref err) => return Some(Err(err.clone())),
         };
         loop {
-            match maybe_await!(self.data.peekn_bytes(self.info, pos))
+            match maybe_await!(self.data.peekn_bytes(self.info, pos, self.barrier))
                 .transpose()?
                 .and_then(|byte| self.decode.push_and_decode(byte))
             {
@@ -623,19 +632,27 @@ mod __impl {
     impl<T: Iterator + Unpin> MaybeStream for T {}
 
     pub type ReadFn = Box<
-        dyn Fn(&mut dyn Any, &ByteVector, usize, usize) -> Result<usize, Exception> + Send + Sync,
+        dyn Fn(&mut dyn Any, &ByteVector, usize, usize, ErasedBarrier) -> Result<usize, Exception>
+            + Send
+            + Sync,
     >;
-    pub type WriteFn =
-        Box<dyn Fn(&mut dyn Any, &ByteVector, usize, usize) -> Result<(), Exception> + Send + Sync>;
-    pub type GetPosFn = Box<dyn Fn(&mut dyn Any) -> Result<u64, Exception> + Send + Sync>;
-    pub type SetPosFn = Box<dyn Fn(&mut dyn Any, u64) -> Result<(), Exception> + Send + Sync>;
-    pub type CloseFn = Box<dyn Fn(&mut dyn Any) -> Result<(), Exception> + Send + Sync>;
+    pub type WriteFn = Box<
+        dyn Fn(&mut dyn Any, &ByteVector, usize, usize, ErasedBarrier) -> Result<(), Exception>
+            + Send
+            + Sync,
+    >;
+    pub type GetPosFn =
+        Box<dyn Fn(&mut dyn Any, ErasedBarrier) -> Result<u64, Exception> + Send + Sync>;
+    pub type SetPosFn =
+        Box<dyn Fn(&mut dyn Any, u64, ErasedBarrier) -> Result<(), Exception> + Send + Sync>;
+    pub type CloseFn =
+        Box<dyn Fn(&mut dyn Any, ErasedBarrier) -> Result<(), Exception> + Send + Sync>;
 
     pub fn read_fn<T>() -> ReadFn
     where
         T: Read + Any + Send + 'static,
     {
-        Box::new(|any, buff, start, count| {
+        Box::new(|any, buff, start, count, _barrier| {
             let concrete = any.downcast_mut::<T>().unwrap();
             let mut buff = buff.as_mut_slice()?;
             concrete
@@ -648,7 +665,7 @@ mod __impl {
     where
         T: Write + Any + Send + 'static,
     {
-        Box::new(|any, buff, start, count| {
+        Box::new(|any, buff, start, count, _barrier| {
             let concrete = any.downcast_mut::<T>().unwrap();
             let buff = buff.as_slice();
             concrete
@@ -663,7 +680,7 @@ mod __impl {
     where
         T: Seek + Any + Send + 'static,
     {
-        Box::new(|any| {
+        Box::new(|any, _barrier| {
             let concrete = any.downcast_mut::<T>().unwrap();
             concrete
                 .stream_position()
@@ -675,7 +692,7 @@ mod __impl {
     where
         T: Seek + Any + Send + 'static,
     {
-        Box::new(|any, pos| {
+        Box::new(|any, pos, _barrier| {
             let concrete = any.downcast_mut::<T>().unwrap();
             let _ = concrete
                 .seek(SeekFrom::Start(pos))
@@ -685,7 +702,7 @@ mod __impl {
     }
 
     pub(super) fn proc_to_read_fn(read: Procedure) -> ReadFn {
-        Box::new(move |_, buff, start, count| {
+        Box::new(move |_, buff, start, count, mut barrier| {
             let [read] = read
                 .call(
                     &[
@@ -693,7 +710,7 @@ mod __impl {
                         Value::from(start),
                         Value::from(count),
                     ],
-                    &mut ContBarrier::new(),
+                    barrier.get(),
                 )
                 .map_err(|err| err.add_condition(IoReadError::new()))?
                 .try_into()
@@ -710,7 +727,7 @@ mod __impl {
     }
 
     pub(super) fn proc_to_write_fn(write: Procedure) -> WriteFn {
-        Box::new(move |_, buff, start, count| {
+        Box::new(move |_, buff, start, count, mut barrier| {
             let _ = write
                 .call(
                     &[
@@ -718,7 +735,7 @@ mod __impl {
                         Value::from(start),
                         Value::from(count),
                     ],
-                    &mut ContBarrier::new(),
+                    barrier.get(),
                 )
                 .map_err(|err| err.add_condition(IoReadError::new()))?;
             Ok(())
@@ -726,9 +743,9 @@ mod __impl {
     }
 
     pub(super) fn proc_to_get_pos_fn(get_pos: Procedure) -> GetPosFn {
-        Box::new(move |_| {
+        Box::new(move |_, mut barrier| {
             let [pos] = get_pos
-                .call(&[], &mut ContBarrier::new())
+                .call(&[], barrier.get())
                 .map_err(|err| err.add_condition(IoError::new()))?
                 .try_into()
                 .map_err(|_| {
@@ -742,18 +759,18 @@ mod __impl {
     }
 
     pub(super) fn proc_to_set_pos_fn(set_pos: Procedure) -> SetPosFn {
-        Box::new(move |_, pos| {
+        Box::new(move |_, pos, mut barrier| {
             let _ = set_pos
-                .call(&[Value::from(pos)], &mut ContBarrier::new())
+                .call(&[Value::from(pos)], barrier.get())
                 .map_err(|err| err.add_condition(IoError::new()))?;
             Ok(())
         })
     }
 
     pub(super) fn proc_to_close_fn(close: Procedure) -> CloseFn {
-        Box::new(move |_| {
+        Box::new(move |_, mut barrier| {
             let _ = close
-                .call(&[], &mut ContBarrier::new())
+                .call(&[], barrier.get())
                 .map_err(|err| err.add_condition(IoError::new()))?;
             Ok(())
         })
@@ -814,12 +831,20 @@ mod __impl {
 
     use super::*;
 
+    // `ErasedBarrier` is passed by value (it's a `Copy` raw-pointer newtype,
+    // not a reference), so it does not need to share the closures' `for<'a>`
+    // higher-ranked lifetime the way a `&'a mut ContBarrier<'a>` would. That
+    // matters: an earlier attempt to give the barrier its own `&mut
+    // ContBarrier<'_>` argument here hit two dead ends depending on whether
+    // its lifetime was unified with `'a` or kept independent - see the
+    // `ErasedBarrier` doc comment in proc.rs for the full story.
     pub type ReadFn = Box<
         dyn for<'a> Fn(
                 &'a mut (dyn Any + Send),
                 &'a ByteVector,
                 usize,
                 usize,
+                ErasedBarrier,
             ) -> BoxFuture<'a, Result<usize, Exception>>
             + Send
             + Sync,
@@ -830,22 +855,33 @@ mod __impl {
                 &'a ByteVector,
                 usize,
                 usize,
+                ErasedBarrier,
             ) -> BoxFuture<'a, Result<(), Exception>>
             + Send
             + Sync,
     >;
     pub type GetPosFn = Box<
-        dyn for<'a> Fn(&'a mut (dyn Any + Send)) -> BoxFuture<'a, Result<u64, Exception>>
+        dyn for<'a> Fn(
+                &'a mut (dyn Any + Send),
+                ErasedBarrier,
+            ) -> BoxFuture<'a, Result<u64, Exception>>
             + Send
             + Sync,
     >;
     pub type SetPosFn = Box<
-        dyn for<'a> Fn(&'a mut (dyn Any + Send), u64) -> BoxFuture<'a, Result<(), Exception>>
+        dyn for<'a> Fn(
+                &'a mut (dyn Any + Send),
+                u64,
+                ErasedBarrier,
+            ) -> BoxFuture<'a, Result<(), Exception>>
             + Send
             + Sync,
     >;
     pub type CloseFn = Box<
-        dyn for<'a> Fn(&'a mut (dyn Any + Send)) -> BoxFuture<'a, Result<(), Exception>>
+        dyn for<'a> Fn(
+                &'a mut (dyn Any + Send),
+                ErasedBarrier,
+            ) -> BoxFuture<'a, Result<(), Exception>>
             + Send
             + Sync,
     >;
@@ -858,7 +894,7 @@ mod __impl {
     where
         T: AsyncRead + Any + Send + Unpin + 'static,
     {
-        Box::new(move |any, buff, start, count| {
+        Box::new(move |any, buff, start, count, _barrier| {
             Box::pin(async move {
                 let mut concrete = Pin::new(any.downcast_mut::<T>().unwrap());
                 let mut local_buff = vec![0u8; count];
@@ -877,7 +913,7 @@ mod __impl {
     where
         T: AsyncWrite + Any + Send + Unpin + 'static,
     {
-        Box::new(|any, buff, start, count| {
+        Box::new(|any, buff, start, count, _barrier| {
             Box::pin(async move {
                 let mut concrete = Pin::new(any.downcast_mut::<T>().unwrap());
                 let local_buff = buff.as_slice()[start..(start + count)].to_vec();
@@ -898,7 +934,7 @@ mod __impl {
     where
         T: AsyncSeek + Any + Send + Unpin + 'static,
     {
-        Box::new(|any| {
+        Box::new(|any, _barrier| {
             Box::pin(async move {
                 let mut concrete = Pin::new(any.downcast_mut::<T>().unwrap());
                 concrete
@@ -913,7 +949,7 @@ mod __impl {
     where
         T: AsyncSeek + Any + Send + Unpin + 'static,
     {
-        Box::new(|any, pos| {
+        Box::new(|any, pos, _barrier| {
             Box::pin(async move {
                 let mut concrete = Pin::new(any.downcast_mut::<T>().unwrap());
                 let _ = concrete
@@ -926,7 +962,7 @@ mod __impl {
     }
 
     pub(super) fn proc_to_read_fn(read: Procedure) -> ReadFn {
-        Box::new(move |_, buff, start, count| {
+        Box::new(move |_, buff, start, count, mut barrier| {
             let read = read.clone();
             Box::pin(async move {
                 let [read] = read
@@ -936,7 +972,7 @@ mod __impl {
                             Value::from(start),
                             Value::from(count),
                         ],
-                        &mut ContBarrier::new(),
+                        barrier.get(),
                     )
                     .await
                     .map_err(|err| err.add_condition(IoReadError::new()))?
@@ -957,7 +993,7 @@ mod __impl {
     }
 
     pub(super) fn proc_to_write_fn(write: Procedure) -> WriteFn {
-        Box::new(move |_, buff, start, count| {
+        Box::new(move |_, buff, start, count, mut barrier| {
             let write = write.clone();
             Box::pin(async move {
                 let _ = write
@@ -967,7 +1003,7 @@ mod __impl {
                             Value::from(start),
                             Value::from(count),
                         ],
-                        &mut ContBarrier::new(),
+                        barrier.get(),
                     )
                     .await
                     .map_err(|err| err.add_condition(IoReadError::new()))?;
@@ -977,11 +1013,11 @@ mod __impl {
     }
 
     pub(super) fn proc_to_get_pos_fn(get_pos: Procedure) -> GetPosFn {
-        Box::new(move |_| {
+        Box::new(move |_, mut barrier| {
             let get_pos = get_pos.clone();
             Box::pin(async move {
                 let [pos] = get_pos
-                    .call(&[], &mut ContBarrier::new())
+                    .call(&[], barrier.get())
                     .await
                     .map_err(|err| err.add_condition(IoError::new()))?
                     .try_into()
@@ -999,11 +1035,11 @@ mod __impl {
     }
 
     pub(super) fn proc_to_set_pos_fn(set_pos: Procedure) -> SetPosFn {
-        Box::new(move |_, pos| {
+        Box::new(move |_, pos, mut barrier| {
             let set_pos = set_pos.clone();
             Box::pin(async move {
                 let _ = set_pos
-                    .call(&[Value::from(pos)], &mut ContBarrier::new())
+                    .call(&[Value::from(pos)], barrier.get())
                     .await
                     .map_err(|err| err.add_condition(IoError::new()))?;
                 Ok(())
@@ -1012,11 +1048,11 @@ mod __impl {
     }
 
     pub(super) fn proc_to_close_fn(close: Procedure) -> CloseFn {
-        Box::new(move |_| {
+        Box::new(move |_, mut barrier| {
             let close = close.clone();
             Box::pin(async move {
                 let _ = close
-                    .call(&[], &mut ContBarrier::new())
+                    .call(&[], barrier.get())
                     .await
                     .map_err(|err| err.add_condition(IoError::new()))?;
                 Ok(())
@@ -1292,19 +1328,27 @@ pub const BUFFER_SIZE: usize = 8192;
 
 impl BinaryPortData {
     #[maybe_async]
-    fn read_byte(&mut self, port_info: &BinaryPortInfo) -> Result<Option<u8>, Exception> {
-        let next_byte = maybe_await!(self.peekn_bytes(port_info, 0))?;
-        maybe_await!(self.consume_bytes(port_info, 1))?;
+    fn read_byte(
+        &mut self,
+        port_info: &BinaryPortInfo,
+        barrier: ErasedBarrier,
+    ) -> Result<Option<u8>, Exception> {
+        let next_byte = maybe_await!(self.peekn_bytes(port_info, 0, barrier))?;
+        maybe_await!(self.consume_bytes(port_info, 1, barrier))?;
         Ok(next_byte)
     }
 
     #[maybe_async]
-    fn read_char(&mut self, port_info: &BinaryPortInfo) -> Result<Option<char>, Exception> {
-        let Some(next_char) = maybe_await!(self.peekn_chars(port_info, 0))? else {
+    fn read_char(
+        &mut self,
+        port_info: &BinaryPortInfo,
+        barrier: ErasedBarrier,
+    ) -> Result<Option<char>, Exception> {
+        let Some(next_char) = maybe_await!(self.peekn_chars(port_info, 0, barrier))? else {
             return Ok(None);
         };
 
-        maybe_await!(self.consume_chars(port_info, 1))?;
+        maybe_await!(self.consume_chars(port_info, 1, barrier))?;
 
         Ok(Some(next_char))
     }
@@ -1314,6 +1358,7 @@ impl BinaryPortData {
         &mut self,
         port_info: &BinaryPortInfo,
         n: usize,
+        barrier: ErasedBarrier,
     ) -> Result<Option<u8>, Exception> {
         let Some(read) = self.read.as_ref() else {
             return Err(Exception::io_read_error("not an input port"));
@@ -1327,7 +1372,7 @@ impl BinaryPortData {
             && let len = self.output_buffer.len()
             && len != 0
         {
-            maybe_await!(write(port, &self.output_buffer, 0, len))?;
+            maybe_await!(write(port, &self.output_buffer, 0, len, barrier))?;
             self.output_buffer.clear()?;
         }
 
@@ -1338,7 +1383,13 @@ impl BinaryPortData {
         while self.bytes_read <= n + self.input_pos {
             match (port_info.buffer_mode, port_info.transcoder) {
                 (BufferMode::None, _) => {
-                    let read = maybe_await!((read)(port, &self.input_buffer, self.bytes_read, 1))?;
+                    let read = maybe_await!((read)(
+                        port,
+                        &self.input_buffer,
+                        self.bytes_read,
+                        1,
+                        barrier
+                    ))?;
                     if read == 1 {
                         self.bytes_read += 1;
                     } else {
@@ -1348,8 +1399,13 @@ impl BinaryPortData {
                 (BufferMode::Line, Some(transcoder)) => {
                     loop {
                         let count = self.input_buffer.len() - self.bytes_read;
-                        let read =
-                            maybe_await!((read)(port, &self.input_buffer, self.bytes_read, count))?;
+                        let read = maybe_await!((read)(
+                            port,
+                            &self.input_buffer,
+                            self.bytes_read,
+                            count,
+                            barrier
+                        ))?;
                         if read == 0 {
                             return Ok(None);
                         }
@@ -1381,8 +1437,13 @@ impl BinaryPortData {
                 }
                 (BufferMode::Line | BufferMode::Block, _) => {
                     let count = self.input_buffer.len() - self.bytes_read;
-                    let read =
-                        maybe_await!((read)(port, &self.input_buffer, self.bytes_read, count))?;
+                    let read = maybe_await!((read)(
+                        port,
+                        &self.input_buffer,
+                        self.bytes_read,
+                        count,
+                        barrier
+                    ))?;
                     if read == 0 {
                         return Ok(None);
                     }
@@ -1399,13 +1460,14 @@ impl BinaryPortData {
         &'a mut self,
         port_info: &'a BinaryPortInfo,
         transcoder: Transcoder,
+        barrier: ErasedBarrier,
     ) -> impl Iterator<Item = Result<(usize, char), Exception>> + use<'a> {
         let eol_type = transcoder.eol_type;
         let decoder = match transcoder.codec {
             Codec::Latin1 => {
                 let mut i = 0;
                 Box::new(std::iter::from_fn(move || {
-                    match self.peekn_bytes(port_info, i) {
+                    match self.peekn_bytes(port_info, i, barrier) {
                         Ok(Some(byte)) => {
                             let res = (i, char::from(byte));
                             i += 1;
@@ -1423,11 +1485,13 @@ impl BinaryPortData {
                     transcoder.error_handling_mode,
                     self.utf16_endianness.unwrap(),
                 ),
+                barrier,
             )),
             Codec::Utf8 => Box::new(Decoder::new(
                 self,
                 port_info,
                 Utf8Buffer::new(transcoder.error_handling_mode),
+                barrier,
             )),
         };
         eol_type.convert_eol_style_to_linefeed(decoder.peekable())
@@ -1438,13 +1502,14 @@ impl BinaryPortData {
         &'a mut self,
         port_info: &'a BinaryPortInfo,
         transcoder: Transcoder,
+        barrier: ErasedBarrier,
     ) -> impl futures::stream::Stream<Item = Result<(usize, char), Exception>> + use<'a> {
         let eol_type = transcoder.eol_type;
         let decoder = match transcoder.codec {
             Codec::Latin1 => async_stream::stream! {
                 let mut i = 0;
                 loop {
-                    match self.peekn_bytes(port_info, i).await {
+                    match self.peekn_bytes(port_info, i, barrier).await {
                         Ok(Some(byte)) => {
                             let res = (i, char::from(byte));
                             i += 1;
@@ -1464,6 +1529,7 @@ impl BinaryPortData {
                         transcoder.error_handling_mode,
                         self.utf16_endianness.unwrap(),
                     ),
+                    barrier,
                 );
                 while let Some(decoded) = decoder.decode_next().await {
                     yield decoded;
@@ -1475,6 +1541,7 @@ impl BinaryPortData {
                     self,
                     port_info,
                     Utf8Buffer::new(transcoder.error_handling_mode),
+                    barrier,
                 );
                 while let Some(decoded) = decoder.decode_next().await {
                     yield decoded;
@@ -1490,6 +1557,7 @@ impl BinaryPortData {
         &mut self,
         port_info: &BinaryPortInfo,
         n: usize,
+        barrier: ErasedBarrier,
     ) -> Result<Option<char>, Exception> {
         let Some(transcoder) = port_info.transcoder else {
             return Err(Exception::io_read_error("not a text port"));
@@ -1498,31 +1566,41 @@ impl BinaryPortData {
         // If this is a utf16 port and we have not assigned endiannes, check for
         // the BOM
         if matches!(transcoder.codec, Codec::Utf16) && self.utf16_endianness.is_none() {
-            let b1 = maybe_await!(self.peekn_bytes(port_info, 0))?;
-            let b2 = maybe_await!(self.peekn_bytes(port_info, 1))?;
+            let b1 = maybe_await!(self.peekn_bytes(port_info, 0, barrier))?;
+            let b2 = maybe_await!(self.peekn_bytes(port_info, 1, barrier))?;
             self.utf16_endianness = match (b1, b2) {
                 (Some(b'\xFF'), Some(b'\xFE')) => {
-                    maybe_await!(self.consume_bytes(port_info, 2))?;
+                    maybe_await!(self.consume_bytes(port_info, 2, barrier))?;
                     Some(Endianness::Le)
                 }
                 (Some(b'\xFE'), Some(b'\xFF')) => {
-                    maybe_await!(self.consume_bytes(port_info, 2))?;
+                    maybe_await!(self.consume_bytes(port_info, 2, barrier))?;
                     Some(Endianness::Be)
                 }
                 _ => Some(Endianness::Le),
             };
         }
 
-        Ok(maybe_await!(self.transcode(port_info, transcoder).nth(n))
-            .transpose()?
-            .map(|(_, chr)| chr))
+        Ok(
+            maybe_await!(self.transcode(port_info, transcoder, barrier).nth(n))
+                .transpose()?
+                .map(|(_, chr)| chr),
+        )
     }
 
     #[maybe_async]
-    fn consume_bytes(&mut self, port_info: &BinaryPortInfo, n: usize) -> Result<(), Exception> {
+    fn consume_bytes(
+        &mut self,
+        port_info: &BinaryPortInfo,
+        n: usize,
+        barrier: ErasedBarrier,
+    ) -> Result<(), Exception> {
         if self.bytes_read < self.input_pos + n {
-            let _ =
-                maybe_await!(self.peekn_bytes(port_info, self.input_pos + n - self.bytes_read))?;
+            let _ = maybe_await!(self.peekn_bytes(
+                port_info,
+                self.input_pos + n - self.bytes_read,
+                barrier
+            ))?;
         }
 
         self.input_pos += n;
@@ -1540,20 +1618,26 @@ impl BinaryPortData {
         &mut self,
         port_info: &BinaryPortInfo,
         n: usize,
+        barrier: ErasedBarrier,
     ) -> Result<(), Exception> {
         let Some(transcoder) = port_info.transcoder else {
             return Err(Exception::io_read_error("not a text port"));
         };
 
-        let Some((bytes_to_skip, last_char)) =
-            maybe_await!(self.transcode(port_info, transcoder).take(n).last()).transpose()?
+        let Some((bytes_to_skip, last_char)) = maybe_await!(
+            self.transcode(port_info, transcoder, barrier)
+                .take(n)
+                .last()
+        )
+        .transpose()?
         else {
             return Ok(());
         };
 
         maybe_await!(self.consume_bytes(
             port_info,
-            bytes_to_skip + transcoder.codec.byte_len(last_char)
+            bytes_to_skip + transcoder.codec.byte_len(last_char),
+            barrier
         ))?;
 
         if self.input_buffer.len() - self.input_pos < 4 {
@@ -1568,7 +1652,12 @@ impl BinaryPortData {
     }
 
     #[maybe_async]
-    fn put_bytes(&mut self, port_info: &BinaryPortInfo, mut bytes: &[u8]) -> Result<(), Exception> {
+    fn put_bytes(
+        &mut self,
+        port_info: &BinaryPortInfo,
+        mut bytes: &[u8],
+        barrier: ErasedBarrier,
+    ) -> Result<(), Exception> {
         let Some(write) = self.write.as_ref() else {
             return Err(Exception::io_write_error("not an output port"));
         };
@@ -1582,10 +1671,10 @@ impl BinaryPortData {
             && let Some(set_pos) = self.set_pos.as_ref()
             && self.bytes_read > 0
         {
-            let curr_pos = maybe_await!(get_pos(port))
+            let curr_pos = maybe_await!(get_pos(port, barrier))
                 .map_err(|err| err.add_condition(IoWriteError::new()))?;
             let seek_to = curr_pos - (self.bytes_read as u64 - self.input_pos as u64);
-            maybe_await!(set_pos(port, seek_to))
+            maybe_await!(set_pos(port, seek_to, barrier))
                 .map_err(|err| err.add_condition(IoWriteError::new()))?;
             self.bytes_read = 0;
             self.input_pos = 0;
@@ -1599,7 +1688,7 @@ impl BinaryPortData {
                         output_buffer.push(*byte);
                         output_buffer.len()
                     };
-                    maybe_await!(write(port, &self.output_buffer, 0, len))?;
+                    maybe_await!(write(port, &self.output_buffer, 0, len, barrier))?;
                     self.output_buffer.as_mut_vec()?.clear();
                 }
             }
@@ -1616,7 +1705,8 @@ impl BinaryPortData {
                         port,
                         &self.output_buffer,
                         0,
-                        self.output_buffer.len()
+                        self.output_buffer.len(),
+                        barrier
                     ))?;
                     self.output_buffer.clear()?;
                 } else {
@@ -1635,7 +1725,8 @@ impl BinaryPortData {
                         port,
                         &self.output_buffer,
                         0,
-                        self.output_buffer.len()
+                        self.output_buffer.len(),
+                        barrier
                     ))?;
                     self.output_buffer.clear()?;
                 } else {
@@ -1649,7 +1740,12 @@ impl BinaryPortData {
     }
 
     #[maybe_async]
-    fn put_str(&mut self, port_info: &BinaryPortInfo, s: &str) -> Result<(), Exception> {
+    fn put_str(
+        &mut self,
+        port_info: &BinaryPortInfo,
+        s: &str,
+        barrier: ErasedBarrier,
+    ) -> Result<(), Exception> {
         let Some(transcoder) = port_info.transcoder else {
             return Err(Exception::io_write_error("not a text port"));
         };
@@ -1668,7 +1764,7 @@ impl BinaryPortData {
             Codec::Latin1 | Codec::Utf8 => {
                 // Probably should do a check here to ensure the string is ascii
                 // if our codec is latin1
-                maybe_await!(self.put_bytes(port_info, s.as_bytes()))?;
+                maybe_await!(self.put_bytes(port_info, s.as_bytes(), barrier))?;
             }
             Codec::Utf16 => {
                 let endianness = self.utf16_endianness.unwrap_or(Endianness::Le);
@@ -1679,14 +1775,14 @@ impl BinaryPortData {
                         Endianness::Be => codepoint.to_be_bytes(),
                     })
                     .collect::<Vec<_>>();
-                maybe_await!(self.put_bytes(port_info, &bytes))?;
+                maybe_await!(self.put_bytes(port_info, &bytes, barrier))?;
             }
         }
         Ok(())
     }
 
     #[maybe_async]
-    fn flush(&mut self) -> Result<(), Exception> {
+    fn flush(&mut self, barrier: ErasedBarrier) -> Result<(), Exception> {
         let Some(write) = self.write.as_ref() else {
             return Err(Exception::io_write_error("not an output port"));
         };
@@ -1699,7 +1795,8 @@ impl BinaryPortData {
             port,
             &self.output_buffer,
             0,
-            self.output_buffer.len()
+            self.output_buffer.len(),
+            barrier
         ))?;
         self.output_buffer.clear()?;
 
@@ -1707,7 +1804,7 @@ impl BinaryPortData {
     }
 
     #[maybe_async]
-    fn get_pos(&mut self) -> Result<u64, Exception> {
+    fn get_pos(&mut self, barrier: ErasedBarrier) -> Result<u64, Exception> {
         let Some(get_pos) = self.get_pos.as_ref() else {
             return Err(Exception::io_error("port does not support port-position"));
         };
@@ -1716,11 +1813,11 @@ impl BinaryPortData {
             return Err(Exception::io_error("port is closed"));
         };
 
-        maybe_await!(get_pos(port))
+        maybe_await!(get_pos(port, barrier))
     }
 
     #[maybe_async]
-    fn set_pos(&mut self, pos: u64) -> Result<(), Exception> {
+    fn set_pos(&mut self, pos: u64, barrier: ErasedBarrier) -> Result<(), Exception> {
         let Some(set_pos) = self.set_pos.as_ref() else {
             return Err(Exception::io_error(
                 "port does not support set-port-position!",
@@ -1737,18 +1834,19 @@ impl BinaryPortData {
                 port,
                 &self.output_buffer,
                 0,
-                self.output_buffer.len()
+                self.output_buffer.len(),
+                barrier
             ))?;
             self.output_buffer.clear()?;
         }
         self.bytes_read = 0;
         self.input_pos = 0;
 
-        maybe_await!(set_pos(port, pos))
+        maybe_await!(set_pos(port, pos, barrier))
     }
 
     #[maybe_async]
-    fn close(&mut self) -> Result<(), Exception> {
+    fn close(&mut self, barrier: ErasedBarrier) -> Result<(), Exception> {
         let mut port = self.inner_port.take();
 
         if let Some(port) = port.as_deref_mut() {
@@ -1757,12 +1855,13 @@ impl BinaryPortData {
                     port,
                     &self.output_buffer,
                     0,
-                    self.output_buffer.len()
+                    self.output_buffer.len(),
+                    barrier
                 ))?;
             }
 
             if let Some(close) = self.close.as_ref() {
-                maybe_await!((close)(port))?;
+                maybe_await!((close)(port, barrier))?;
             }
         }
 
@@ -1796,6 +1895,7 @@ impl CustomTextualPortData {
         &mut self,
         port_info: &CustomTextualPortInfo,
         n: usize,
+        mut barrier: ErasedBarrier,
     ) -> Result<Option<char>, Exception> {
         let Some(read) = port_info.read.as_ref() else {
             return Err(Exception::io_read_error("not an input port"));
@@ -1815,7 +1915,7 @@ impl CustomTextualPortData {
                     Value::from(0usize),
                     Value::from(len)
                 ],
-                &mut ContBarrier::new()
+                barrier.get()
             ))?;
             self.output_buffer.clear();
         }
@@ -1837,7 +1937,7 @@ impl CustomTextualPortData {
                     Value::from(start),
                     Value::from(count)
                 ],
-                &mut ContBarrier::new()
+                barrier.get()
             ))?
             .expect1()?;
 
@@ -1851,9 +1951,13 @@ impl CustomTextualPortData {
     }
 
     #[maybe_async]
-    fn read_char(&mut self, port_info: &CustomTextualPortInfo) -> Result<Option<char>, Exception> {
-        let next_chr = maybe_await!(self.peekn_chars(port_info, 0))?;
-        maybe_await!(self.consume_chars(port_info, 1))?;
+    fn read_char(
+        &mut self,
+        port_info: &CustomTextualPortInfo,
+        barrier: ErasedBarrier,
+    ) -> Result<Option<char>, Exception> {
+        let next_chr = maybe_await!(self.peekn_chars(port_info, 0, barrier))?;
+        maybe_await!(self.consume_chars(port_info, 1, barrier))?;
         Ok(next_chr)
     }
 
@@ -1862,10 +1966,14 @@ impl CustomTextualPortData {
         &mut self,
         port_info: &CustomTextualPortInfo,
         n: usize,
+        barrier: ErasedBarrier,
     ) -> Result<(), Exception> {
         if self.chars_read < self.input_pos + n {
-            let _ =
-                maybe_await!(self.peekn_chars(port_info, self.input_pos + n - self.chars_read))?;
+            let _ = maybe_await!(self.peekn_chars(
+                port_info,
+                self.input_pos + n - self.chars_read,
+                barrier
+            ))?;
         }
 
         self.input_pos += n;
@@ -1879,7 +1987,12 @@ impl CustomTextualPortData {
     }
 
     #[maybe_async]
-    fn put_str(&mut self, port_info: &CustomTextualPortInfo, s: &str) -> Result<(), Exception> {
+    fn put_str(
+        &mut self,
+        port_info: &CustomTextualPortInfo,
+        s: &str,
+        mut barrier: ErasedBarrier,
+    ) -> Result<(), Exception> {
         let Some(write) = port_info.write.as_ref() else {
             return Err(Exception::io_write_error("not an output port"));
         };
@@ -1893,11 +2006,11 @@ impl CustomTextualPortData {
             && let Some(set_pos) = port_info.set_pos.as_ref()
             && self.chars_read > 0
         {
-            let curr_pos: u64 = maybe_await!(get_pos.call(&[], &mut ContBarrier::new()))?
+            let curr_pos: u64 = maybe_await!(get_pos.call(&[], barrier.get()))?
                 .expect1()
                 .map_err(|err: Exception| err.add_condition(IoWriteError::new()))?;
             let seek_to = curr_pos - (self.chars_read as u64 - self.input_pos as u64);
-            maybe_await!(set_pos.call(&[Value::from(seek_to)], &mut ContBarrier::new()))?;
+            maybe_await!(set_pos.call(&[Value::from(seek_to)], barrier.get()))?;
             self.chars_read = 0;
             self.input_pos = 0;
         }
@@ -1914,7 +2027,7 @@ impl CustomTextualPortData {
                             Value::from(0usize),
                             Value::from(1usize)
                         ],
-                        &mut ContBarrier::new()
+                        barrier.get()
                     ))?;
                 }
             }
@@ -1938,7 +2051,7 @@ impl CustomTextualPortData {
                             Value::from(0usize),
                             Value::from(len)
                         ],
-                        &mut ContBarrier::new()
+                        barrier.get()
                     ))?;
                     self.output_buffer.clear();
                 }
@@ -1953,7 +2066,7 @@ impl CustomTextualPortData {
                                 Value::from(0usize),
                                 Value::from(len)
                             ],
-                            &mut ContBarrier::new()
+                            barrier.get()
                         ))?;
                         self.output_buffer.clear();
                     }
@@ -1966,7 +2079,11 @@ impl CustomTextualPortData {
     }
 
     #[maybe_async]
-    fn flush(&mut self, port_info: &CustomTextualPortInfo) -> Result<(), Exception> {
+    fn flush(
+        &mut self,
+        port_info: &CustomTextualPortInfo,
+        mut barrier: ErasedBarrier,
+    ) -> Result<(), Exception> {
         let Some(write) = port_info.write.as_ref() else {
             return Err(Exception::io_write_error("not an output port"));
         };
@@ -1981,7 +2098,7 @@ impl CustomTextualPortData {
                 Value::from(0usize),
                 Value::from(self.output_buffer.len()),
             ],
-            &mut ContBarrier::new()
+            barrier.get()
         ))?;
         self.output_buffer.clear();
 
@@ -1989,7 +2106,11 @@ impl CustomTextualPortData {
     }
 
     #[maybe_async]
-    fn get_pos(&mut self, port_info: &CustomTextualPortInfo) -> Result<u64, Exception> {
+    fn get_pos(
+        &mut self,
+        port_info: &CustomTextualPortInfo,
+        mut barrier: ErasedBarrier,
+    ) -> Result<u64, Exception> {
         let Some(get_pos) = port_info.get_pos.as_ref() else {
             return Err(Exception::io_error("port does not support port-position"));
         };
@@ -1998,11 +2119,16 @@ impl CustomTextualPortData {
             return Err(Exception::io_error("port is closed"));
         }
 
-        maybe_await!(get_pos.call(&[], &mut ContBarrier::new()))?.expect1()
+        maybe_await!(get_pos.call(&[], barrier.get()))?.expect1()
     }
 
     #[maybe_async]
-    fn set_pos(&mut self, port_info: &CustomTextualPortInfo, pos: u64) -> Result<(), Exception> {
+    fn set_pos(
+        &mut self,
+        port_info: &CustomTextualPortInfo,
+        pos: u64,
+        mut barrier: ErasedBarrier,
+    ) -> Result<(), Exception> {
         let Some(set_pos) = port_info.set_pos.as_ref() else {
             return Err(Exception::io_error(
                 "port does not support set-port-position!",
@@ -2021,7 +2147,7 @@ impl CustomTextualPortData {
                     Value::from(0usize),
                     Value::from(self.output_buffer.len()),
                 ],
-                &mut ContBarrier::new()
+                barrier.get()
             ))?;
             self.output_buffer.clear();
         }
@@ -2029,13 +2155,17 @@ impl CustomTextualPortData {
         self.chars_read = 0;
         self.input_pos = 0;
 
-        maybe_await!(set_pos.call(&[Value::from(pos)], &mut ContBarrier::new()))?;
+        maybe_await!(set_pos.call(&[Value::from(pos)], barrier.get()))?;
 
         Ok(())
     }
 
     #[maybe_async]
-    fn close(&mut self, port_info: &CustomTextualPortInfo) -> Result<(), Exception> {
+    fn close(
+        &mut self,
+        port_info: &CustomTextualPortInfo,
+        mut barrier: ErasedBarrier,
+    ) -> Result<(), Exception> {
         if !self.open {
             // TODO: Do we return an error here?
             return Ok(());
@@ -2043,10 +2173,10 @@ impl CustomTextualPortData {
 
         self.open = false;
 
-        maybe_await!(self.flush(port_info))?;
+        maybe_await!(self.flush(port_info, barrier))?;
 
         if let Some(close) = port_info.close.as_ref() {
-            maybe_await!(close.call(&[], &mut ContBarrier::new()))?;
+            maybe_await!(close.call(&[], barrier.get()))?;
         }
 
         Ok(())
@@ -2066,10 +2196,14 @@ pub(crate) enum PortData {
 impl PortData {
     #[allow(dead_code)]
     #[maybe_async]
-    fn read_byte(&mut self, port_info: &PortInfo) -> Result<Option<u8>, Exception> {
+    fn read_byte(
+        &mut self,
+        port_info: &PortInfo,
+        barrier: ErasedBarrier,
+    ) -> Result<Option<u8>, Exception> {
         match (self, port_info) {
             (Self::BinaryPort(port_data), PortInfo::BinaryPort(port_info)) => {
-                maybe_await!(port_data.read_byte(port_info))
+                maybe_await!(port_data.read_byte(port_info, barrier))
             }
             (Self::CustomTextualPort(_), PortInfo::CustomTextualPort(_)) => {
                 Err(Exception::io_read_error("not a binary port"))
@@ -2079,23 +2213,32 @@ impl PortData {
     }
 
     #[maybe_async]
-    pub(crate) fn read_char(&mut self, port_info: &PortInfo) -> Result<Option<char>, Exception> {
+    pub(crate) fn read_char(
+        &mut self,
+        port_info: &PortInfo,
+        barrier: ErasedBarrier,
+    ) -> Result<Option<char>, Exception> {
         match (self, port_info) {
             (Self::BinaryPort(port_data), PortInfo::BinaryPort(port_info)) => {
-                maybe_await!(port_data.read_char(port_info))
+                maybe_await!(port_data.read_char(port_info, barrier))
             }
             (Self::CustomTextualPort(port_data), PortInfo::CustomTextualPort(port_info)) => {
-                maybe_await!(port_data.read_char(port_info))
+                maybe_await!(port_data.read_char(port_info, barrier))
             }
             _ => unreachable!(),
         }
     }
 
     #[maybe_async]
-    fn peekn_bytes(&mut self, port_info: &PortInfo, n: usize) -> Result<Option<u8>, Exception> {
+    fn peekn_bytes(
+        &mut self,
+        port_info: &PortInfo,
+        n: usize,
+        barrier: ErasedBarrier,
+    ) -> Result<Option<u8>, Exception> {
         match (self, port_info) {
             (Self::BinaryPort(port_data), PortInfo::BinaryPort(port_info)) => {
-                maybe_await!(port_data.peekn_bytes(port_info, n))
+                maybe_await!(port_data.peekn_bytes(port_info, n, barrier))
             }
             (Self::CustomTextualPort(_), PortInfo::CustomTextualPort(_)) => {
                 Err(Exception::io_read_error("not a binary port"))
@@ -2109,23 +2252,29 @@ impl PortData {
         &mut self,
         port_info: &PortInfo,
         n: usize,
+        barrier: ErasedBarrier,
     ) -> Result<Option<char>, Exception> {
         match (self, port_info) {
             (Self::BinaryPort(port_data), PortInfo::BinaryPort(port_info)) => {
-                maybe_await!(port_data.peekn_chars(port_info, n))
+                maybe_await!(port_data.peekn_chars(port_info, n, barrier))
             }
             (Self::CustomTextualPort(port_data), PortInfo::CustomTextualPort(port_info)) => {
-                maybe_await!(port_data.peekn_chars(port_info, n))
+                maybe_await!(port_data.peekn_chars(port_info, n, barrier))
             }
             _ => unreachable!(),
         }
     }
 
     #[maybe_async]
-    fn consume_bytes(&mut self, port_info: &PortInfo, n: usize) -> Result<(), Exception> {
+    fn consume_bytes(
+        &mut self,
+        port_info: &PortInfo,
+        n: usize,
+        barrier: ErasedBarrier,
+    ) -> Result<(), Exception> {
         match (self, port_info) {
             (Self::BinaryPort(port_data), PortInfo::BinaryPort(port_info)) => {
-                maybe_await!(port_data.consume_bytes(port_info, n))
+                maybe_await!(port_data.consume_bytes(port_info, n, barrier))
             }
             (Self::CustomTextualPort(_), PortInfo::CustomTextualPort(_)) => {
                 Err(Exception::io_read_error("not a binary port"))
@@ -2139,23 +2288,29 @@ impl PortData {
         &mut self,
         port_info: &PortInfo,
         n: usize,
+        barrier: ErasedBarrier,
     ) -> Result<(), Exception> {
         match (self, port_info) {
             (Self::BinaryPort(port_data), PortInfo::BinaryPort(port_info)) => {
-                maybe_await!(port_data.consume_chars(port_info, n))
+                maybe_await!(port_data.consume_chars(port_info, n, barrier))
             }
             (Self::CustomTextualPort(port_data), PortInfo::CustomTextualPort(port_info)) => {
-                maybe_await!(port_data.consume_chars(port_info, n))
+                maybe_await!(port_data.consume_chars(port_info, n, barrier))
             }
             _ => unreachable!(),
         }
     }
 
     #[maybe_async]
-    fn put_bytes(&mut self, port_info: &PortInfo, bytes: &[u8]) -> Result<(), Exception> {
+    fn put_bytes(
+        &mut self,
+        port_info: &PortInfo,
+        bytes: &[u8],
+        barrier: ErasedBarrier,
+    ) -> Result<(), Exception> {
         match (self, port_info) {
             (Self::BinaryPort(port_data), PortInfo::BinaryPort(port_info)) => {
-                maybe_await!(port_data.put_bytes(port_info, bytes))
+                maybe_await!(port_data.put_bytes(port_info, bytes, barrier))
             }
             (Self::CustomTextualPort(_), PortInfo::CustomTextualPort(_)) => {
                 Err(Exception::io_read_error("not a binary port"))
@@ -2165,65 +2320,75 @@ impl PortData {
     }
 
     #[maybe_async]
-    fn put_str(&mut self, port_info: &PortInfo, s: &str) -> Result<(), Exception> {
+    fn put_str(
+        &mut self,
+        port_info: &PortInfo,
+        s: &str,
+        barrier: ErasedBarrier,
+    ) -> Result<(), Exception> {
         match (self, port_info) {
             (Self::BinaryPort(port_data), PortInfo::BinaryPort(port_info)) => {
-                maybe_await!(port_data.put_str(port_info, s))
+                maybe_await!(port_data.put_str(port_info, s, barrier))
             }
             (Self::CustomTextualPort(port_data), PortInfo::CustomTextualPort(port_info)) => {
-                maybe_await!(port_data.put_str(port_info, s))
+                maybe_await!(port_data.put_str(port_info, s, barrier))
             }
             _ => unreachable!(),
         }
     }
 
     #[maybe_async]
-    fn flush(&mut self, port_info: &PortInfo) -> Result<(), Exception> {
+    fn flush(&mut self, port_info: &PortInfo, barrier: ErasedBarrier) -> Result<(), Exception> {
         match (self, port_info) {
             (Self::BinaryPort(port_data), _) => {
-                maybe_await!(port_data.flush())
+                maybe_await!(port_data.flush(barrier))
             }
             (Self::CustomTextualPort(port_data), PortInfo::CustomTextualPort(port_info)) => {
-                maybe_await!(port_data.flush(port_info))
+                maybe_await!(port_data.flush(port_info, barrier))
             }
             _ => unreachable!(),
         }
     }
 
     #[maybe_async]
-    fn get_pos(&mut self, port_info: &PortInfo) -> Result<u64, Exception> {
+    fn get_pos(&mut self, port_info: &PortInfo, barrier: ErasedBarrier) -> Result<u64, Exception> {
         match (self, port_info) {
             (Self::BinaryPort(port_data), _) => {
-                maybe_await!(port_data.get_pos())
+                maybe_await!(port_data.get_pos(barrier))
             }
             (Self::CustomTextualPort(port_data), PortInfo::CustomTextualPort(port_info)) => {
-                maybe_await!(port_data.get_pos(port_info))
+                maybe_await!(port_data.get_pos(port_info, barrier))
             }
             _ => unreachable!(),
         }
     }
 
     #[maybe_async]
-    fn set_pos(&mut self, port_info: &PortInfo, pos: u64) -> Result<(), Exception> {
+    fn set_pos(
+        &mut self,
+        port_info: &PortInfo,
+        pos: u64,
+        barrier: ErasedBarrier,
+    ) -> Result<(), Exception> {
         match (self, port_info) {
             (Self::BinaryPort(port_data), _) => {
-                maybe_await!(port_data.set_pos(pos))
+                maybe_await!(port_data.set_pos(pos, barrier))
             }
             (Self::CustomTextualPort(port_data), PortInfo::CustomTextualPort(port_info)) => {
-                maybe_await!(port_data.set_pos(port_info, pos))
+                maybe_await!(port_data.set_pos(port_info, pos, barrier))
             }
             _ => unreachable!(),
         }
     }
 
     #[maybe_async]
-    fn close(&mut self, port_info: &PortInfo) -> Result<(), Exception> {
+    fn close(&mut self, port_info: &PortInfo, barrier: ErasedBarrier) -> Result<(), Exception> {
         match (self, port_info) {
             (Self::BinaryPort(port_data), _) => {
-                maybe_await!(port_data.close())
+                maybe_await!(port_data.close(barrier))
             }
             (Self::CustomTextualPort(port_data), PortInfo::CustomTextualPort(port_info)) => {
-                maybe_await!(port_data.close(port_info))
+                maybe_await!(port_data.close(port_info, barrier))
             }
             _ => unreachable!(),
         }
@@ -2468,7 +2633,9 @@ impl Port {
     /// Read a single byte from the port. Returns an exception if the port is
     /// not a binary port.
     #[maybe_async]
-    pub fn get_u8(&self) -> Result<Option<u8>, Exception> {
+    pub fn get_u8(&self, barrier: &mut ContBarrier<'_>) -> Result<Option<u8>, Exception> {
+        let barrier = ErasedBarrier::new(barrier);
+
         #[cfg(not(feature = "async"))]
         let mut data = self.0.data.lock().unwrap();
 
@@ -2476,8 +2643,8 @@ impl Port {
         let mut data = self.0.data.lock().await;
 
         // TODO: Ensure this is a binary port
-        if let Some(byte) = maybe_await!(data.peekn_bytes(&self.0.info, 0))? {
-            maybe_await!(data.consume_bytes(&self.0.info, 1))?;
+        if let Some(byte) = maybe_await!(data.peekn_bytes(&self.0.info, 0, barrier))? {
+            maybe_await!(data.consume_bytes(&self.0.info, 1, barrier))?;
             Ok(Some(byte))
         } else {
             Ok(None)
@@ -2487,7 +2654,9 @@ impl Port {
     /// Lookahead one byte into the port. Does not advance the port's position.
     /// Returns an exception if the port is not a binary port.
     #[maybe_async]
-    pub fn lookahead_u8(&self) -> Result<Option<u8>, Exception> {
+    pub fn lookahead_u8(&self, barrier: &mut ContBarrier<'_>) -> Result<Option<u8>, Exception> {
+        let barrier = ErasedBarrier::new(barrier);
+
         #[cfg(not(feature = "async"))]
         let mut data = self.0.data.lock().unwrap();
 
@@ -2495,21 +2664,23 @@ impl Port {
         let mut data = self.0.data.lock().await;
 
         // TODO: Ensure this is a binary port
-        maybe_await!(data.peekn_bytes(&self.0.info, 0))
+        maybe_await!(data.peekn_bytes(&self.0.info, 0, barrier))
     }
 
     /// Read a single [`char`] from the port. Returns an exception if the port
     /// is not a textual port.
     #[maybe_async]
-    pub fn get_char(&self) -> Result<Option<char>, Exception> {
+    pub fn get_char(&self, barrier: &mut ContBarrier<'_>) -> Result<Option<char>, Exception> {
+        let barrier = ErasedBarrier::new(barrier);
+
         #[cfg(not(feature = "async"))]
         let mut data = self.0.data.lock().unwrap();
 
         #[cfg(feature = "async")]
         let mut data = self.0.data.lock().await;
 
-        if let Some(chr) = maybe_await!(data.peekn_chars(&self.0.info, 0))? {
-            maybe_await!(data.consume_chars(&self.0.info, 1))?;
+        if let Some(chr) = maybe_await!(data.peekn_chars(&self.0.info, 0, barrier))? {
+            maybe_await!(data.consume_chars(&self.0.info, 1, barrier))?;
             Ok(Some(chr))
         } else {
             Ok(None)
@@ -2519,22 +2690,24 @@ impl Port {
     /// Lookahead one [`char`] into the port. Does not advance the port's
     /// position. Returns an exception if the port is not a textual port.
     #[maybe_async]
-    pub fn lookahead_char(&self) -> Result<Option<char>, Exception> {
+    pub fn lookahead_char(&self, barrier: &mut ContBarrier<'_>) -> Result<Option<char>, Exception> {
+        let barrier = ErasedBarrier::new(barrier);
+
         #[cfg(not(feature = "async"))]
         let mut data = self.0.data.lock().unwrap();
 
         #[cfg(feature = "async")]
         let mut data = self.0.data.lock().await;
 
-        maybe_await!(data.peekn_chars(&self.0.info, 0))
+        maybe_await!(data.peekn_chars(&self.0.info, 0, barrier))
     }
 
     /// Read a line from the port, not including the newline character.
     #[maybe_async]
-    pub fn get_line(&self) -> Result<Option<String>, Exception> {
+    pub fn get_line(&self, barrier: &mut ContBarrier<'_>) -> Result<Option<String>, Exception> {
         let mut out = String::new();
         loop {
-            match maybe_await!(self.get_char())? {
+            match maybe_await!(self.get_char(barrier))? {
                 Some('\n') => return Ok(Some(out)),
                 Some(chr) => out.push(chr),
                 None if out.is_empty() => return Ok(None),
@@ -2545,10 +2718,14 @@ impl Port {
 
     /// Read a string of `n` characters long.
     #[maybe_async]
-    pub fn get_string_n(&self, n: usize) -> Result<Option<String>, Exception> {
+    pub fn get_string_n(
+        &self,
+        n: usize,
+        barrier: &mut ContBarrier<'_>,
+    ) -> Result<Option<String>, Exception> {
         let mut out = String::with_capacity(n);
         for _ in 0..n {
-            if let Some(chr) = maybe_await!(self.get_char())? {
+            if let Some(chr) = maybe_await!(self.get_char(barrier))? {
                 out.push(chr);
             } else {
                 break;
@@ -2559,9 +2736,12 @@ impl Port {
 
     /// Read the contents of the port until eof.
     #[maybe_async]
-    pub fn get_string_all(&self) -> Result<Option<String>, Exception> {
+    pub fn get_string_all(
+        &self,
+        barrier: &mut ContBarrier<'_>,
+    ) -> Result<Option<String>, Exception> {
         let mut out = String::new();
-        while let Some(chr) = maybe_await!(self.get_char())? {
+        while let Some(chr) = maybe_await!(self.get_char(barrier))? {
             out.push(chr);
         }
         Ok(Some(out))
@@ -2570,14 +2750,20 @@ impl Port {
     /// Read a single datum from the port and advance the position to right after
     /// the datum.
     #[maybe_async]
-    pub fn get_sexpr(&self, span: Span) -> Result<Option<(Syntax, Span)>, ParseSyntaxError> {
+    pub fn get_sexpr(
+        &self,
+        span: Span,
+        barrier: &mut ContBarrier<'_>,
+    ) -> Result<Option<(Syntax, Span)>, ParseSyntaxError> {
+        let barrier = ErasedBarrier::new(barrier);
+
         #[cfg(not(feature = "async"))]
         let mut data = self.0.data.lock().unwrap();
 
         #[cfg(feature = "async")]
         let mut data = self.0.data.lock().await;
 
-        let mut parser = Parser::new(&mut data, &self.0.info, span);
+        let mut parser = Parser::new(&mut data, &self.0.info, span, barrier);
 
         let sexpr_or_eof = maybe_await!(parser.get_sexpr_or_eof())?;
         let ending_span = parser.curr_span();
@@ -2587,21 +2773,29 @@ impl Port {
 
     /// Read all datums from the port until EOF.
     #[maybe_async]
-    pub fn all_sexprs(&self, span: Span) -> Result<Syntax, ParseSyntaxError> {
+    pub fn all_sexprs(
+        &self,
+        span: Span,
+        barrier: &mut ContBarrier<'_>,
+    ) -> Result<Syntax, ParseSyntaxError> {
+        let barrier = ErasedBarrier::new(barrier);
+
         #[cfg(not(feature = "async"))]
         let mut data = self.0.data.lock().unwrap();
 
         #[cfg(feature = "async")]
         let mut data = self.0.data.lock().await;
 
-        let mut parser = Parser::new(&mut data, &self.0.info, span);
+        let mut parser = Parser::new(&mut data, &self.0.info, span, barrier);
 
         Ok(maybe_await!(parser.all_sexprs())?)
     }
 
     /// Write a single byte to the port.
     #[maybe_async]
-    pub fn put_u8(&self, byte: u8) -> Result<(), Exception> {
+    pub fn put_u8(&self, byte: u8, barrier: &mut ContBarrier<'_>) -> Result<(), Exception> {
+        let barrier = ErasedBarrier::new(barrier);
+
         #[cfg(not(feature = "async"))]
         let mut data = self.0.data.lock().unwrap();
 
@@ -2610,12 +2804,14 @@ impl Port {
 
         // TODO: ensure this is not a textual port
 
-        maybe_await!(data.put_bytes(&self.0.info, &[byte]))
+        maybe_await!(data.put_bytes(&self.0.info, &[byte], barrier))
     }
 
     /// Write a byte slice to the port.
     #[maybe_async]
-    pub fn put_bytes(&self, bytes: &[u8]) -> Result<(), Exception> {
+    pub fn put_bytes(&self, bytes: &[u8], barrier: &mut ContBarrier<'_>) -> Result<(), Exception> {
+        let barrier = ErasedBarrier::new(barrier);
+
         #[cfg(not(feature = "async"))]
         let mut data = self.0.data.lock().unwrap();
 
@@ -2624,12 +2820,14 @@ impl Port {
 
         // TODO: ensure this is not a textual port
 
-        maybe_await!(data.put_bytes(&self.0.info, bytes))
+        maybe_await!(data.put_bytes(&self.0.info, bytes, barrier))
     }
 
     /// Write a single character to the port.
     #[maybe_async]
-    pub fn put_char(&self, chr: char) -> Result<(), Exception> {
+    pub fn put_char(&self, chr: char, barrier: &mut ContBarrier<'_>) -> Result<(), Exception> {
+        let barrier = ErasedBarrier::new(barrier);
+
         #[cfg(not(feature = "async"))]
         let mut data = self.0.data.lock().unwrap();
 
@@ -2639,12 +2837,18 @@ impl Port {
         let mut buf: [u8; 4] = [0; 4];
         let s = chr.encode_utf8(&mut buf);
 
-        maybe_await!(data.put_str(&self.0.info, s))
+        maybe_await!(data.put_str(&self.0.info, s, barrier))
     }
 
     /// Write a char slice to the port.
     #[maybe_async]
-    pub fn put_chars(&self, chars: &[char]) -> Result<(), Exception> {
+    pub fn put_chars(
+        &self,
+        chars: &[char],
+        barrier: &mut ContBarrier<'_>,
+    ) -> Result<(), Exception> {
+        let barrier = ErasedBarrier::new(barrier);
+
         #[cfg(not(feature = "async"))]
         let mut data = self.0.data.lock().unwrap();
 
@@ -2655,7 +2859,7 @@ impl Port {
             let mut buf: [u8; 4] = [0; 4];
             let s = chr.encode_utf8(&mut buf);
 
-            maybe_await!(data.put_str(&self.0.info, s))?;
+            maybe_await!(data.put_str(&self.0.info, s, barrier))?;
         }
 
         Ok(())
@@ -2663,52 +2867,60 @@ impl Port {
 
     /// Write the contents of a str `s` to the port.
     #[maybe_async]
-    pub fn put_str(&self, s: &str) -> Result<(), Exception> {
+    pub fn put_str(&self, s: &str, barrier: &mut ContBarrier<'_>) -> Result<(), Exception> {
+        let barrier = ErasedBarrier::new(barrier);
+
         #[cfg(not(feature = "async"))]
         let mut data = self.0.data.lock().unwrap();
 
         #[cfg(feature = "async")]
         let mut data = self.0.data.lock().await;
 
-        maybe_await!(data.put_str(&self.0.info, s))
+        maybe_await!(data.put_str(&self.0.info, s, barrier))
     }
 
     /// Flush the contents of the port to the writer sink.
     #[maybe_async]
-    pub fn flush(&self) -> Result<(), Exception> {
+    pub fn flush(&self, barrier: &mut ContBarrier<'_>) -> Result<(), Exception> {
+        let barrier = ErasedBarrier::new(barrier);
+
         #[cfg(not(feature = "async"))]
         let mut data = self.0.data.lock().unwrap();
 
         #[cfg(feature = "async")]
         let mut data = self.0.data.lock().await;
 
-        maybe_await!(data.flush(&self.0.info))
+        maybe_await!(data.flush(&self.0.info, barrier))
     }
 
     /// Return the position of the port, erroring if the operation is not
     /// supported.
     #[maybe_async]
-    pub fn get_pos(&self) -> Result<u64, Exception> {
+    pub fn get_pos(&self, barrier: &mut ContBarrier<'_>) -> Result<u64, Exception> {
+        let barrier = ErasedBarrier::new(barrier);
+
         #[cfg(not(feature = "async"))]
         let mut data = self.0.data.lock().unwrap();
 
         #[cfg(feature = "async")]
         let mut data = self.0.data.lock().await;
 
-        maybe_await!(data.get_pos(&self.0.info))
+        maybe_await!(data.get_pos(&self.0.info, barrier))
     }
 
     /// Sets the position of the port, erroring if the operation is not
     /// supported.
     #[maybe_async]
-    pub fn set_pos(&self, pos: u64) -> Result<(), Exception> {
+    pub fn set_pos(&self, pos: u64, barrier: &mut ContBarrier<'_>) -> Result<(), Exception> {
+        let barrier = ErasedBarrier::new(barrier);
+
         #[cfg(not(feature = "async"))]
         let mut data = self.0.data.lock().unwrap();
 
         #[cfg(feature = "async")]
         let mut data = self.0.data.lock().await;
 
-        maybe_await!(data.set_pos(&self.0.info, pos))
+        maybe_await!(data.set_pos(&self.0.info, pos, barrier))
     }
 }
 
@@ -2786,7 +2998,7 @@ mod prompt {
         I: rustyline::history::History + Send + Sync + 'static,
     {
         fn read_fn() -> Option<ReadFn> {
-            Some(Box::new(|any, buff, start, count| {
+            Some(Box::new(|any, buff, start, count, _barrier| {
                 use std::cmp::Ordering;
 
                 let buff = &mut buff.as_mut_slice()?[start..(start + count)];
@@ -2870,7 +3082,7 @@ mod prompt {
 
     impl IntoPort for Prompt {
         fn read_fn() -> Option<ReadFn> {
-            Some(Box::new(|any, buff, start, count| {
+            Some(Box::new(|any, buff, start, count, _barrier| {
                 Box::pin(async move {
                     use std::cmp::Ordering;
 
@@ -3453,11 +3665,24 @@ pub fn port_has_port_position_pred(port: &Value) -> Result<Vec<Value>, Exception
     Ok(vec![Value::from(port.has_port_position())])
 }
 
+// port-position, set-port-position!, close-port, and port-eof? all reach
+// into a Port's read/write/get-pos/set-pos/close, which may be a custom
+// (Scheme-defined) procedure, so they need the caller's barrier: promoted
+// from `#[bridge]` to `#[cps_bridge]` to get it.
+
 #[maybe_async]
-#[bridge(name = "port-position", lib = "(rnrs io builtins (6))")]
-pub fn port_position(port: &Value) -> Result<Vec<Value>, Exception> {
-    let port: Port = port.clone().try_into()?;
-    Ok(vec![Value::from(maybe_await!(port.get_pos())?)])
+#[cps_bridge(def = "port-position port", lib = "(rnrs io builtins (6))")]
+pub fn port_position(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let port: Port = args[0].clone().try_into()?;
+    let pos = maybe_await!(port.get_pos(barrier))?;
+    Ok(Application::new(k, None, vec![Value::from(pos)]))
 }
 
 #[bridge(name = "port-has-set-port-position!?", lib = "(rnrs io builtins (6))")]
@@ -3467,18 +3692,33 @@ pub fn port_has_set_port_position_bang_pred(port: &Value) -> Result<Vec<Value>, 
 }
 
 #[maybe_async]
-#[bridge(name = "set-port-position!", lib = "(rnrs io builtins (6))")]
-pub fn set_port_position_bang(port: &Value, pos: &Value) -> Result<Vec<Value>, Exception> {
-    let port: Port = port.clone().try_into()?;
-    let pos: u64 = pos.clone().try_into()?;
-    maybe_await!(port.set_pos(pos))?;
-    Ok(Vec::new())
+#[cps_bridge(def = "set-port-position! port pos", lib = "(rnrs io builtins (6))")]
+pub fn set_port_position_bang(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let port: Port = args[0].clone().try_into()?;
+    let pos: u64 = args[1].clone().try_into()?;
+    maybe_await!(port.set_pos(pos, barrier))?;
+    Ok(Application::new(k, None, Vec::new()))
 }
 
 #[maybe_async]
-#[bridge(name = "close-port", lib = "(rnrs io builtins (6))")]
-pub fn close_port(port: &Value) -> Result<Vec<Value>, Exception> {
-    let port: Port = port.clone().try_into()?;
+#[cps_bridge(def = "close-port port", lib = "(rnrs io builtins (6))")]
+pub fn close_port(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let port: Port = args[0].clone().try_into()?;
+    let erased = ErasedBarrier::new(barrier);
 
     #[cfg(not(feature = "async"))]
     let mut data = port.0.data.lock().unwrap();
@@ -3486,9 +3726,9 @@ pub fn close_port(port: &Value) -> Result<Vec<Value>, Exception> {
     #[cfg(feature = "tokio")]
     let mut data = port.0.data.lock().await;
 
-    maybe_await!(data.close(&port.0.info))?;
+    maybe_await!(data.close(&port.0.info, erased))?;
 
-    Ok(Vec::new())
+    Ok(Application::new(k, None, Vec::new()))
 }
 
 // TODO: call-with-port
@@ -3503,9 +3743,17 @@ pub fn input_port_pred(obj: &Value) -> Result<Vec<Value>, Exception> {
 }
 
 #[maybe_async]
-#[bridge(name = "port-eof?", lib = "(rnrs io builtins (6))")]
-pub fn port_eof_pred(input_port: &Value) -> Result<Vec<Value>, Exception> {
-    let port: Port = input_port.clone().try_into()?;
+#[cps_bridge(def = "port-eof? input-port", lib = "(rnrs io builtins (6))")]
+pub fn port_eof_pred(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let port: Port = args[0].clone().try_into()?;
+    let erased = ErasedBarrier::new(barrier);
 
     #[cfg(not(feature = "async"))]
     let mut data = port.0.data.lock().unwrap();
@@ -3513,9 +3761,8 @@ pub fn port_eof_pred(input_port: &Value) -> Result<Vec<Value>, Exception> {
     #[cfg(feature = "tokio")]
     let mut data = port.0.data.lock().await;
 
-    Ok(vec![Value::from(
-        maybe_await!(data.peekn_bytes(&port.0.info, 0))?.is_none(),
-    )])
+    let is_eof = maybe_await!(data.peekn_bytes(&port.0.info, 0, erased))?.is_none();
+    Ok(Application::new(k, None, vec![Value::from(is_eof)]))
 }
 
 #[maybe_async]
@@ -3644,7 +3891,7 @@ pub fn current_input_port(
     k: Procedure,
     _args: &[Value],
     _rest_args: &[Value],
-    barrier: &mut ContBarrier,
+    barrier: &mut ContBarrier<'_>,
 ) -> Result<Application, Exception> {
     let current_input_port = barrier.current_input_port();
     Ok(Application::new(
@@ -3661,7 +3908,7 @@ pub fn current_output_port(
     k: Procedure,
     _args: &[Value],
     _rest_args: &[Value],
-    barrier: &mut ContBarrier,
+    barrier: &mut ContBarrier<'_>,
 ) -> Result<Application, Exception> {
     let current_input_port = barrier.current_output_port();
     Ok(Application::new(
@@ -3678,7 +3925,7 @@ pub fn current_error_port(
     k: Procedure,
     _args: &[Value],
     _rest_args: &[Value],
-    _barrier: &mut ContBarrier,
+    _barrier: &mut ContBarrier<'_>,
 ) -> Result<Application, Exception> {
     let current_error_port = Port::new(
         "<stderr>",
@@ -3697,89 +3944,175 @@ pub fn current_error_port(
 }
 
 // 8.2.8. Binary input
+//
+// All of get-u8, lookahead-u8, get-char, lookahead-char, get-string-n,
+// get-line, get-string-all, and get-datum read through a Port, which may be
+// backed by a custom (Scheme-defined) read procedure, so they need the
+// caller's barrier: promoted from `#[bridge]` to `#[cps_bridge]` to get it.
 
 #[maybe_async]
-#[bridge(name = "get-u8", lib = "(rnrs io builtins (6))")]
-pub fn get_u8(binary_input_port: &Value) -> Result<Vec<Value>, Exception> {
-    let port: Port = binary_input_port.clone().try_into()?;
-    if let Some(byte) = maybe_await!(port.get_u8())? {
-        Ok(vec![Value::from(byte)])
+#[cps_bridge(def = "get-u8 binary-input-port", lib = "(rnrs io builtins (6))")]
+pub fn get_u8(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let port: Port = args[0].clone().try_into()?;
+    let result = if let Some(byte) = maybe_await!(port.get_u8(barrier))? {
+        Value::from(byte)
     } else {
-        Ok(vec![EOF_OBJECT.clone()])
-    }
+        EOF_OBJECT.clone()
+    };
+    Ok(Application::new(k, None, vec![result]))
 }
 
 #[maybe_async]
-#[bridge(name = "lookahead-u8", lib = "(rnrs io builtins (6))")]
-pub fn lookahead_u8(binary_input_port: &Value) -> Result<Vec<Value>, Exception> {
-    let port: Port = binary_input_port.clone().try_into()?;
-    if let Some(byte) = maybe_await!(port.lookahead_u8())? {
-        Ok(vec![Value::from(byte)])
+#[cps_bridge(def = "lookahead-u8 binary-input-port", lib = "(rnrs io builtins (6))")]
+pub fn lookahead_u8(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let port: Port = args[0].clone().try_into()?;
+    let result = if let Some(byte) = maybe_await!(port.lookahead_u8(barrier))? {
+        Value::from(byte)
     } else {
-        Ok(vec![EOF_OBJECT.clone()])
-    }
+        EOF_OBJECT.clone()
+    };
+    Ok(Application::new(k, None, vec![result]))
 }
 
 // 8.2.9. Textual input
 
 #[maybe_async]
-#[bridge(name = "get-char", lib = "(rnrs io builtins (6))")]
-pub fn get_char(textual_input_port: Port) -> Result<Vec<Value>, Exception> {
-    if let Some(chr) = maybe_await!(textual_input_port.get_char())? {
-        Ok(vec![Value::from(chr)])
+#[cps_bridge(def = "get-char textual-input-port", lib = "(rnrs io builtins (6))")]
+pub fn get_char(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let port: Port = args[0].clone().try_into()?;
+    let result = if let Some(chr) = maybe_await!(port.get_char(barrier))? {
+        Value::from(chr)
     } else {
-        Ok(vec![EOF_OBJECT.clone()])
-    }
+        EOF_OBJECT.clone()
+    };
+    Ok(Application::new(k, None, vec![result]))
 }
 
 #[maybe_async]
-#[bridge(name = "lookahead-char", lib = "(rnrs io builtins (6))")]
-pub fn lookahead_char(textual_input_port: Port) -> Result<Vec<Value>, Exception> {
-    if let Some(chr) = maybe_await!(textual_input_port.lookahead_char())? {
-        Ok(vec![Value::from(chr)])
+#[cps_bridge(
+    def = "lookahead-char textual-input-port",
+    lib = "(rnrs io builtins (6))"
+)]
+pub fn lookahead_char(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let port: Port = args[0].clone().try_into()?;
+    let result = if let Some(chr) = maybe_await!(port.lookahead_char(barrier))? {
+        Value::from(chr)
     } else {
-        Ok(vec![EOF_OBJECT.clone()])
-    }
+        EOF_OBJECT.clone()
+    };
+    Ok(Application::new(k, None, vec![result]))
 }
 
 #[maybe_async]
-#[bridge(name = "get-string-n", lib = "(rnrs io builtins (6))")]
-pub fn get_string_n(textual_input_port: Port, n: usize) -> Result<Vec<Value>, Exception> {
-    if let Some(s) = maybe_await!(textual_input_port.get_string_n(n))? {
-        Ok(vec![Value::from(s)])
+#[cps_bridge(
+    def = "get-string-n textual-input-port n",
+    lib = "(rnrs io builtins (6))"
+)]
+pub fn get_string_n(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let port: Port = args[0].clone().try_into()?;
+    let n: usize = args[1].clone().try_into()?;
+    let result = if let Some(s) = maybe_await!(port.get_string_n(n, barrier))? {
+        Value::from(s)
     } else {
-        Ok(vec![EOF_OBJECT.clone()])
-    }
+        EOF_OBJECT.clone()
+    };
+    Ok(Application::new(k, None, vec![result]))
 }
 
 #[maybe_async]
-#[bridge(name = "get-line", lib = "(rnrs io builtins (6))")]
-pub fn get_line(textual_input_port: Port) -> Result<Vec<Value>, Exception> {
-    if let Some(line) = maybe_await!(textual_input_port.get_line())? {
-        Ok(vec![Value::from(line)])
+#[cps_bridge(def = "get-line textual-input-port", lib = "(rnrs io builtins (6))")]
+pub fn get_line(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let port: Port = args[0].clone().try_into()?;
+    let result = if let Some(line) = maybe_await!(port.get_line(barrier))? {
+        Value::from(line)
     } else {
-        Ok(vec![EOF_OBJECT.clone()])
-    }
+        EOF_OBJECT.clone()
+    };
+    Ok(Application::new(k, None, vec![result]))
 }
 
 #[maybe_async]
-#[bridge(name = "get-string-all", lib = "(rnrs io builtins (6))")]
-pub fn get_string_all(textual_input_port: Port) -> Result<Vec<Value>, Exception> {
-    if let Some(s) = maybe_await!(textual_input_port.get_string_all())? {
-        Ok(vec![Value::from(s)])
+#[cps_bridge(
+    def = "get-string-all textual-input-port",
+    lib = "(rnrs io builtins (6))"
+)]
+pub fn get_string_all(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let port: Port = args[0].clone().try_into()?;
+    let result = if let Some(s) = maybe_await!(port.get_string_all(barrier))? {
+        Value::from(s)
     } else {
-        Ok(vec![EOF_OBJECT.clone()])
-    }
+        EOF_OBJECT.clone()
+    };
+    Ok(Application::new(k, None, vec![result]))
 }
 
 #[maybe_async]
-#[bridge(name = "get-datum", lib = "(rnrs io builtins (6))")]
-pub fn get_datum(textual_input_port: Port) -> Result<Vec<Value>, Exception> {
-    if let Some((syntax, _)) = maybe_await!(textual_input_port.get_sexpr(Span::default()))? {
-        Ok(vec![Value::datum_from_syntax(&syntax)])
+#[cps_bridge(def = "get-datum textual-input-port", lib = "(rnrs io builtins (6))")]
+pub fn get_datum(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let port: Port = args[0].clone().try_into()?;
+    let result = if let Some((syntax, _)) = maybe_await!(port.get_sexpr(Span::default(), barrier))?
+    {
+        Value::datum_from_syntax(&syntax)
     } else {
-        Ok(vec![EOF_OBJECT.clone()])
-    }
+        EOF_OBJECT.clone()
+    };
+    Ok(Application::new(k, None, vec![result]))
 }
 
 // 8.2.10. Output ports
@@ -3810,11 +4143,18 @@ pub fn output_port_pred(obj: &Value) -> Result<Vec<Value>, Exception> {
 }
 
 #[maybe_async]
-#[bridge(name = "flush-output-port", lib = "(rnrs io builtins (6))")]
-pub fn flush_output_port(obj: &Value) -> Result<Vec<Value>, Exception> {
-    let port: Port = obj.clone().try_into()?;
-    maybe_await!(port.flush())?;
-    Ok(Vec::new())
+#[cps_bridge(def = "flush-output-port obj", lib = "(rnrs io builtins (6))")]
+pub fn flush_output_port(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let port: Port = args[0].clone().try_into()?;
+    maybe_await!(port.flush(barrier))?;
+    Ok(Application::new(k, None, Vec::new()))
 }
 
 #[bridge(name = "output-port-buffer-mode", lib = "(rnrs io builtins (6))")]
@@ -3932,25 +4272,48 @@ pub fn make_custom_textual_output_port(
 }
 
 // 8.2.11. Binary output
+//
+// put-u8, put-bytevector, put-char, put-string, and put-datum all write
+// through a Port, which may be backed by a custom (Scheme-defined) write
+// procedure, so they need the caller's barrier: promoted from `#[bridge]`
+// to `#[cps_bridge]` to get it.
 
 #[maybe_async]
-#[bridge(name = "put-u8", lib = "(rnrs io builtins (6))")]
-pub fn put_u8(binary_output_port: &Value, octet: &Value) -> Result<Vec<Value>, Exception> {
-    let port: Port = binary_output_port.clone().try_into()?;
-    let octet: u8 = octet.clone().try_into()?;
-    maybe_await!(port.put_u8(octet))?;
-    Ok(Vec::new())
+#[cps_bridge(
+    def = "put-u8 binary-output-port octet",
+    lib = "(rnrs io builtins (6))"
+)]
+pub fn put_u8(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let port: Port = args[0].clone().try_into()?;
+    let octet: u8 = args[1].clone().try_into()?;
+    maybe_await!(port.put_u8(octet, barrier))?;
+    Ok(Application::new(k, None, Vec::new()))
 }
 
 #[cfg(not(feature = "async"))]
-#[bridge(name = "put-bytevector", lib = "(rnrs io builtins (6))")]
+#[cps_bridge(
+    def = "put-bytevector port bytevector . start-count",
+    lib = "(rnrs io builtins (6))"
+)]
 pub fn put_bytevector(
-    port: Port,
-    bytevector: ByteVector,
-    start_count: &[Value],
-) -> Result<Vec<Value>, Exception> {
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let port: Port = args[0].clone().try_into()?;
+    let bytevector: ByteVector = args[1].clone().try_into()?;
     let bytevector = bytevector.as_slice();
-    let slice = match start_count {
+    let slice = match rest_args {
         [] => &bytevector[..],
         [start] => {
             let start: usize = start.try_to()?;
@@ -3968,27 +4331,32 @@ pub fn put_bytevector(
             &bytevector[start..(start + count)]
         }
         _ => {
-            return Err(Exception::wrong_num_of_var_args(
-                2..4,
-                2 + start_count.len(),
-            ));
+            return Err(Exception::wrong_num_of_var_args(2..4, 2 + rest_args.len()));
         }
     };
-    port.put_bytes(slice)?;
-    Ok(Vec::new())
+    port.put_bytes(slice, barrier)?;
+    Ok(Application::new(k, None, Vec::new()))
 }
 
 #[cfg(feature = "async")]
-#[bridge(name = "put-bytevector", lib = "(rnrs io builtins (6))")]
+#[cps_bridge(
+    def = "put-bytevector port bytevector . start-count",
+    lib = "(rnrs io builtins (6))"
+)]
 pub async fn put_bytevector(
-    port: Port,
-    bytevector: ByteVector,
-    start_count: &[Value],
-) -> Result<Vec<Value>, Exception> {
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let port: Port = args[0].clone().try_into()?;
+    let bytevector: ByteVector = args[1].clone().try_into()?;
     // We have to copy the slice to another buffer... it's really obnoxious
     let slice = {
         let bytevector = bytevector.as_slice();
-        match start_count {
+        match rest_args {
             [] => bytevector[..].to_vec(),
             [start] => {
                 let start: usize = start.try_to()?;
@@ -4006,37 +4374,52 @@ pub async fn put_bytevector(
                 bytevector[start..(start + count)].to_vec()
             }
             _ => {
-                return Err(Exception::wrong_num_of_var_args(
-                    2..4,
-                    2 + start_count.len(),
-                ));
+                return Err(Exception::wrong_num_of_var_args(2..4, 2 + rest_args.len()));
             }
         }
     };
-    port.put_bytes(&slice).await?;
-    Ok(Vec::new())
+    port.put_bytes(&slice, barrier).await?;
+    Ok(Application::new(k, None, Vec::new()))
 }
 
 // 8.2.12. Textual output
 
 #[maybe_async]
-#[bridge(name = "put-char", lib = "(rnrs io builtins (6))")]
-pub fn put_char(textual_output_port: &Value, chr: &Value) -> Result<Vec<Value>, Exception> {
-    let port: Port = textual_output_port.clone().try_into()?;
-    let chr: char = chr.clone().try_into()?;
-    maybe_await!(port.put_char(chr))?;
-    Ok(Vec::new())
+#[cps_bridge(
+    def = "put-char textual-output-port chr",
+    lib = "(rnrs io builtins (6))"
+)]
+pub fn put_char(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let port: Port = args[0].clone().try_into()?;
+    let chr: char = args[1].clone().try_into()?;
+    maybe_await!(port.put_char(chr, barrier))?;
+    Ok(Application::new(k, None, Vec::new()))
 }
 
 #[cfg(not(feature = "async"))]
-#[bridge(name = "put-string", lib = "(rnrs io builtins (6))")]
+#[cps_bridge(
+    def = "put-string port string . start-count",
+    lib = "(rnrs io builtins (6))"
+)]
 pub fn put_string(
-    port: Port,
-    string: WideString,
-    start_count: &[Value],
-) -> Result<Vec<Value>, Exception> {
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let port: Port = args[0].clone().try_into()?;
+    let string: WideString = args[1].clone().try_into()?;
     let string = string.as_slice();
-    let slice = match start_count {
+    let slice = match rest_args {
         [] => &string[..],
         [start] => {
             let start: usize = start.try_to()?;
@@ -4054,26 +4437,31 @@ pub fn put_string(
             &string[start..(start + count)]
         }
         _ => {
-            return Err(Exception::wrong_num_of_var_args(
-                2..4,
-                2 + start_count.len(),
-            ));
+            return Err(Exception::wrong_num_of_var_args(2..4, 2 + rest_args.len()));
         }
     };
-    port.put_chars(slice)?;
-    Ok(Vec::new())
+    port.put_chars(slice, barrier)?;
+    Ok(Application::new(k, None, Vec::new()))
 }
 
 #[cfg(feature = "async")]
-#[bridge(name = "put-string", lib = "(rnrs io builtins (6))")]
+#[cps_bridge(
+    def = "put-string port string . start-count",
+    lib = "(rnrs io builtins (6))"
+)]
 pub async fn put_string(
-    port: Port,
-    string: WideString,
-    start_count: &[Value],
-) -> Result<Vec<Value>, Exception> {
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let port: Port = args[0].clone().try_into()?;
+    let string: WideString = args[1].clone().try_into()?;
     let slice = {
         let string = string.as_slice();
-        match start_count {
+        match rest_args {
             [] => string[..].to_vec(),
             [start] => {
                 let start: usize = start.try_to()?;
@@ -4091,24 +4479,31 @@ pub async fn put_string(
                 string[start..(start + count)].to_vec()
             }
             _ => {
-                return Err(Exception::wrong_num_of_var_args(
-                    2..4,
-                    2 + start_count.len(),
-                ));
+                return Err(Exception::wrong_num_of_var_args(2..4, 2 + rest_args.len()));
             }
         }
     };
-    port.put_chars(&slice).await?;
-    Ok(Vec::new())
+    port.put_chars(&slice, barrier).await?;
+    Ok(Application::new(k, None, Vec::new()))
 }
 
 #[maybe_async]
-#[bridge(name = "put-datum", lib = "(rnrs io builtins (6))")]
-pub fn put_datum(textual_output_port: &Value, datum: &Value) -> Result<Vec<Value>, Exception> {
-    let port: Port = textual_output_port.clone().try_into()?;
-    let str_rep = format!("{datum:?}");
-    maybe_await!(port.put_str(&str_rep))?;
-    Ok(Vec::new())
+#[cps_bridge(
+    def = "put-datum textual-output-port datum",
+    lib = "(rnrs io builtins (6))"
+)]
+pub fn put_datum(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let port: Port = args[0].clone().try_into()?;
+    let str_rep = format!("{:?}", args[1]);
+    maybe_await!(port.put_str(&str_rep, barrier))?;
+    Ok(Application::new(k, None, Vec::new()))
 }
 
 // 8.2.13. Input/output ports
@@ -4605,7 +5000,7 @@ pub fn read_char(
         }
     };
 
-    let result = if let Some(byte) = maybe_await!(input_port.get_char())? {
+    let result = if let Some(byte) = maybe_await!(input_port.get_char(barrier))? {
         Value::from(byte)
     } else {
         EOF_OBJECT.clone()
@@ -4639,7 +5034,7 @@ pub fn peek_char(
         }
     };
 
-    let result = if let Some(byte) = maybe_await!(input_port.lookahead_char())? {
+    let result = if let Some(byte) = maybe_await!(input_port.lookahead_char(barrier))? {
         Value::from(byte)
     } else {
         EOF_OBJECT.clone()
@@ -4673,11 +5068,12 @@ pub fn read(
         }
     };
 
-    let result = if let Some((syntax, _)) = maybe_await!(input_port.get_sexpr(Span::default()))? {
-        Value::datum_from_syntax(&syntax)
-    } else {
-        EOF_OBJECT.clone()
-    };
+    let result =
+        if let Some((syntax, _)) = maybe_await!(input_port.get_sexpr(Span::default(), barrier))? {
+            Value::datum_from_syntax(&syntax)
+        } else {
+            EOF_OBJECT.clone()
+        };
 
     Ok(Application::new(k, None, vec![result]))
 }
@@ -4709,7 +5105,7 @@ pub fn write_char(
         }
     };
 
-    maybe_await!(output_port.put_char(chr))?;
+    maybe_await!(output_port.put_char(chr, barrier))?;
 
     Ok(Application::new(k, None, Vec::new()))
 }
@@ -4739,7 +5135,7 @@ pub fn newline(
         }
     };
 
-    maybe_await!(output_port.put_char('\n'))?;
+    maybe_await!(output_port.put_char('\n', barrier))?;
 
     Ok(Application::new(k, None, Vec::new()))
 }
@@ -4771,7 +5167,7 @@ pub fn display(
         }
     };
 
-    maybe_await!(output_port.put_str(&obj))?;
+    maybe_await!(output_port.put_str(&obj, barrier))?;
 
     Ok(Application::new(k, None, Vec::new()))
 }
@@ -4803,7 +5199,7 @@ pub fn write(
         }
     };
 
-    maybe_await!(output_port.put_str(&obj))?;
+    maybe_await!(output_port.put_str(&obj, barrier))?;
 
     Ok(Application::new(k, None, Vec::new()))
 }

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -695,7 +695,15 @@ impl Procedure {
         self.0.is_continuation()
     }
 
-    /// Applies `args` to the procedure and returns the values it evaluates to.
+    /// Applies `args` to the procedure and returns the values it evaluates
+    /// to.
+    ///
+    /// This is the boundary every Rust-mediated re-entry into Scheme
+    /// crosses (hashtable callbacks, port procedures, macro transformers,
+    /// `eval`, ...), and each such re-entry gets a fresh barrier id for the
+    /// duration of the call - see
+    /// [`ContBarrier::swap_fresh_id`] for why - while still sharing the
+    /// caller's `dyn_stack`/`cont_marks`/`params` through the same barrier.
     #[maybe_async]
     pub fn call(
         &self,
@@ -703,17 +711,25 @@ impl Procedure {
         barrier: &mut ContBarrier<'_>,
     ) -> Result<Vec<Value>, Exception> {
         let k = (!self.is_continuation()).then(|| halt_continuation(self.get_runtime()));
-        maybe_await!(Application::new(self.clone(), k, args.to_vec()).eval(barrier))
+        let saved_id = barrier.swap_fresh_id();
+        let result = maybe_await!(Application::new(self.clone(), k, args.to_vec()).eval(barrier));
+        barrier.restore_id(saved_id);
+        result
     }
 
     #[cfg(feature = "async")]
+    /// Just like [`call`](Self::call) but throws an error if we encounter
+    /// an async function. Gets a fresh barrier id the same way.
     pub fn call_sync(
         &self,
         args: &[Value],
         barrier: &mut ContBarrier<'_>,
     ) -> Result<Vec<Value>, Exception> {
         let k = (!self.is_continuation()).then(|| halt_continuation(self.get_runtime()));
-        Application::new(self.clone(), k, args.to_vec()).eval_sync(barrier)
+        let saved_id = barrier.swap_fresh_id();
+        let result = Application::new(self.clone(), k, args.to_vec()).eval_sync(barrier);
+        barrier.restore_id(saved_id);
+        result
     }
 
     pub(crate) fn to_primop(&self) -> Option<PrimOp> {
@@ -848,35 +864,53 @@ impl Application {
         }
     }
 
-    /// Evaluate the application - and all subsequent application - until all that
-    /// remains are values. This is the main trampoline of the evaluation engine.
+    /// Evaluate the application - and all subsequent application - until all
+    /// that remains are values. This is the main trampoline of the
+    /// evaluation engine.
+    ///
+    /// Owns the continuation-mark balance for this run: pushes the baseline
+    /// frame that the terminal (halt) continuation pops on a successful
+    /// exit, and truncates back to the entry depth on every exit. On
+    /// success the truncate is a no-op; on a halt_err exit (uncaught raise,
+    /// failed cross-barrier escape, missing prompt tag) it discards the
+    /// baseline frame plus one leaked frame per pending continuation whose
+    /// invocation - and therefore whose pop - never happened. Since the
+    /// barrier passed in is now typically the caller's (re-entry threads it
+    /// through rather than starting fresh), a leak here would otherwise
+    /// persist for as long as the caller's barrier does.
     #[maybe_async]
     pub fn eval(mut self, barrier: &mut ContBarrier<'_>) -> Result<Vec<Value>, Exception> {
-        loop {
+        barrier.push_marks();
+        let restore_depth = barrier.marks_depth() - 1;
+        let result = loop {
             let op = match self.op {
                 OpType::Proc(proc) => proc,
-                OpType::HaltOk => return Ok(self.args),
-                OpType::HaltErr => {
-                    return Err(Exception(self.args.pop().unwrap()));
-                }
+                OpType::HaltOk => break Ok(self.args),
+                OpType::HaltErr => break Err(Exception(self.args.pop().unwrap())),
             };
             self = maybe_await!(op.0.apply(self.k, self.args, barrier));
-        }
+        };
+        barrier.truncate_marks(restore_depth);
+        result
     }
 
     #[cfg(feature = "async")]
-    /// Just like [eval] but throws an error if we encounter an async function.
+    /// Just like [eval] but throws an error if we encounter an async
+    /// function. Owns the continuation-mark balance the same way
+    /// [`eval`](Self::eval) does.
     pub fn eval_sync(mut self, barrier: &mut ContBarrier) -> Result<Vec<Value>, Exception> {
-        loop {
+        barrier.push_marks();
+        let restore_depth = barrier.marks_depth() - 1;
+        let result = loop {
             let op = match self.op {
                 OpType::Proc(proc) => proc,
-                OpType::HaltOk => return Ok(self.args),
-                OpType::HaltErr => {
-                    return Err(Exception(self.args.pop().unwrap()));
-                }
+                OpType::HaltOk => break Ok(self.args),
+                OpType::HaltErr => break Err(Exception(self.args.pop().unwrap())),
             };
             self = op.0.apply_sync(self.k, self.args, barrier);
-        }
+        };
+        barrier.truncate_marks(restore_depth);
+        result
     }
 }
 
@@ -950,8 +984,14 @@ pub fn apply(
 #[cfg(feature = "async")]
 type Param<'a> = &'a mut (dyn Any + Send + Sync);
 
+// `Send` even without the `async` feature: `spawn_snapshot` (used by
+// `threads.rs`'s OS-thread spawn, which exists regardless of `async`)
+// carries a `ContBarrier` across a thread boundary. Its params map is
+// always empty in a snapshot, but auto-trait derivation looks at the field
+// type, not the runtime value, so `ContBarrier` is only `Send` if `Param`
+// is.
 #[cfg(not(feature = "async"))]
-type Param<'a> = &'a mut dyn Any;
+type Param<'a> = &'a mut (dyn Any + Send);
 
 /// A continuation barrier. Escape procedures created within a continuation
 /// barrier cannot be called within another barrier.
@@ -969,17 +1009,42 @@ pub struct ContBarrier<'a> {
     params: HashMap<Symbol, Param<'a>>,
 }
 
+fn fresh_barrier_id() -> usize {
+    static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+    NEXT_ID.fetch_add(1, Ordering::Relaxed)
+}
+
 impl<'a> ContBarrier<'a> {
     pub fn new() -> Self {
-        static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
-
         Self {
-            id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
+            id: fresh_barrier_id(),
             dyn_stack: Vec::new(),
             // Procedures returned by the JIT compiler are delimited
             // continuations (of sorts), and therefore we need to preallocate
             // the initial marks for them since there's no mechanism to allocate
             // for them when they're run.
+            cont_marks: vec![HashMap::new()],
+            params: HashMap::new(),
+        }
+    }
+
+    /// A snapshot of this barrier's dynamic state for a spawned thread,
+    /// task, or future: current ports carry over (ambient configuration),
+    /// winders/exception handlers/prompts do not (they belong to this
+    /// barrier's own escape/unwind stack and a spawn is a new dynamic
+    /// extent), continuation marks start fresh, and params start empty (a
+    /// spawned computation does not inherit host parameters bound via
+    /// [`add_param`](Self::add_param)). Fresh id, since the spawned
+    /// computation is not nested inside this barrier's escape scope.
+    pub fn spawn_snapshot(&self) -> ContBarrier<'static> {
+        ContBarrier {
+            id: fresh_barrier_id(),
+            dyn_stack: self
+                .dyn_stack
+                .iter()
+                .filter(|elem| elem.crosses_spawn())
+                .cloned()
+                .collect(),
             cont_marks: vec![HashMap::new()],
             params: HashMap::new(),
         }
@@ -997,7 +1062,7 @@ impl<'a> ContBarrier<'a> {
         &mut self,
         key: impl Into<Symbol>,
         #[cfg(feature = "async")] val: &'a mut (impl Any + Send + Sync),
-        #[cfg(not(feature = "async"))] val: &'a mut impl Any,
+        #[cfg(not(feature = "async"))] val: &'a mut (impl Any + Send),
     ) {
         self.params.insert(key.into(), val);
     }
@@ -1046,12 +1111,44 @@ impl<'a> ContBarrier<'a> {
         (params, child_barrier)
     }
 
+    /// Swaps in a fresh id for the duration of a Rust-mediated re-entry
+    /// into Scheme, returning the previous one to be restored via
+    /// [`restore_id`](Self::restore_id) once that call returns.
+    ///
+    /// Threading the caller's barrier through re-entry (see
+    /// [`Procedure::call`]) shares its `dyn_stack`/`cont_marks`/`params` on
+    /// purpose - that's the whole point, e.g. a hashtable hash function
+    /// should see the caller's exception handlers. But `id` guards escape
+    /// procedures against jumping across a Rust re-entry frame, and that
+    /// guard only works if each such frame gets its own id: reusing the
+    /// caller's id verbatim would make a continuation captured outside the
+    /// call look like it belongs to the same barrier as code running
+    /// inside it, defeating the check the barrier exists for.
+    pub(crate) fn swap_fresh_id(&mut self) -> usize {
+        std::mem::replace(&mut self.id, fresh_barrier_id())
+    }
+
+    pub(crate) fn restore_id(&mut self, id: usize) {
+        self.id = id;
+    }
+
     pub(crate) fn push_marks(&mut self) {
         self.cont_marks.push(HashMap::new());
     }
 
     pub(crate) fn pop_marks(&mut self) {
         self.cont_marks.pop();
+    }
+
+    pub(crate) fn marks_depth(&self) -> usize {
+        self.cont_marks.len()
+    }
+
+    /// Truncate continuation marks back to `depth`, discarding frames left
+    /// behind by pending continuations when the trampoline exits early
+    /// (halt_err). No-op on balanced exits.
+    pub(crate) fn truncate_marks(&mut self, depth: usize) {
+        self.cont_marks.truncate(depth);
     }
 
     pub(crate) fn current_marks(&self, tag: Symbol) -> Vec<Value> {
@@ -1161,6 +1258,68 @@ where
     }
 }
 
+/// A type-erased `&mut ContBarrier` for `dyn Fn` trait-object boundaries
+/// that cannot carry the barrier's `'a` (host-parameter) lifetime as an
+/// ordinary higher-ranked type parameter.
+///
+/// Custom port procedures (`ReadFn`/`WriteFn`/`GetPosFn`/`SetPosFn`/
+/// `CloseFn` in `ports.rs`) are `Box<dyn Fn(..)>` closures stored on a
+/// long-lived `Port`, called repeatedly over the port's lifetime with a
+/// different barrier borrow each time. The natural signature for that,
+/// `dyn for<'a> Fn(.., &'a mut ContBarrier<'a>)`, does not work: as soon as
+/// another argument shares the trait object's higher-ranked lifetime (the
+/// underlying reader/writer, threaded through as `&dyn Any`, or the async
+/// variants' `BoxFuture<'a, _>` return type), the compiler either can't
+/// prove the closure body's captures outlive that lifetime, or (if it can)
+/// pins the barrier borrow to that same lifetime for the rest of the
+/// enclosing scope, so a second call through the same closure with a
+/// reborrowed barrier is rejected as a double mutable borrow (`E0499`).
+/// Giving the barrier its own, unrelated higher-ranked lifetime sidesteps
+/// the double-borrow but then the async closures don't type-check at all
+/// (`&mut ContBarrier` would need to outlive the returned future without
+/// any way to say so in a bare `dyn Fn` type). Confirmed with a minimal
+/// repro against both the sync and async (`BoxFuture`) shapes before
+/// reaching for this.
+///
+/// `ErasedBarrier` breaks the coupling by hiding the lifetime behind a raw
+/// pointer: the closure signature takes `&mut ErasedBarrier` (no lifetime
+/// parameter to unify with anything), and the closure body calls
+/// [`get`](Self::get) to recover a `&mut ContBarrier<'_>` scoped to that
+/// call only.
+///
+/// SAFETY: sound as long as an `ErasedBarrier` is never used after the
+/// `ContBarrier` it was constructed from goes out of scope or is otherwise
+/// invalidated. Every call site in this crate constructs one immediately
+/// before passing it into a port closure and drops it right after that
+/// call returns, so this holds by construction.
+///
+/// The struct itself has to be `pub`, not `pub(crate)`: it appears in the
+/// signature of `ReadFn`/`WriteFn`/etc., which are part of the public
+/// `IntoPort` trait embedders implement for their own reader/writer types.
+/// `new` and `get` stay `pub(crate)` though, so an embedder's `read_fn`/
+/// `write_fn`/etc. can only accept-and-ignore the parameter, never
+/// construct or dereference one - the unsafety is confined to this crate.
+#[derive(Clone, Copy)]
+pub struct ErasedBarrier(*mut ());
+
+impl ErasedBarrier {
+    pub(crate) fn new(barrier: &mut ContBarrier<'_>) -> Self {
+        Self(barrier as *mut ContBarrier<'_> as *mut ())
+    }
+
+    pub(crate) fn get(&mut self) -> &mut ContBarrier<'_> {
+        unsafe { &mut *(self.0 as *mut ContBarrier<'_>) }
+    }
+}
+
+// SAFETY: the pointee is only ever accessed through `get`, for the
+// duration of a single call, from the same thread/task that created the
+// `ErasedBarrier` (it is never sent across an await point or a thread
+// boundary itself - only the `ContBarrier` snapshot obtained from
+// `spawn_snapshot` crosses those, and that's a distinct, owned value).
+unsafe impl Send for ErasedBarrier {}
+unsafe impl Sync for ErasedBarrier {}
+
 /// A copy of [`ContBarrier`] without mutable parameters
 #[derive(Clone, Debug, Trace)]
 pub struct SavedDynamicState {
@@ -1211,6 +1370,23 @@ pub(crate) enum DynStackElem {
     ExceptionHandler(Procedure),
     CurrentInputPort(Port),
     CurrentOutputPort(Port),
+}
+
+impl DynStackElem {
+    /// Whether this entry survives a spawn (thread, task, or future): the
+    /// spawned computation is a new dynamic extent, so winders, exception
+    /// handlers, and prompts must not carry over, but current ports are
+    /// just ambient configuration, so they do. Exhaustive match so adding a
+    /// variant forces an explicit decision here.
+    fn crosses_spawn(&self) -> bool {
+        match self {
+            DynStackElem::CurrentInputPort(_) | DynStackElem::CurrentOutputPort(_) => true,
+            DynStackElem::Prompt(_)
+            | DynStackElem::PromptBarrier(_)
+            | DynStackElem::Winder(_)
+            | DynStackElem::ExceptionHandler(_) => false,
+        }
+    }
 }
 
 pub(crate) unsafe extern "C" fn pop_dyn_stack(
@@ -1306,8 +1482,20 @@ fn escape_procedure(
         .unwrap();
     let saved_barrier_read = saved_barrier.as_ref();
 
+    // Cross-barrier escape must halt this trampoline (halt_err) instead of
+    // raising through the exception-handler search. Barrier re-entry now
+    // shares dyn_stack/cont_marks with the caller (see Procedure::call), so
+    // raising here would find a handler belonging to an ancestor
+    // evaluation (e.g. guard's), whose own escape continuation also has to
+    // cross this same barrier to deliver the catch - causing a second
+    // rejection with no handler left to catch that one. Halting instead
+    // unwinds this call as a plain Err, and the exception-handler search
+    // happens once the caller (with its own, restored barrier id) converts
+    // that Err into a raise.
     if saved_barrier_read.id != barrier.id {
-        return Err(Exception::error("attempt to cross continuation barrier"));
+        return Ok(Application::halt_err(Value::from(Exception::error(
+            "attempt to cross continuation barrier",
+        ))));
     }
 
     barrier.cont_marks = saved_barrier_read.cont_marks.clone();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -94,6 +94,10 @@ impl Runtime {
         let progm = TopLevelEnvironment::new_program(self, path);
         let env = Environment::Top(progm.clone());
 
+        // Top-level entry: genuinely fresh dynamic state, threaded through
+        // reading the source, compilation, and evaluation.
+        let mut barrier = ContBarrier::default();
+
         let mut form = {
             let port = Port::new(
                 path.display(),
@@ -103,7 +107,7 @@ impl Runtime {
             );
             let file_name = path.file_name().unwrap().to_str().unwrap_or("<unknown>");
             let span = Span::new(file_name);
-            maybe_await!(port.all_sexprs(span)).map_err(Exception::from)?
+            maybe_await!(port.all_sexprs(span, &mut barrier)).map_err(Exception::from)?
         };
 
         form.add_scope(progm.scope());
@@ -128,10 +132,11 @@ impl Runtime {
             self,
             &form,
             &env,
-            &mut mutable_vars
+            &mut mutable_vars,
+            &mut barrier
         ))?;
         let proc = maybe_await!(Compiler::new(mutable_vars).compile(self, &body))?;
-        maybe_await!(Application::new(proc, None, Vec::new()).eval(&mut ContBarrier::default()))
+        maybe_await!(Application::new(proc, None, Vec::new()).eval(&mut barrier))
     }
 
     /// Define a library from Rust code. Useful if file system access is disabled.

--- a/src/syntax/lex.rs
+++ b/src/syntax/lex.rs
@@ -14,6 +14,7 @@ use crate::{
     exceptions::Exception,
     num::{self, NumberRepr, SimpleNumber},
     ports::{PortData, PortInfo},
+    proc::ErasedBarrier,
 };
 
 pub struct Lexer<'a> {
@@ -22,16 +23,26 @@ pub struct Lexer<'a> {
     pos: usize,
     buff: Vec<char>,
     curr_span: Span,
+    // Only `peek` and `consume_chars` below actually touch the port, so the
+    // barrier is stashed here once at construction rather than threaded
+    // through every one of the lexer's methods.
+    barrier: ErasedBarrier,
 }
 
 impl<'a> Lexer<'a> {
-    pub(crate) fn new(port_data: &'a mut PortData, port_info: &'a PortInfo, span: Span) -> Self {
+    pub(crate) fn new(
+        port_data: &'a mut PortData,
+        port_info: &'a PortInfo,
+        span: Span,
+        barrier: ErasedBarrier,
+    ) -> Self {
         Self {
             port_data,
             port_info,
             pos: 0,
             buff: Vec::new(),
             curr_span: span,
+            barrier,
         }
     }
 
@@ -50,12 +61,13 @@ impl<'a> Lexer<'a> {
             return Ok(Some(self.buff[self.pos]));
         }
         while self.buff.len() < self.pos {
-            let Some(chr) = maybe_await!(self.port_data.read_char(self.port_info))? else {
+            let Some(chr) = maybe_await!(self.port_data.read_char(self.port_info, self.barrier))?
+            else {
                 return Ok(None);
             };
             self.buff.push(chr);
         }
-        maybe_await!(self.port_data.peekn_chars(self.port_info, 0))
+        maybe_await!(self.port_data.peekn_chars(self.port_info, 0, self.barrier))
     }
 
     #[maybe_async]
@@ -121,10 +133,11 @@ impl<'a> Lexer<'a> {
     fn consume_chars(&mut self) -> Result<(), Exception> {
         // Consume all the characters we need to
         if self.pos > self.buff.len() {
-            maybe_await!(
-                self.port_data
-                    .consume_chars(self.port_info, self.pos - self.buff.len())
-            )?;
+            maybe_await!(self.port_data.consume_chars(
+                self.port_info,
+                self.pos - self.buff.len(),
+                self.barrier
+            ))?;
         }
         self.pos = 0;
         self.buff.clear();

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -26,6 +26,9 @@ use std::{
 #[cfg(feature = "async")]
 use futures::future::BoxFuture;
 
+#[cfg(feature = "async")]
+use crate::proc::ErasedBarrier;
+
 pub mod lex;
 pub mod parse;
 
@@ -277,7 +280,11 @@ impl Syntax {
     }
 
     #[maybe_async]
-    fn apply_transformer(&self, transformer: &Procedure) -> Result<Expansion, Exception> {
+    fn apply_transformer(
+        &self,
+        transformer: &Procedure,
+        barrier: &mut ContBarrier<'_>,
+    ) -> Result<Expansion, Exception> {
         // Create a new scope for the expansion
         let intro_scope = Scope::new();
 
@@ -286,8 +293,7 @@ impl Syntax {
         input.add_scope(intro_scope);
 
         // Call the transformer with the input:
-        let transformer_output =
-            maybe_await!(transformer.call(&[Value::from(input)], &mut ContBarrier::new()))?;
+        let transformer_output = maybe_await!(transformer.call(&[Value::from(input)], barrier))?;
 
         let output: Value = transformer_output.expect1()?;
         let mut output = Syntax::wrap(output, self.span());
@@ -297,20 +303,29 @@ impl Syntax {
     }
 
     #[cfg(not(feature = "async"))]
-    fn expand_once(&self, env: &Environment) -> Result<Expansion, Exception> {
-        self.expand_once_inner(env)
+    fn expand_once(
+        &self,
+        env: &Environment,
+        barrier: &mut ContBarrier<'_>,
+    ) -> Result<Expansion, Exception> {
+        self.expand_once_inner(env, barrier)
     }
 
     #[cfg(feature = "async")]
     fn expand_once<'a>(
         &'a self,
         env: &'a Environment,
+        barrier: &'a mut ContBarrier<'_>,
     ) -> BoxFuture<'a, Result<Expansion, Exception>> {
-        Box::pin(self.expand_once_inner(env))
+        Box::pin(self.expand_once_inner(env, barrier))
     }
 
     #[maybe_async]
-    fn expand_once_inner(&self, env: &Environment) -> Result<Expansion, Exception> {
+    fn expand_once_inner(
+        &self,
+        env: &Environment,
+        barrier: &mut ContBarrier<'_>,
+    ) -> Result<Expansion, Exception> {
         match self {
             Self::List { list, .. } => {
                 let ident = match list.first() {
@@ -319,7 +334,7 @@ impl Syntax {
                 };
                 if let Some(binding) = ident.resolve() {
                     if let Some(transformer) = maybe_await!(env.lookup_keyword(binding))? {
-                        return maybe_await!(self.apply_transformer(&transformer));
+                        return maybe_await!(self.apply_transformer(&transformer, barrier));
                     } else if let Some(Primitive::Set) = env.lookup_primitive(binding)
                         && let [Syntax::Identifier { ident, .. }, ..] = &list.as_slice()[1..]
                     {
@@ -334,7 +349,7 @@ impl Syntax {
                                     ident.sym
                                 )));
                             }
-                            return maybe_await!(self.apply_transformer(&transformer));
+                            return maybe_await!(self.apply_transformer(&transformer, barrier));
                         }
                     }
                 }
@@ -343,7 +358,7 @@ impl Syntax {
                 if let Some(binding) = ident.resolve()
                     && let Some(transformer) = maybe_await!(env.lookup_keyword(binding))?
                 {
-                    return maybe_await!(self.apply_transformer(&transformer));
+                    return maybe_await!(self.apply_transformer(&transformer, barrier));
                 }
             }
             _ => (),
@@ -353,9 +368,13 @@ impl Syntax {
 
     /// Fully expand the outermost syntax object.
     #[maybe_async]
-    pub(crate) fn expand(mut self, env: &Environment) -> Result<Syntax, Exception> {
+    pub(crate) fn expand(
+        mut self,
+        env: &Environment,
+        barrier: &mut ContBarrier<'_>,
+    ) -> Result<Syntax, Exception> {
         loop {
-            match maybe_await!(self.expand_once(env)) {
+            match maybe_await!(self.expand_once(env, barrier)) {
                 Ok(Expansion::Unexpanded) => {
                     return Ok(self);
                 }
@@ -381,7 +400,11 @@ impl Syntax {
             BufferMode::Block,
             Some(Transcoder::native()),
         );
-        port.all_sexprs(Span::new(file_name))
+        // The port is a fresh in-memory Cursor: its read/write closures are
+        // native and ignore the barrier entirely, so there is no re-entry
+        // into Scheme possible here, and a fresh barrier is correct (not
+        // just expedient).
+        port.all_sexprs(Span::new(file_name), &mut ContBarrier::new())
     }
 
     #[cfg(feature = "async")]
@@ -407,7 +430,11 @@ impl Syntax {
         futures::executor::block_on(async move {
             use crate::syntax::parse::Parser;
 
-            let mut parser = Parser::new(&mut data, info, Span::new(file_name));
+            // Same reasoning as the sync variant above: a fresh in-memory
+            // Cursor port can't re-enter Scheme, so a fresh barrier is fine.
+            let mut barrier = ContBarrier::new();
+            let erased = ErasedBarrier::new(&mut barrier);
+            let mut parser = Parser::new(&mut data, info, Span::new(file_name), erased);
             parser.all_sexprs().await
         })
     }

--- a/src/syntax/parse.rs
+++ b/src/syntax/parse.rs
@@ -2,6 +2,7 @@ use crate::{
     keywords::Keyword,
     num::Number,
     ports::{PortData, PortInfo},
+    proc::ErasedBarrier,
     syntax::lex::ParseNumberError,
     value::Value,
 };
@@ -40,10 +41,15 @@ macro_rules! token {
 }
 
 impl<'a> Parser<'a> {
-    pub(crate) fn new(port_data: &'a mut PortData, port_info: &'a PortInfo, span: Span) -> Self {
+    pub(crate) fn new(
+        port_data: &'a mut PortData,
+        port_info: &'a PortInfo,
+        span: Span,
+        barrier: ErasedBarrier,
+    ) -> Self {
         Parser {
             lookahead: Vec::new(),
-            lexer: Lexer::new(port_data, port_info, span),
+            lexer: Lexer::new(port_data, port_info, span, barrier),
         }
     }
 }

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -13,8 +13,10 @@ use scheme_rs_macros::bridge;
 use crate::{
     exceptions::Exception,
     gc::{Gc, Trace},
-    proc::{ContBarrier, Procedure},
+    proc::{Application, ContBarrier, Procedure},
     records::{Embeddable, Embedded, RecordTypeDescriptor, rtd},
+    registry::cps_bridge,
+    runtime::Runtime,
     value::Value,
 };
 
@@ -37,8 +39,20 @@ unsafe impl Embeddable for JoinHandle {
     }
 }
 
-#[bridge(name = "spawn", lib = "(threads (1))")]
-pub fn spawn(thunk: Procedure) -> Result<Vec<Value>, Exception> {
+// An OS thread is a new dynamic extent, so it gets a spawn snapshot rather
+// than the caller's barrier: promoted from `#[bridge]` to `#[cps_bridge]`
+// to reach it.
+#[cps_bridge(def = "spawn thunk", lib = "(threads (1))")]
+pub fn spawn(
+    _runtime: &Runtime,
+    _env: &[Value],
+    k: Procedure,
+    args: &[Value],
+    _rest_args: &[Value],
+    barrier: &mut ContBarrier<'_>,
+) -> Result<Application, Exception> {
+    let thunk: Procedure = args[0].clone().try_into()?;
+    let mut snapshot = barrier.spawn_snapshot();
     let cell = Gc::new(Mutex::new(Ok(Vec::new())));
     let cell_cloned = cell.clone();
     let join_handle = thread::spawn(move || {
@@ -46,16 +60,20 @@ pub fn spawn(thunk: Procedure) -> Result<Vec<Value>, Exception> {
 
         #[cfg(not(feature = "async"))]
         {
-            *cell_write = thunk.call(&[], &mut ContBarrier::new());
+            *cell_write = thunk.call(&[], &mut snapshot);
         }
 
         #[cfg(feature = "async")]
         {
-            *cell_write = thunk.call_sync(&[], &mut ContBarrier::new());
+            *cell_write = thunk.call_sync(&[], &mut snapshot);
         }
     });
     let id = join_handle.thread().id();
-    Ok(vec![Value::from(JoinHandle { id, result: cell })])
+    Ok(Application::new(
+        k,
+        None,
+        vec![Value::from(JoinHandle { id, result: cell })],
+    ))
 }
 
 #[bridge(name = "join", lib = "(threads (1))")]

--- a/tests/dynamic_state_inheritance.rs
+++ b/tests/dynamic_state_inheritance.rs
@@ -1,0 +1,3 @@
+mod common;
+
+common::run_test!(dynamic_state_inheritance);

--- a/tests/dynamic_state_inheritance.scm
+++ b/tests/dynamic_state_inheritance.scm
@@ -1,0 +1,44 @@
+(import (rnrs) (test) (threads (1)))
+
+;; 1. A hashtable hash function must observe the exception handler installed
+;; by its caller. Without threading the caller's barrier through, the hash
+;; function runs against a fresh, empty barrier, so raise-continuable finds
+;; no handler and the operation fails; the guard below would then produce
+;; 'no-handler-seen.
+(define ht
+  (make-hashtable
+   (lambda (k) (raise-continuable 'need-hash))
+   eq?))
+
+(define handler-result
+  (guard (e (#t 'no-handler-seen))
+    (with-exception-handler
+      (lambda (c) 42)
+      (lambda ()
+        (hashtable-set! ht 'a 1)
+        (hashtable-ref ht 'a #f)))))
+
+(assert-equal? handler-result 1)
+
+;; 2. Escape procedures still cannot cross the Rust re-entry frame. The
+;; fresh barrier id at the callback boundary must keep rejecting jumps.
+(assert-equal?
+ (call/cc
+  (lambda (k)
+    (let ((ht2 (make-hashtable (lambda (key) (k 'escaped)) eq?)))
+      (guard (e (#t 'blocked))
+        (hashtable-set! ht2 'x 1)
+        'not-blocked))))
+ 'blocked)
+
+;; 3. A spawned thread must not run the parent's winders. Each parent
+;; winder fires exactly once, from the parent.
+(define order '())
+(dynamic-wind
+    (lambda () (set! order (cons 'in order)))
+    (lambda ()
+      (join (spawn (lambda ()
+                     (guard (e (#t 'caught))
+                       (error 'child "boom"))))))
+    (lambda () (set! order (cons 'out order))))
+(assert-equal? order '(out in))


### PR DESCRIPTION
Third alternative to #319 and #323 for the same problem: a hashtable hash
function, a custom port callback, etc. currently run against a fresh, empty
`ContBarrier` instead of observing the caller's dynamic state.

Rationale: no thread-locals, no task-locals, no ambient state anywhere.
`ContBarrier` stays exactly as it is today (id + dyn_stack + cont_marks +
params); every re-entry site just gets handed the caller's barrier instead
of building `ContBarrier::new()`. If it compiles, the barrier reached that
call correctly - there's no separate ambient-publication step that could be
missing or stale.

## What changed

- `Procedure::call`/`call_sync` (the one place every re-entry - hashtable
  callbacks, port procedures, macro transformers, `eval` - already funnels
  through) swap in a fresh id for the call's duration and restore the
  caller's id after, so escape procedures still can't cross a Rust re-entry
  frame even though dyn_stack/cont_marks/params are now shared.
- `escape_procedure`'s cross-barrier rejection halts its own trampoline
  (`halt_err`) instead of raising through the exception-handler search, for
  the same reason as in #323: raising would find a handler belonging to an
  ancestor evaluation (e.g. `guard`'s) whose own escape continuation also
  has to cross this barrier to deliver the catch.
- `spawn_snapshot()` on `ContBarrier`, same `crosses_spawn` classification
  as #319/#323: current ports cross a spawn, winders/handlers/prompts don't,
  marks and params start fresh.
- Hashtables, futures/threads spawn, and the compiler/expander pipeline
  (`Expression::parse` and everything that calls it - `Let`, `Lambda`,
  `Body`, `SyntaxCase`, `define_syntax`, ...) now take a barrier parameter
  and pass it down. `#[bridge]` functions that reach a hashtable or port
  callback moved to `#[cps_bridge]` to get one.
- Ports: `ReadFn`/`WriteFn`/`GetPosFn`/`SetPosFn`/`CloseFn` closures take an
  `ErasedBarrier` - see below.
- `dynamic_state_inheritance` test ported from #319/#323.

## The hard parts

**Port closures.** `ReadFn` et al. are `Box<dyn Fn(..)>` stored on a
long-lived `Port`, called repeatedly with a different barrier borrow each
time. The natural signature, `dyn for<'a> Fn(.., &'a mut ContBarrier<'a>)`,
does not work - confirmed with a minimal repro before touching the real
code:

- If the barrier's `'a` is unified with another argument's lifetime (the
  underlying reader/writer, or the async variants' `BoxFuture<'a, _>`
  return type), the compiler pins the barrier borrow to that lifetime for
  the rest of the enclosing scope. A second call through the same closure
  with a reborrowed barrier is then rejected as a double mutable borrow
  (`E0499`).
- Giving the barrier its own, independent higher-ranked lifetime sidesteps
  that, but then the async closures don't type-check at all: the future
  would need to capture a reference outliving its own declared bound with
  no way to say so in a bare `dyn Fn` type.

Fix: `ErasedBarrier`, a `Copy` raw-pointer newtype with `pub(crate)`
`new`/`get`. Closures take it in place of `ContBarrier`; `get()` recovers a
real `&mut ContBarrier<'_>` scoped to one call. Cost: it has to be `pub`
(not `pub(crate)`) because it appears in `ReadFn`'s signature, which is part
of the public `IntoPort` trait embedders implement - so the unsafe
lifetime-erasure trick is now visible, if inert, in the public API.

Once the closure boundary was erased, threading it further in was the path
of least resistance: `BinaryPortData`, `CustomTextualPortData` (which calls
`Procedure::call` directly, no closure involved, but shares the dispatch
enum with the one that does), `PortData`, and the `Decoder`/`transcode`
iterator/stream all take `ErasedBarrier` internally, converting to a real
barrier only where they touch `Procedure::call`. `Port`'s own public
methods take a real `&mut ContBarrier<'_>` and erase it once at that
boundary, since that's the natural type for their callers (bridges).

**Compiler/expander pipeline.** Fully tractable, no shortcuts, but a wide
diff: ~35 function signatures across `ast.rs`/`syntax/mod.rs`/`expand.rs`
gained a `barrier` parameter, because `Expression::parse` sits at the
center of the whole recursive-descent AST builder and macro expansion
(`Syntax::expand`) is called from inside it.

**Sites left on a fresh barrier, deliberately.** `Syntax::from_str` (both
variants) and `string->number` build a `Port` over an in-memory `Cursor`;
the REPL's input loop reads through the readline-backed `Prompt`. None of
these can ever re-enter Scheme (their read closures are native and ignore
the barrier), so `ContBarrier::new()` there is correct, not a shortcut.

## Signature-change count

~140 named `barrier` parameters added across ~120 distinct functions/
methods (some counted per sync/async cfg variant), plus a handful of
closures (`proc_to_*_fn`) and two structs (`Lexer`, `Decoder`) that stash a
barrier/`ErasedBarrier` as a field instead of a parameter.

## Diff size vs #323

+1549/-568 (2117 total) vs #323's +671/-385 (1056 total) - roughly 2x. Pure
threading has no shared infrastructure to amortize the cost across call
sites the way ambient publication does; every one of the ~140 signatures
above is a place #323 didn't have to touch.

## Verification

`cargo build`/`test`/`clippy -- -D warnings`/`fmt --check`, default and
`--features async,tokio`, all green.

Happy to reshape or drop pieces if a hybrid of these three approaches looks
better once you've seen all three.