### PR TITLE
Spike: single runtime image for plugins (Guile-style linkage)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,7 @@
+# Link the scheme-rs runtime dynamically so there is exactly one runtime
+# image per process (Guile's libguile model). Plugins are dlopened cdylibs;
+# with static linkage they would embed a second heap, collector and set of
+# statics. This config also applies to tests/test-plugin, which sits below
+# this directory.
+[build]
+rustflags = ["-C", "prefer-dynamic"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+/dist

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,12 @@ plugins = ["dep:libloading"]
 [profile.release]
 lto = true
 
+# Profile for packaged, relocatable builds (scripts/package.sh). LTO cannot
+# be combined with dynamic linking of the runtime dylib.
+[profile.dist]
+inherits = "release"
+lto = false
+
 [build-dependencies]
 nom = "7"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,20 @@ documentation = "https://docs.rs/crate/scheme-rs"
 homepage = "https://github.com/maplant/scheme-rs"
 repository = "https://github.com/maplant/scheme-rs"
 
+# There must be exactly one scheme-rs runtime image per process (like Guile's
+# libguile). Building a dylib alongside the rlib lets plugins and host
+# binaries link the runtime dynamically (see .cargo/config.toml), so a
+# plugin's dlopen resolves to the image already loaded in the host.
+[lib]
+crate-type = ["rlib", "dylib"]
+
+# test-plugin must be a workspace member: plugin and host have to agree on
+# the exact scheme-rs build (one resolver, one lockfile, one feature
+# unification), otherwise the plugin links runtime symbols that do not exist
+# in the image the host has already loaded.
+[workspace]
+members = ["proc-macros", "tests/test-plugin"]
+
 [dependencies]
 arc-swap = "1"
 async-stream = { version = "0.3", optional = true }

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Packages scheme-rs as a self-contained, relocatable bundle (the
+# Guile/libpython shipping model): the interpreter binary plus the shared
+# runtime image it links against.
+#
+#   dist/
+#     scheme-rs             the interpreter; resolves its libraries relative
+#                           to itself via @executable_path
+#     libscheme_rs.dylib    the runtime image (install name
+#                           @rpath/libscheme_rs.dylib)
+#     libstd-*.dylib        Rust's standard library. Shared on purpose: a
+#                           static libstd inside the runtime dylib plus
+#                           another inside a plugin would recreate the
+#                           dual-image problem one level down.
+#     libtest_plugin.dylib  the test plugin, built in the same cargo
+#                           invocation so it links the exact same runtime
+#
+# Plugins dlopened by the packaged binary reference
+# @rpath/libscheme_rs.dylib and @rpath/libstd-*.dylib; dyld matches those
+# against the images the host has already loaded, so the process holds
+# exactly one runtime image. load_plugin's identity canary rejects anything
+# else.
+set -euo pipefail
+
+if [[ "$(uname)" != "Darwin" ]]; then
+    echo "package.sh: only macOS is implemented so far" >&2
+    exit 1
+fi
+
+cd "$(dirname "$0")/.."
+
+# Host binary and plugin must agree on the exact scheme-rs build (symbol
+# names include the crate disambiguator), so build both in one invocation.
+cargo build --profile dist -p scheme-rs -p test-plugin --all-features
+
+target=target/dist
+dist=dist
+rm -rf "$dist"
+mkdir -p "$dist"
+
+cp "$target/scheme-rs" "$dist/"
+cp "$target/deps/libscheme_rs.dylib" "$dist/"
+cp "$target/deps/libtest_plugin.dylib" "$dist/"
+cp "$(rustc --print target-libdir)"/libstd-*.dylib "$dist/"
+
+# rustc records the runtime dylib's absolute build path as its install name;
+# rewrite everything to @rpath so the bundle is relocatable and can never
+# resolve back into the build tree.
+build_path=$(otool -D "$dist/libscheme_rs.dylib" | tail -1)
+install_name_tool -id @rpath/libscheme_rs.dylib "$dist/libscheme_rs.dylib"
+install_name_tool -id @rpath/libtest_plugin.dylib "$dist/libtest_plugin.dylib"
+install_name_tool -change "$build_path" @rpath/libscheme_rs.dylib "$dist/scheme-rs"
+install_name_tool -change "$build_path" @rpath/libscheme_rs.dylib "$dist/libtest_plugin.dylib"
+install_name_tool -add_rpath @executable_path "$dist/scheme-rs"
+install_name_tool -add_rpath @loader_path "$dist/libscheme_rs.dylib"
+install_name_tool -add_rpath @loader_path "$dist/libtest_plugin.dylib"
+
+# install_name_tool invalidates code signatures; re-sign ad hoc.
+for f in "$dist/scheme-rs" "$dist"/*.dylib; do
+    codesign --force --sign - "$f"
+done
+
+echo "packaged into $dist/"

--- a/src/records.rs
+++ b/src/records.rs
@@ -212,7 +212,7 @@
 
 use std::{
     alloc::{self, Layout},
-    any::{Any, TypeId},
+    any::Any,
     collections::HashMap,
     fmt,
     hash::{Hash, Hasher},
@@ -412,14 +412,17 @@ impl Record {
         let embedded_ptr = self.0.embedded_ptr()?;
         let embedded_vtable = self.0.rtd.embedded_vtable.as_ref()?;
 
-        if TypeId::of::<E>() == embedded_vtable.type_id {
+        let rtd = E::rtd();
+        // Type identity is the runtime-registered record type descriptor, not
+        // the compile-time TypeId. `Embeddable::rtd` memoizes its descriptor,
+        // so pointer equality identifies the embedded type.
+        if Arc::ptr_eq(&(embedded_vtable.rtd)(), &rtd) {
             return Some(Embedded::from_raw_parts(
                 NonNull::new(embedded_ptr as *mut E).unwrap(),
                 self.clone(),
             ));
         }
 
-        let rtd = E::rtd();
         let mut embedded = embedded_vtable.ptr_to_parent(embedded_ptr, &rtd)?;
         while let Some(parent) = embedded.parent_record(&rtd) {
             embedded = parent;
@@ -694,7 +697,9 @@ unsafe impl Trace for RecordInner {
 /// scheme records. Those layouts are stored in the RTD.
 pub unsafe trait Embeddable: Trace + Any + Send + Sync {
     /// The Record Type Descriptor of the value. Can be constructed at runtime,
-    /// but cannot change.
+    /// but cannot change. Must return clones of a single memoized [`Arc`] (as
+    /// the [`rtd!`](crate::records::rtd) macro does); the descriptor's address
+    /// is the runtime identity of the type.
     fn rtd() -> Arc<RecordTypeDescriptor>
     where
         Self: Sized;
@@ -782,8 +787,10 @@ pub unsafe trait Embeddable: Trace + Any + Send + Sync {
 // TODO: add trace(skip_all) attribute
 #[derive(Copy, Clone, Trace)]
 pub struct EmbeddableVTable {
+    /// Returns the record type descriptor of the embedded type. Serves as the
+    /// runtime identity of the type; see [`EmbeddableVTable::same_embedded_type`].
     #[trace(skip)]
-    pub type_id: TypeId,
+    pub rtd: fn() -> Arc<RecordTypeDescriptor>,
     #[trace(skip)]
     layout: Layout,
     pub embedded_fields: usize,
@@ -820,7 +827,7 @@ pub struct EmbeddableVTable {
 impl EmbeddableVTable {
     pub const fn new<E: Embeddable>(embedded_fields: usize) -> Self {
         Self {
-            type_id: TypeId::of::<E>(),
+            rtd: E::rtd,
             layout: Layout::new::<E>(),
             embedded_fields,
             visit_children: |this, visitor| unsafe {
@@ -864,6 +871,12 @@ impl EmbeddableVTable {
         rtd: &Arc<RecordTypeDescriptor>,
     ) -> Option<&dyn Embeddable> {
         (self.parent_record)(ptr, rtd).and_then(|ptr| unsafe { ptr.as_ref() })
+    }
+
+    /// Whether two vtables describe the same embedded Rust type, determined by
+    /// the identity of their runtime record type descriptors.
+    pub fn same_embedded_type(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&(self.rtd)(), &(other.rtd)())
     }
 }
 
@@ -1560,7 +1573,7 @@ fn record_accessor_fn(
         // The field lives inside the embedded Rust value.
         let embedded_ptr = record.0.embedded_ptr().unwrap();
         let embedded_vtable = record.0.rtd.embedded_vtable.as_ref().unwrap();
-        if rtd.embedded_vtable.unwrap().type_id == embedded_vtable.type_id {
+        if rtd.embedded_vtable.unwrap().same_embedded_type(embedded_vtable) {
             (embedded_vtable.get_field)(embedded_ptr, local_idx)?
         } else {
             let mut embedded = embedded_vtable.ptr_to_parent(embedded_ptr, &rtd).unwrap();
@@ -1642,7 +1655,7 @@ fn record_mutator_fn(
         // The field lives inside the embedded Rust value.
         let embedded_ptr = record.0.embedded_ptr().unwrap();
         let embedded_vtable = record.0.rtd.embedded_vtable.as_ref().unwrap();
-        if rtd.embedded_vtable.unwrap().type_id == embedded_vtable.type_id {
+        if rtd.embedded_vtable.unwrap().same_embedded_type(embedded_vtable) {
             (embedded_vtable.set_field)(embedded_ptr, local_idx, new_val.clone())?;
         } else {
             let mut embedded = embedded_vtable.ptr_to_parent(embedded_ptr, &rtd).unwrap();

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -142,9 +142,12 @@ inventory::collect!(BridgeFn);
 #[cfg(feature = "plugins")]
 #[unsafe(no_mangle)]
 pub extern "C" fn scheme_rs_bridges() -> PluginBridges {
-    use std::sync::OnceLock;
-    static BRIDGES: OnceLock<Vec<BridgeFn>> = OnceLock::new();
-    let bridges = BRIDGES.get_or_init(|| inventory::iter::<BridgeFn>().copied().collect());
+    // Collected fresh (and leaked) on every call: with a single runtime image
+    // per process, each dlopened plugin appends its bridges to this shared
+    // inventory, so a memoized snapshot would hide plugins loaded after the
+    // first call. Plugin loads are rare, so the leak is bounded and small.
+    let bridges: &'static [BridgeFn] =
+        Box::leak(inventory::iter::<BridgeFn>().copied().collect::<Box<[_]>>());
     PluginBridges {
         version: SCHEME_RS_VERSION.as_ptr(),
         version_len: SCHEME_RS_VERSION.len(),

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -240,6 +240,13 @@ impl RegistryInner {
         }
 
         for (name, lib) in new_libs {
+            // First registration wins: a plugin's inventory contains every
+            // bridge of its scheme-rs image, and must not displace libraries
+            // the host has already registered (e.g. the bridge stdlib).
+            if self.libs.contains_key(&name) {
+                continue;
+            }
+
             let scope = Scope::new();
 
             let exports = lib

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -157,6 +157,22 @@ pub extern "C" fn scheme_rs_bridges() -> PluginBridges {
 pub static SCHEME_RS_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg(feature = "plugins")]
+static RUNTIME_IDENTITY: u8 = 0;
+
+/// Returns the address of a static inside this scheme-rs image.
+///
+/// There must be exactly one scheme-rs runtime image per process (one heap,
+/// one collector, one set of statics). Host and plugin each resolve this
+/// symbol within their own image; differing addresses mean the plugin
+/// statically embeds a second copy of the runtime and is rejected at load
+/// time.
+#[cfg(feature = "plugins")]
+#[unsafe(no_mangle)]
+pub extern "C" fn scheme_rs_runtime_identity() -> *const () {
+    std::ptr::from_ref(&RUNTIME_IDENTITY).cast()
+}
+
+#[cfg(feature = "plugins")]
 #[repr(C)]
 pub struct PluginBridges {
     pub version: *const u8,
@@ -418,6 +434,23 @@ impl Registry {
         rt: &Runtime,
         library: libloading::Library,
     ) -> Result<(), Exception> {
+        unsafe {
+            let identity: libloading::Symbol<extern "C" fn() -> *const ()> =
+                library.get(b"scheme_rs_runtime_identity").map_err(|e| {
+                    Exception::error(format!(
+                        "plugin does not export scheme_rs_runtime_identity: {e}"
+                    ))
+                })?;
+            if identity() != scheme_rs_runtime_identity() {
+                return Err(Exception::error(
+                    "plugin embeds its own copy of the scheme-rs runtime; plugins \
+                     must link scheme-rs dynamically (build with -C prefer-dynamic) \
+                     so host and plugin share a single runtime image"
+                        .to_string(),
+                ));
+            }
+        }
+
         let bridges: &[BridgeFn] = unsafe {
             let func: libloading::Symbol<extern "C" fn() -> PluginBridges> =
                 library.get(b"scheme_rs_bridges").map_err(|e| {

--- a/tests/plugins.rs
+++ b/tests/plugins.rs
@@ -5,12 +5,55 @@ mod common;
 #[cfg(feature = "plugins")]
 fn test_plugin_dylib_name() -> &'static str {
     if cfg!(target_os = "macos") {
-        "target/debug/libtest_plugin.dylib"
+        "libtest_plugin.dylib"
     } else if cfg!(target_os = "windows") {
-        "target/debug/test_plugin.dll"
+        "test_plugin.dll"
     } else {
-        "target/debug/libtest_plugin.so"
+        "libtest_plugin.so"
     }
+}
+
+/// Builds the test plugin and returns the path to its dylib.
+///
+/// The plugin must link the exact same scheme-rs image as this test binary,
+/// so its dlopen resolves the runtime to the image already loaded in this
+/// process; any other scheme-rs build is a second runtime image, which
+/// load_plugin rejects. Building via `cargo test` with both packages
+/// selected reproduces this suite's build exactly: same workspace, same
+/// profile, and same feature unification (dev-dependencies included).
+///
+/// Note: this assumes the suite itself runs with --all-features.
+#[cfg(feature = "plugins")]
+fn build_test_plugin() -> std::path::PathBuf {
+    use std::path::Path;
+    use std::process::Command;
+
+    let status = Command::new("cargo")
+        .args([
+            "test",
+            "-p",
+            "scheme-rs",
+            "-p",
+            "test-plugin",
+            "--all-features",
+            "--no-run",
+            "--quiet",
+        ])
+        .current_dir(Path::new(env!("CARGO_MANIFEST_DIR")))
+        .status()
+        .expect("failed to build test plugin");
+    assert!(status.success(), "test plugin build failed");
+
+    // <target>/debug/deps/plugins-<hash> -> <target>/debug/deps
+    let deps_dir = std::env::current_exe()
+        .expect("failed to locate test executable")
+        .parent()
+        .expect("unexpected test executable location")
+        .to_path_buf();
+
+    let dylib = deps_dir.join(test_plugin_dylib_name());
+    assert!(dylib.exists(), "test plugin dylib not found at {dylib:?}");
+    dylib
 }
 
 #[cfg(feature = "plugins")]
@@ -20,18 +63,8 @@ fn test_plugin_dylib_name() -> &'static str {
 fn load_plugin_and_call_bridges() {
     use scheme_rs::runtime::Runtime;
     use std::path::Path;
-    use std::process::Command;
 
-    let plugin_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/test-plugin");
-    let status = Command::new("cargo")
-        .args(["build", "--quiet"])
-        .current_dir(&plugin_dir)
-        .status()
-        .expect("failed to build test plugin");
-    assert!(status.success(), "test plugin build failed");
-
-    let dylib = plugin_dir.join(test_plugin_dylib_name());
-    assert!(dylib.exists(), "test plugin dylib not found at {dylib:?}");
+    let dylib = build_test_plugin();
 
     let rt = Runtime::new();
     let lib = unsafe { libloading::Library::new(&dylib) }.expect("failed to dlopen test plugin");
@@ -48,16 +81,8 @@ fn load_plugin_and_call_bridges() {
 fn load_same_plugin_twice_is_ok() {
     use scheme_rs::runtime::Runtime;
     use std::path::Path;
-    use std::process::Command;
 
-    let plugin_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/test-plugin");
-    Command::new("cargo")
-        .args(["build", "--quiet"])
-        .current_dir(&plugin_dir)
-        .status()
-        .expect("failed to build test plugin");
-
-    let dylib = plugin_dir.join(test_plugin_dylib_name());
+    let dylib = build_test_plugin();
 
     let rt = Runtime::new();
     let lib1 = unsafe { libloading::Library::new(&dylib) }.unwrap();

--- a/tests/test-plugin/Cargo.toml
+++ b/tests/test-plugin/Cargo.toml
@@ -4,8 +4,13 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
+# rlib so the (empty) integration test can depend on the lib unit, which
+# makes `cargo test --no-run` emit the cdylib. See tests/link.rs.
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
+# The feature set must match the host build exactly (here: the host test
+# suite's --all-features) so cargo computes the same -C metadata hash for
+# scheme-rs and the plugin links the very same runtime dylib as the host.
 [dependencies]
-scheme-rs = { path = "../..", features = ["plugins", "async", "tokio"] }
+scheme-rs = { path = "../..", features = ["plugins", "async", "tokio", "lsp", "load-libraries-from-fs"] }

--- a/tests/test-plugin/tests/link.rs
+++ b/tests/test-plugin/tests/link.rs
@@ -1,0 +1,5 @@
+//! Intentionally empty. Integration tests depend on the package's lib unit,
+//! which forces `cargo test --no-run` to emit the cdylib artifact. The host
+//! test suite builds the plugin through `cargo test` (not `cargo build`) so
+//! that feature unification — including dev-dependencies — matches the host
+//! build exactly and the plugin links the very same scheme-rs image.


### PR DESCRIPTION
Plugins currently embed a second statically-linked copy of scheme-rs: two heaps, two collectors, per-image TypeIds. `cargo test --test plugins --all-features` fails on main — plugin-created strings are never `equal?` to host strings (`Record::cast` compares `TypeId`, which differs across images), and loading any plugin replaces the host's registered stdlib (`register_bridges` is last-wins over the plugin's full inventory slice). Plugin-allocated objects are also never collected.

This spike makes the runtime a single shared image per process, following Guile's libguile model (extensions dynamically link one `libguile`; statically embedding a copy is unsupported):

- scheme-rs builds as `dylib`; plugins and host binaries link it dynamically (`-C prefer-dynamic` via `.cargo/config.toml`), so dlopen resolves to the already-loaded image
- load-time identity canary: plugins export the address of a runtime static; `load_plugin` rejects a plugin whose runtime image differs from the host's
- `register_bridges` is now first-wins: plugins can't displace `(rnrs base)`
- `Record::cast` compares runtime RTD identity instead of compile-time `TypeId` (Guile smob-tag style: type identity is a runtime value)
- `scheme_rs_bridges()` no longer memoizes: with one shared inventory, a snapshot taken at the first load would hide plugins loaded later

Getting one image also means host and plugin must agree on the *exact* scheme-rs build — rustc symbol names include the crate disambiguator, and `-Zshare-generics` (on in debug) makes plugins reference monomorphizations expected to exist in the runtime dylib. To that end `tests/test-plugin` is now a workspace member, and the plugin test builds it with `cargo test -p scheme-rs -p test-plugin --all-features --no-run`: same workspace, same lockfile, same profile, and — because it's a test-class command with scheme-rs selected — the same feature unification (dev-dependencies included). Any weaker equivalence reproducibly diverges: cargo relinks a differing `libscheme_rs` unit onto the same unhashed filename and dlopen fails with missing symbols. An empty integration test in test-plugin forces `--no-run` to emit the cdylib.

Verified on macOS (aarch64): plugin and host test binary both carry a load command for the same absolute `deps/libscheme_rs.dylib`; dyld reuses the image, the canary sees one address, plugin strings are `equal?`, and the plugin cdylib shrinks from ~56 MB to ~59 KB.

## Shipping

Shipped apps can't run under cargo, and since dynamic-load is a runtime capability they can't opt out of hosting plugins either — so the shipping story is a relocatable bundle, as with Guile/libpython. `scripts/package.sh` (macOS so far) builds with `--profile dist` (release minus LTO, which can't combine with dynamic linking) and produces a self-contained `dist/`: the interpreter, `libscheme_rs.dylib`, and the toolchain's `libstd-*.dylib`, install names rewritten to `@rpath` with the executable resolving both via `@executable_path`. One shared libstd is load-bearing: a static libstd inside the runtime dylib plus another inside the host would recreate the dual-image problem one level down. Plugins reference `@rpath/libscheme_rs.dylib`, which dyld matches against the already-loaded image — never the build tree.

Verified from a clean environment (`env -i`, cwd outside the bundle): the packaged binary runs scripts and the REPL, `%load-plugin` on the bundled test plugin passes the identity canary and calls bridges correctly, `DYLD_PRINT_LIBRARIES` shows exactly one `libscheme_rs` image (all three libraries resolved from `dist/`), and loading a plugin bound to a *different* scheme-rs build is rejected by the canary with a clear error. A plain dev-tree binary still runs fine via cargo; a fully static binary (no `plugins` feature needed at runtime) remains available with `RUSTFLAGS='' cargo build`, since env `RUSTFLAGS` overrides the config default.

## Test status

- `cargo test --test plugins --all-features`: 3/3 pass, including from a wiped target dir
- `cargo test` (default features): green
- `cargo test --all-features`: only the 4 pre-existing async doctest failures in src/docs.md
- `cargo clippy --all-targets`: no new warnings
- packaged bundle: script run, REPL, plugin load, and canary reject-path all verified without cargo or loader env vars

## Open questions for review

- Linux/Windows untested. Linux should be friendlier (SONAME-based dedupe + `LD_LIBRARY_PATH` set by cargo); Windows needs a look at import-lib naming and PATH. `scripts/package.sh` is macOS-only so far (Linux needs the `$ORIGIN`-rpath equivalent).
- `cargo build --release` currently fails: `lto = true` can't combine with `prefer-dynamic` linking of the runtime dylib. The `dist` profile sidesteps this for packaging; either release drops LTO or release keeps a static runtime (and then can't host plugins).
- `cargo build` (dev) and `cargo test` (test profile) build distinct lib units that alias the same unhashed `libscheme_rs.dylib`, so alternating commands re-links it. Harmless but noisy.
- The plugin build command hardcodes `--all-features`; running the plugin suite with a different feature set would diverge again. The canary/dlopen turns that into a hard error rather than silent dual-runtime, but it's a footgun.
- The canary's reject path was verified manually (dist binary refusing a dev-tree plugin) but has no automated test; that needs a deliberately-divergent second fixture.

Draft: build/linkage plumbing needs review for Linux/Windows; opening early for design discussion.