### PR TITLE
feat: plugin ABI with stable C boundary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,13 +48,14 @@ cranelift-module = "0.122"
 
 # Optional dependencies
 tokio = { version = "1.47", features = ["full"], optional = true }
+scheme-rs-plugin-api = { version = "0.1.0", path = "plugin-api", optional = true }
 
 [features]
 default = ["load-libraries-from-fs"]
 async = ["dep:futures", "dep:async-stream"]
 lsp = ["dep:lsp-server", "dep:lsp-types", "dep:serde", "dep:serde_json"]
 load-libraries-from-fs = []
-plugins = ["dep:libloading"]
+plugins = ["dep:libloading", "dep:scheme-rs-plugin-api"]
 
 [profile.release]
 lto = true

--- a/plugin-api/Cargo.toml
+++ b/plugin-api/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "scheme-rs-plugin-api"
+version = "0.1.0"
+edition = "2024"
+description = "Plugin API for scheme-rs — depend on this, not scheme-rs itself"
+license = "MPL-2.0"
+publish = false
+
+[dependencies]
+scheme-rs-plugin-api-macros = { path = "macros" }

--- a/plugin-api/macros/Cargo.toml
+++ b/plugin-api/macros/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "scheme-rs-plugin-api-macros"
+version = "0.1.0"
+edition = "2024"
+description = "Proc macros for scheme-rs plugin API"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }

--- a/plugin-api/macros/src/lib.rs
+++ b/plugin-api/macros/src/lib.rs
@@ -1,0 +1,165 @@
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{
+    Ident, ItemFn, LitStr, ReturnType, Token,
+    parse::{Parse, ParseStream},
+    parse_macro_input,
+};
+
+struct BridgeAttrs {
+    name: String,
+    lib: String,
+    blocking: bool,
+}
+
+impl Parse for BridgeAttrs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut name = None;
+        let mut lib = None;
+        let mut blocking = false;
+
+        while !input.is_empty() {
+            let key: Ident = input.parse()?;
+            input.parse::<Token![=]>()?;
+
+            match key.to_string().as_str() {
+                "name" => {
+                    let val: LitStr = input.parse()?;
+                    name = Some(val.value());
+                }
+                "lib" => {
+                    let val: LitStr = input.parse()?;
+                    lib = Some(val.value());
+                }
+                "blocking" => {
+                    let val: syn::LitBool = input.parse()?;
+                    blocking = val.value();
+                }
+                other => {
+                    return Err(syn::Error::new(
+                        key.span(),
+                        format!("unknown attribute `{other}`"),
+                    ));
+                }
+            }
+
+            if !input.is_empty() {
+                input.parse::<Token![,]>()?;
+            }
+        }
+
+        let name = name.ok_or_else(|| input.error("missing required attribute `name`"))?;
+        let lib = lib.ok_or_else(|| input.error("missing required attribute `lib`"))?;
+        Ok(BridgeAttrs { name, lib, blocking })
+    }
+}
+
+fn returns_result(ret: &ReturnType) -> bool {
+    if let ReturnType::Type(_, ty) = ret {
+        if let syn::Type::Path(tp) = ty.as_ref() {
+            if let Some(seg) = tp.path.segments.last() {
+                return seg.ident == "Result";
+            }
+        }
+    }
+    false
+}
+
+#[proc_macro_attribute]
+pub fn plugin_bridge(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let attrs = parse_macro_input!(attr as BridgeAttrs);
+    let func = parse_macro_input!(item as ItemFn);
+
+    let fn_name = &func.sig.ident;
+    let wrapper_name = format_ident!("__plugin_bridge_{}", fn_name);
+    let spec_name = format_ident!("__plugin_bridge_spec_{}", fn_name);
+
+    let params: Vec<_> = func.sig.inputs.iter().collect();
+    let nargs = params.len();
+    let bridge_name = &attrs.name;
+    let bridge_lib = &attrs.lib;
+    let blocking = attrs.blocking;
+
+    let arg_bindings: Vec<_> = (0..nargs).map(|i| format_ident!("__arg_{}", i)).collect();
+
+    let extractions: Vec<_> = params
+        .iter()
+        .enumerate()
+        .map(|(i, param)| {
+            let ty = match param {
+                syn::FnArg::Typed(pat) => &pat.ty,
+                _ => unreachable!("plugin_bridge does not support self parameters"),
+            };
+            let binding = &arg_bindings[i];
+            quote! {
+                let #binding: #ty = match <#ty as ::scheme_rs_plugin_api::FromScheme>::from_scheme(
+                    unsafe { &*args.add(#i) }
+                ) {
+                    Ok(v) => v,
+                    Err(e) => return ::scheme_rs_plugin_api::BridgeReturn::err(e.message()),
+                };
+            }
+        })
+        .collect();
+
+    let call_args: Vec<_> = arg_bindings.iter().map(|b| quote! { #b }).collect();
+
+    let result_handling = if returns_result(&func.sig.output) {
+        quote! {
+            match #fn_name(#(#call_args),*) {
+                Ok(val) => ::scheme_rs_plugin_api::BridgeReturn::ok(
+                    ::scheme_rs_plugin_api::IntoScheme::into_scheme(val)
+                ),
+                Err(e) => {
+                    let e: ::scheme_rs_plugin_api::PluginError = ::std::convert::Into::into(e);
+                    ::scheme_rs_plugin_api::BridgeReturn::err(e.message())
+                }
+            }
+        }
+    } else {
+        quote! {
+            let val = #fn_name(#(#call_args),*);
+            ::scheme_rs_plugin_api::BridgeReturn::ok(
+                ::scheme_rs_plugin_api::IntoScheme::into_scheme(val)
+            )
+        }
+    };
+
+    let name_len = bridge_name.len();
+    let lib_len = bridge_lib.len();
+
+    let output = quote! {
+        #func
+
+        unsafe extern "C" fn #wrapper_name(
+            args: *const ::scheme_rs_plugin_api::Value,
+            nargs: usize,
+        ) -> ::scheme_rs_plugin_api::BridgeReturn {
+            if nargs != #nargs {
+                return ::scheme_rs_plugin_api::BridgeReturn::err(
+                    concat!(#bridge_name, ": expected ", stringify!(#nargs), " arguments")
+                );
+            }
+            #(#extractions)*
+            #result_handling
+        }
+
+        fn #spec_name() -> ::scheme_rs_plugin_api::BridgeSpec {
+            static NAME: &[u8] = #bridge_name.as_bytes();
+            static LIB: &[u8] = #bridge_lib.as_bytes();
+            ::scheme_rs_plugin_api::BridgeSpec {
+                name_ptr: NAME.as_ptr(),
+                name_len: #name_len,
+                lib_ptr: LIB.as_ptr(),
+                lib_len: #lib_len,
+                num_args: #nargs,
+                variadic: false,
+                func: Some(#wrapper_name as ::scheme_rs_plugin_api::SimpleBridgeFn),
+                cps_func: None,
+                blocking: #blocking,
+            }
+        }
+    };
+
+    output.into()
+}

--- a/plugin-api/src/convert.rs
+++ b/plugin-api/src/convert.rs
@@ -1,0 +1,93 @@
+use crate::host;
+use crate::types::PluginError;
+use crate::value::Value;
+
+pub trait FromScheme: Sized {
+    fn from_scheme(v: &Value) -> Result<Self, PluginError>;
+}
+
+pub trait IntoScheme {
+    fn into_scheme(self) -> Value;
+}
+
+impl FromScheme for i64 {
+    fn from_scheme(v: &Value) -> Result<Self, PluginError> {
+        if !v.is_number() {
+            return Err(PluginError::type_error("expected integer"));
+        }
+        Ok(host::to_integer(v))
+    }
+}
+
+impl FromScheme for f64 {
+    fn from_scheme(v: &Value) -> Result<Self, PluginError> {
+        if !v.is_number() {
+            return Err(PluginError::type_error("expected number"));
+        }
+        Ok(host::to_float(v))
+    }
+}
+
+impl FromScheme for bool {
+    fn from_scheme(v: &Value) -> Result<Self, PluginError> {
+        v.to_bool()
+            .ok_or_else(|| PluginError::type_error("expected boolean"))
+    }
+}
+
+impl FromScheme for String {
+    fn from_scheme(v: &Value) -> Result<Self, PluginError> {
+        if !v.is_string() {
+            return Err(PluginError::type_error("expected string"));
+        }
+        Ok(host::to_string_copy(v))
+    }
+}
+
+impl FromScheme for Value {
+    fn from_scheme(v: &Value) -> Result<Self, PluginError> {
+        Ok(v.clone())
+    }
+}
+
+impl IntoScheme for i64 {
+    fn into_scheme(self) -> Value {
+        host::make_integer(self)
+    }
+}
+
+impl IntoScheme for f64 {
+    fn into_scheme(self) -> Value {
+        host::make_float(self)
+    }
+}
+
+impl IntoScheme for bool {
+    fn into_scheme(self) -> Value {
+        Value::from_bool(self)
+    }
+}
+
+impl IntoScheme for String {
+    fn into_scheme(self) -> Value {
+        host::make_string(&self)
+    }
+}
+
+impl IntoScheme for &str {
+    fn into_scheme(self) -> Value {
+        host::make_string(self)
+    }
+}
+
+impl IntoScheme for Value {
+    fn into_scheme(self) -> Value {
+        self
+    }
+}
+
+impl IntoScheme for () {
+    fn into_scheme(self) -> Value {
+        Value::undefined()
+    }
+}

--- a/plugin-api/src/convert.rs
+++ b/plugin-api/src/convert.rs
@@ -12,10 +12,8 @@ pub trait IntoScheme {
 
 impl FromScheme for i64 {
     fn from_scheme(v: &Value) -> Result<Self, PluginError> {
-        if !v.is_number() {
-            return Err(PluginError::type_error("expected integer"));
-        }
-        Ok(host::to_integer(v))
+        host::to_integer(v)
+            .ok_or_else(|| PluginError::type_error("expected integer"))
     }
 }
 
@@ -37,10 +35,8 @@ impl FromScheme for bool {
 
 impl FromScheme for String {
     fn from_scheme(v: &Value) -> Result<Self, PluginError> {
-        if !v.is_string() {
-            return Err(PluginError::type_error("expected string"));
-        }
-        Ok(host::to_string_copy(v))
+        host::to_string_copy(v)
+            .ok_or_else(|| PluginError::type_error("expected string"))
     }
 }
 

--- a/plugin-api/src/host.rs
+++ b/plugin-api/src/host.rs
@@ -1,0 +1,205 @@
+use std::ffi::c_void;
+use std::sync::OnceLock;
+
+use crate::types::{
+    ApplicationResult, Barrier, BridgeSpec, Continuation, PluginError, TypeHandle,
+};
+use crate::value::Value;
+
+// ── Host function table ────────────────────────────────────────────────────
+
+#[repr(C)]
+pub struct HostFnTable {
+    // Value construction
+    pub make_integer: unsafe extern "C" fn(i64) -> Value,
+    pub make_float: unsafe extern "C" fn(f64) -> Value,
+    pub make_string: unsafe extern "C" fn(*const u8, usize) -> Value,
+    pub make_symbol: unsafe extern "C" fn(*const u8, usize) -> Value,
+    pub cons: unsafe extern "C" fn(Value, Value) -> Value,
+    pub make_vector: unsafe extern "C" fn(*const Value, usize) -> Value,
+
+    // Extraction
+    pub to_integer: unsafe extern "C" fn(*const Value) -> i64,
+    pub to_float: unsafe extern "C" fn(*const Value) -> f64,
+    pub to_string_copy: unsafe extern "C" fn(*const Value, *mut *mut u8, *mut usize),
+
+    // Pair ops
+    pub car: unsafe extern "C" fn(*const Value) -> Value,
+    pub cdr: unsafe extern "C" fn(*const Value) -> Value,
+
+    // Procedure calls
+    pub call:
+        unsafe extern "C" fn(*const Value, *const Value, usize, *mut *mut u8, *mut usize) -> Value,
+
+    // CPS primitives
+    pub apply_continuation:
+        unsafe extern "C" fn(*const Value, *const Value, usize) -> ApplicationResult,
+    pub make_application:
+        unsafe extern "C" fn(*const Value, *const Value, *const Value, usize) -> ApplicationResult,
+    pub raise_error: unsafe extern "C" fn(*const u8, usize, *mut c_void) -> ApplicationResult,
+
+    // Foreign types
+    pub register_type:
+        unsafe extern "C" fn(*const u8, usize, Option<unsafe extern "C" fn(*mut c_void)>) -> usize,
+    pub make_foreign: unsafe extern "C" fn(usize, *mut c_void) -> Value,
+    pub get_foreign: unsafe extern "C" fn(usize, *const Value) -> *mut c_void,
+
+    // Bridge registration
+    pub register_bridge: unsafe extern "C" fn(*const BridgeSpec) -> bool,
+
+    // Refcounting
+    pub value_retain: unsafe extern "C" fn(usize),
+    pub value_release: unsafe extern "C" fn(usize),
+
+    // Module interaction
+    pub define: unsafe extern "C" fn(*const u8, usize, Value),
+    pub lookup: unsafe extern "C" fn(*const u8, usize, *const u8, usize) -> Value,
+}
+
+// ── Global state ───────────────────────────────────────────────────────────
+
+static HOST: OnceLock<&'static HostFnTable> = OnceLock::new();
+
+pub(crate) fn host() -> &'static HostFnTable {
+    HOST.get()
+        .copied()
+        .expect("host function table not initialized")
+}
+
+/// Initialize the host function table. Called from generated plugin init code.
+///
+/// # Safety
+/// `table` must point to a valid `HostFnTable` with `'static` lifetime.
+pub unsafe fn _init_host(table: *const ()) {
+    let table_ref: &'static HostFnTable = unsafe { &*(table as *const HostFnTable) };
+
+    HOST.set(table_ref).ok();
+
+    crate::value::HOST
+        .set(crate::value::HostFns {
+            retain: table_ref.value_retain,
+            release: table_ref.value_release,
+        })
+        .ok();
+}
+
+// ── Public wrapper functions ───────────────────────────────────────────────
+
+pub fn make_integer(n: i64) -> Value {
+    unsafe { (host().make_integer)(n) }
+}
+
+pub fn make_float(n: f64) -> Value {
+    unsafe { (host().make_float)(n) }
+}
+
+pub fn make_string(s: &str) -> Value {
+    unsafe { (host().make_string)(s.as_ptr(), s.len()) }
+}
+
+pub fn make_symbol(s: &str) -> Value {
+    unsafe { (host().make_symbol)(s.as_ptr(), s.len()) }
+}
+
+pub fn to_integer(v: &Value) -> i64 {
+    unsafe { (host().to_integer)(v) }
+}
+
+pub fn to_float(v: &Value) -> f64 {
+    unsafe { (host().to_float)(v) }
+}
+
+pub fn to_string_copy(v: &Value) -> String {
+    let mut ptr: *mut u8 = std::ptr::null_mut();
+    let mut len: usize = 0;
+    unsafe {
+        (host().to_string_copy)(v, &mut ptr, &mut len);
+        let slice = std::slice::from_raw_parts_mut(ptr, len);
+        let s = String::from_utf8_lossy(slice).into_owned();
+        drop(Box::from_raw(slice));
+        s
+    }
+}
+
+pub fn cons(car: Value, cdr: Value) -> Value {
+    unsafe { (host().cons)(car, cdr) }
+}
+
+pub fn car(pair: &Value) -> Value {
+    unsafe { (host().car)(pair) }
+}
+
+pub fn cdr(pair: &Value) -> Value {
+    unsafe { (host().cdr)(pair) }
+}
+
+pub fn call(proc: &Value, args: &[Value]) -> Result<Value, PluginError> {
+    let mut err_ptr: *mut u8 = std::ptr::null_mut();
+    let mut err_len: usize = 0;
+    let result =
+        unsafe { (host().call)(proc, args.as_ptr(), args.len(), &mut err_ptr, &mut err_len) };
+    if err_ptr.is_null() {
+        Ok(result)
+    } else {
+        let msg = unsafe {
+            let slice = std::slice::from_raw_parts(err_ptr, err_len);
+            let s = String::from_utf8_lossy(slice).into_owned();
+            drop(Box::from_raw(std::slice::from_raw_parts_mut(
+                err_ptr, err_len,
+            )));
+            s
+        };
+        Err(PluginError::new(msg))
+    }
+}
+
+pub fn apply_continuation(k: &Continuation, args: &[Value]) -> ApplicationResult {
+    unsafe { (host().apply_continuation)(k.as_value(), args.as_ptr(), args.len()) }
+}
+
+pub fn make_application(
+    proc: &Value,
+    k: &Continuation,
+    args: &[Value],
+) -> ApplicationResult {
+    unsafe { (host().make_application)(proc, k.as_value(), args.as_ptr(), args.len()) }
+}
+
+pub fn raise_error(msg: &str, barrier: &Barrier) -> ApplicationResult {
+    unsafe { (host().raise_error)(msg.as_ptr(), msg.len(), barrier.as_ptr()) }
+}
+
+pub fn register_type(
+    name: &str,
+    finalizer: Option<unsafe extern "C" fn(*mut c_void)>,
+) -> TypeHandle {
+    let raw = unsafe { (host().register_type)(name.as_ptr(), name.len(), finalizer) };
+    TypeHandle::from_raw(raw)
+}
+
+pub fn make_foreign(handle: TypeHandle, data: *mut c_void) -> Value {
+    unsafe { (host().make_foreign)(handle.as_raw(), data) }
+}
+
+pub fn get_foreign(handle: TypeHandle, value: &Value) -> *mut c_void {
+    unsafe { (host().get_foreign)(handle.as_raw(), value) }
+}
+
+pub fn define(name: &str, value: Value) {
+    unsafe { (host().define)(name.as_ptr(), name.len(), value) }
+}
+
+pub fn lookup(module: &str, name: &str) -> Value {
+    unsafe {
+        (host().lookup)(
+            module.as_ptr(),
+            module.len(),
+            name.as_ptr(),
+            name.len(),
+        )
+    }
+}
+
+pub fn register_bridge(spec: &BridgeSpec) -> bool {
+    unsafe { (host().register_bridge)(spec) }
+}

--- a/plugin-api/src/host.rs
+++ b/plugin-api/src/host.rs
@@ -19,7 +19,7 @@ pub struct HostFnTable {
     pub make_vector: unsafe extern "C" fn(*const Value, usize) -> Value,
 
     // Extraction
-    pub to_integer: unsafe extern "C" fn(*const Value) -> i64,
+    pub to_integer: unsafe extern "C" fn(*const Value, *mut i64) -> bool,
     pub to_float: unsafe extern "C" fn(*const Value) -> f64,
     pub to_string_copy: unsafe extern "C" fn(*const Value, *mut *mut u8, *mut usize),
 
@@ -101,23 +101,28 @@ pub fn make_symbol(s: &str) -> Value {
     unsafe { (host().make_symbol)(s.as_ptr(), s.len()) }
 }
 
-pub fn to_integer(v: &Value) -> i64 {
-    unsafe { (host().to_integer)(v) }
+pub fn to_integer(v: &Value) -> Option<i64> {
+    let mut out: i64 = 0;
+    let ok = unsafe { (host().to_integer)(v, &mut out) };
+    if ok { Some(out) } else { None }
 }
 
 pub fn to_float(v: &Value) -> f64 {
     unsafe { (host().to_float)(v) }
 }
 
-pub fn to_string_copy(v: &Value) -> String {
+pub fn to_string_copy(v: &Value) -> Option<String> {
     let mut ptr: *mut u8 = std::ptr::null_mut();
     let mut len: usize = 0;
     unsafe {
         (host().to_string_copy)(v, &mut ptr, &mut len);
+        if ptr.is_null() {
+            return None;
+        }
         let slice = std::slice::from_raw_parts_mut(ptr, len);
         let s = String::from_utf8_lossy(slice).into_owned();
         drop(Box::from_raw(slice));
-        s
+        Some(s)
     }
 }
 

--- a/plugin-api/src/lib.rs
+++ b/plugin-api/src/lib.rs
@@ -1,0 +1,14 @@
+pub mod convert;
+pub mod host;
+pub mod types;
+pub mod value;
+
+pub use convert::{FromScheme, IntoScheme};
+pub use host::{
+    HostFnTable, apply_continuation, call, car, cdr, cons, define, get_foreign, lookup,
+    make_application, make_float, make_foreign, make_integer, make_string, make_symbol, raise_error,
+    register_bridge, register_type, to_float, to_integer, to_string_copy,
+};
+pub use scheme_rs_plugin_api_macros::plugin_bridge;
+pub use types::*;
+pub use value::Value;

--- a/plugin-api/src/types.rs
+++ b/plugin-api/src/types.rs
@@ -14,6 +14,15 @@ impl Continuation {
         Self(v)
     }
 
+    /// Construct a `Continuation` from a raw plugin `Value`.
+    ///
+    /// # Safety
+    /// The caller must ensure `v` is a valid continuation value received
+    /// from the host (i.e. the `k` pointer in a `CpsBridgeFn`).
+    pub unsafe fn from_raw(v: *const Value) -> Self {
+        Self(unsafe { (*v).clone() })
+    }
+
     pub fn as_value(&self) -> &Value {
         &self.0
     }
@@ -26,6 +35,18 @@ pub struct Barrier {
 }
 
 impl Barrier {
+    /// Construct a `Barrier` from a raw pointer.
+    ///
+    /// # Safety
+    /// The caller must ensure `ptr` is a valid barrier pointer received
+    /// from the host (i.e. the barrier argument in a `CpsBridgeFn`).
+    pub unsafe fn from_raw(ptr: *mut c_void) -> Self {
+        Self {
+            ptr,
+            _not_send: PhantomData,
+        }
+    }
+
     pub(crate) fn as_ptr(&self) -> *mut c_void {
         self.ptr
     }

--- a/plugin-api/src/types.rs
+++ b/plugin-api/src/types.rs
@@ -1,0 +1,149 @@
+use std::ffi::c_void;
+use std::fmt;
+use std::marker::PhantomData;
+
+use crate::value::Value;
+
+// ── Opaque handles ─────────────────────────────────────────────────────────
+
+#[repr(transparent)]
+pub struct Continuation(Value);
+
+impl Continuation {
+    pub(crate) fn from_value(v: Value) -> Self {
+        Self(v)
+    }
+
+    pub fn as_value(&self) -> &Value {
+        &self.0
+    }
+}
+
+#[repr(C)]
+pub struct Barrier {
+    ptr: *mut c_void,
+    _not_send: PhantomData<*mut ()>,
+}
+
+impl Barrier {
+    pub(crate) fn as_ptr(&self) -> *mut c_void {
+        self.ptr
+    }
+}
+
+#[repr(transparent)]
+pub struct ApplicationResult(*mut c_void);
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TypeHandle(usize);
+
+impl TypeHandle {
+    pub(crate) fn from_raw(raw: usize) -> Self {
+        Self(raw)
+    }
+
+    pub fn as_raw(&self) -> usize {
+        self.0
+    }
+}
+
+// ── Error type ─────────────────────────────────────────────────────────────
+
+pub struct PluginError {
+    message: String,
+}
+
+impl PluginError {
+    pub fn new(msg: impl Into<String>) -> Self {
+        Self {
+            message: msg.into(),
+        }
+    }
+
+    pub fn type_error(msg: impl Into<String>) -> Self {
+        Self {
+            message: format!("type error: {}", msg.into()),
+        }
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for PluginError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl fmt::Debug for PluginError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PluginError")
+            .field("message", &self.message)
+            .finish()
+    }
+}
+
+impl std::error::Error for PluginError {}
+
+impl From<std::io::Error> for PluginError {
+    fn from(e: std::io::Error) -> Self {
+        Self::new(e.to_string())
+    }
+}
+
+impl From<fmt::Error> for PluginError {
+    fn from(e: fmt::Error) -> Self {
+        Self::new(e.to_string())
+    }
+}
+
+// ── Bridge function types ──────────────────────────────────────────────────
+
+pub type SimpleBridgeFn = unsafe extern "C" fn(*const Value, usize) -> BridgeReturn;
+
+pub type CpsBridgeFn =
+    unsafe extern "C" fn(*const Value, *const Value, usize, *mut c_void) -> ApplicationResult;
+
+#[repr(C)]
+pub struct BridgeReturn {
+    pub value: Value,
+    pub error: *const u8,
+    pub error_len: usize,
+}
+
+impl BridgeReturn {
+    pub fn ok(value: Value) -> Self {
+        Self {
+            value,
+            error: std::ptr::null(),
+            error_len: 0,
+        }
+    }
+
+    pub fn err(msg: &str) -> Self {
+        let leaked = Box::leak(msg.to_owned().into_boxed_str());
+        Self {
+            value: Value::undefined(),
+            error: leaked.as_ptr(),
+            error_len: leaked.len(),
+        }
+    }
+}
+
+// ── Bridge registration ────────────────────────────────────────────────────
+
+#[repr(C)]
+pub struct BridgeSpec {
+    pub name_ptr: *const u8,
+    pub name_len: usize,
+    pub lib_ptr: *const u8,
+    pub lib_len: usize,
+    pub num_args: usize,
+    pub variadic: bool,
+    pub func: Option<SimpleBridgeFn>,
+    pub cps_func: Option<CpsBridgeFn>,
+    pub blocking: bool,
+}

--- a/plugin-api/src/value.rs
+++ b/plugin-api/src/value.rs
@@ -1,0 +1,370 @@
+use std::sync::OnceLock;
+
+// ── Tag encoding (matches host src/value.rs exactly) ───────────────────────
+//
+// 4 low bits encode the type tag. Even tags identify heap-allocated types
+// (except Pair/Record with null pointer, which are null/undefined).
+// Odd values (bit 0 = 1) are inline fixnums — the upper 63 bits hold the
+// integer value directly.
+
+const ALIGNMENT: usize = 16;
+const TAG_BITS: usize = ALIGNMENT.ilog2() as usize; // 4
+const TAG_MASK: usize = 0b1111;
+
+const TAG_PAIR: usize = 0;
+const TAG_BOOLEAN: usize = 1 << 1;            // 2
+const TAG_CHAR_OR_SYMBOL: usize = 2 << 1;     // 4
+const TAG_NUMBER: usize = 3 << 1;             // 6
+const TAG_PROCEDURE: usize = 4 << 1;          // 8
+const TAG_RECORD: usize = 5 << 1;             // 10
+const TAG_RTD: usize = 6 << 1;                // 12
+const TAG_CELL: usize = 7 << 1;               // 14
+
+const SYMBOL_CHAR: u32 = 0x110000;
+
+// ── Well-known constants ────────────────────────────────────────────────────
+
+const NULL_VALUE: usize = TAG_PAIR;            // 0 — Pair tag with null pointer
+const TRUE_VALUE: usize = TAG_BOOLEAN | (1 << TAG_BITS); // 18
+const FALSE_VALUE: usize = TAG_BOOLEAN;        // 2
+const UNDEFINED_VALUE: usize = TAG_RECORD;     // 10 — Record tag with null pointer
+
+// ── Host function table (populated by the host at load time) ────────────────
+
+type RetainFn = unsafe extern "C" fn(usize);
+type ReleaseFn = unsafe extern "C" fn(usize);
+
+pub(crate) struct HostFns {
+    pub retain: RetainFn,
+    pub release: ReleaseFn,
+}
+
+pub(crate) static HOST: OnceLock<HostFns> = OnceLock::new();
+
+// ── Value ───────────────────────────────────────────────────────────────────
+
+/// A Scheme value with identical layout to the host's `Value(*const ())`.
+///
+/// Uses tagged pointers: 4 low bits encode the type tag, upper bits hold either
+/// an aligned heap pointer or an inline immediate (booleans, characters, symbols,
+/// null, undefined, fixnums).
+#[repr(transparent)]
+pub struct Value(usize);
+
+unsafe impl Send for Value {}
+unsafe impl Sync for Value {}
+
+impl Value {
+    // ── Tag introspection ───────────────────────────────────────────────
+
+    #[inline]
+    fn tag(&self) -> usize {
+        self.0 & TAG_MASK
+    }
+
+    /// True when no reference-count management is needed.
+    ///
+    /// Immediate values are: fixnums, booleans, characters, symbols,
+    /// null, and undefined.
+    #[inline]
+    pub fn is_immediate(&self) -> bool {
+        if self.0 & 1 == 1 {
+            return true; // FixNum
+        }
+        match self.tag() {
+            TAG_PAIR => self.is_null(),
+            TAG_BOOLEAN | TAG_CHAR_OR_SYMBOL => true,
+            TAG_RECORD => self.is_undefined(),
+            _ => false,
+        }
+    }
+
+    #[inline]
+    pub fn is_null(&self) -> bool {
+        self.0 == NULL_VALUE
+    }
+
+    #[inline]
+    pub fn is_undefined(&self) -> bool {
+        self.0 == UNDEFINED_VALUE
+    }
+
+    #[inline]
+    pub fn is_boolean(&self) -> bool {
+        self.tag() == TAG_BOOLEAN
+    }
+
+    #[inline]
+    pub fn is_pair(&self) -> bool {
+        self.tag() == TAG_PAIR && !self.is_null()
+    }
+
+    #[inline]
+    pub fn is_procedure(&self) -> bool {
+        self.tag() == TAG_PROCEDURE
+    }
+
+    #[inline]
+    pub fn is_record(&self) -> bool {
+        self.tag() == TAG_RECORD && !self.is_undefined()
+    }
+
+    #[inline]
+    pub fn is_symbol(&self) -> bool {
+        if self.tag() != TAG_CHAR_OR_SYMBOL {
+            return false;
+        }
+        let untagged = self.0 & !TAG_MASK;
+        ((untagged as u32) >> TAG_BITS) == SYMBOL_CHAR
+    }
+
+    #[inline]
+    pub fn is_number(&self) -> bool {
+        (self.0 & 1 == 1) || self.tag() == TAG_NUMBER
+    }
+
+    #[inline]
+    pub fn is_string(&self) -> bool {
+        // In the current host encoding, strings are records.
+        // The host's extraction function handles the actual type check.
+        self.is_record()
+    }
+
+    #[inline]
+    pub fn is_character(&self) -> bool {
+        if self.tag() != TAG_CHAR_OR_SYMBOL {
+            return false;
+        }
+        let untagged = self.0 & !TAG_MASK;
+        ((untagged as u32) >> TAG_BITS) != SYMBOL_CHAR
+    }
+
+    // ── Constructors for immediates ─────────────────────────────────────
+
+    #[inline]
+    pub fn null() -> Self {
+        Self(NULL_VALUE)
+    }
+
+    #[inline]
+    pub fn undefined() -> Self {
+        Self(UNDEFINED_VALUE)
+    }
+
+    #[inline]
+    pub fn from_bool(b: bool) -> Self {
+        Self(TAG_BOOLEAN | ((b as usize) << TAG_BITS))
+    }
+
+    // ── Extractors ──────────────────────────────────────────────────────
+
+    #[inline]
+    pub fn to_bool(&self) -> Option<bool> {
+        if self.is_boolean() {
+            Some(self.0 != FALSE_VALUE)
+        } else {
+            None
+        }
+    }
+
+    // ── Raw access ──────────────────────────────────────────────────────
+
+    #[inline]
+    pub fn as_raw(&self) -> usize {
+        self.0
+    }
+
+    /// Reconstruct a `Value` from a raw `usize` previously obtained via
+    /// [`as_raw`](Value::as_raw).
+    ///
+    /// # Safety
+    /// The caller must ensure `raw` was produced by `as_raw` (or the host
+    /// equivalent `Value::into_raw`) and that ownership semantics are
+    /// respected (i.e. the refcount has been incremented if a second owner
+    /// is being created).
+    #[inline]
+    pub unsafe fn from_raw(raw: usize) -> Self {
+        Self(raw)
+    }
+}
+
+// ── Clone / Drop ────────────────────────────────────────────────────────────
+
+impl Clone for Value {
+    fn clone(&self) -> Self {
+        if self.is_immediate() {
+            return Self(self.0);
+        }
+        let host = HOST
+            .get()
+            .expect("cannot clone heap Value: host not initialized");
+        unsafe { (host.retain)(self.0) };
+        Self(self.0)
+    }
+}
+
+impl Drop for Value {
+    fn drop(&mut self) {
+        if self.is_immediate() {
+            return;
+        }
+        let host = HOST
+            .get()
+            .expect("cannot drop heap Value: host not initialized");
+        unsafe { (host.release)(self.0) };
+    }
+}
+
+// ── Debug ───────────────────────────────────────────────────────────────────
+
+impl std::fmt::Debug for Value {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0 & 1 == 1 {
+            let n = (self.0 as i64) >> 1;
+            return write!(f, "Value::fixnum({n})");
+        }
+        match self.tag() {
+            TAG_PAIR if self.is_null() => write!(f, "Value::null"),
+            TAG_PAIR => write!(f, "Value::pair({:#x})", self.0),
+            TAG_BOOLEAN => write!(f, "Value::bool({})", self.0 == TRUE_VALUE),
+            TAG_CHAR_OR_SYMBOL if self.is_symbol() => {
+                write!(f, "Value::symbol({:#x})", self.0 >> 32)
+            }
+            TAG_CHAR_OR_SYMBOL => {
+                let cp = ((self.0 & !TAG_MASK) as u32) >> TAG_BITS;
+                write!(f, "Value::char({cp:#x})")
+            }
+            TAG_NUMBER => write!(f, "Value::number({:#x})", self.0),
+            TAG_PROCEDURE => write!(f, "Value::procedure({:#x})", self.0),
+            TAG_RECORD if self.is_undefined() => write!(f, "Value::undefined"),
+            TAG_RECORD => write!(f, "Value::record({:#x})", self.0),
+            TAG_RTD => write!(f, "Value::rtd({:#x})", self.0),
+            TAG_CELL => write!(f, "Value::cell({:#x})", self.0),
+            tag => write!(f, "Value({:#x}, tag={tag})", self.0),
+        }
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn null_value() {
+        let v = Value::null();
+        assert!(v.is_null());
+        assert!(v.is_immediate());
+        assert!(!v.is_undefined());
+        assert!(!v.is_boolean());
+        assert!(!v.is_pair());
+    }
+
+    #[test]
+    fn undefined_value() {
+        let v = Value::undefined();
+        assert!(v.is_undefined());
+        assert!(v.is_immediate());
+        assert!(!v.is_null());
+        assert!(!v.is_boolean());
+    }
+
+    #[test]
+    fn boolean_true() {
+        let v = Value::from_bool(true);
+        assert!(v.is_boolean());
+        assert!(v.is_immediate());
+        assert_eq!(v.to_bool(), Some(true));
+        assert_eq!(v.as_raw(), TRUE_VALUE);
+    }
+
+    #[test]
+    fn boolean_false() {
+        let v = Value::from_bool(false);
+        assert!(v.is_boolean());
+        assert!(v.is_immediate());
+        assert_eq!(v.to_bool(), Some(false));
+        assert_eq!(v.as_raw(), FALSE_VALUE);
+    }
+
+    #[test]
+    fn non_boolean_to_bool_is_none() {
+        assert_eq!(Value::null().to_bool(), None);
+        assert_eq!(Value::undefined().to_bool(), None);
+    }
+
+    #[test]
+    fn raw_roundtrip() {
+        let v = Value::from_bool(true);
+        let raw = v.as_raw();
+        let v2 = unsafe { Value::from_raw(raw) };
+        assert_eq!(v2.as_raw(), raw);
+        assert!(v2.is_boolean());
+        assert_eq!(v2.to_bool(), Some(true));
+    }
+
+    #[test]
+    fn constants_match_host() {
+        assert_eq!(NULL_VALUE, 0);  // Pair tag = 0
+        assert_eq!(FALSE_VALUE, 2); // Boolean tag
+        assert_eq!(TRUE_VALUE, 18); // Boolean tag | (1 << 4)
+        assert_eq!(UNDEFINED_VALUE, 10); // Record tag = 10
+    }
+
+    #[test]
+    fn tag_bits_layout() {
+        assert_eq!(TAG_BITS, 4);
+        assert_eq!(TAG_MASK, 0b1111);
+    }
+
+    #[test]
+    fn immediate_clone_no_panic() {
+        let vals = [
+            Value::null(),
+            Value::undefined(),
+            Value::from_bool(true),
+            Value::from_bool(false),
+        ];
+        for v in &vals {
+            let _cloned = v.clone();
+        }
+    }
+
+    #[test]
+    fn immediate_drop_no_panic() {
+        let _ = Value::null();
+        let _ = Value::undefined();
+        let _ = Value::from_bool(true);
+        let _ = Value::from_bool(false);
+    }
+
+    #[test]
+    fn size_and_alignment() {
+        assert_eq!(size_of::<Value>(), size_of::<usize>());
+        assert_eq!(size_of::<Value>(), size_of::<*const ()>());
+    }
+
+    #[test]
+    fn tag_discrimination() {
+        let null = Value::null();
+        let undef = Value::undefined();
+        let t = Value::from_bool(true);
+
+        assert!(!null.is_procedure());
+        assert!(!null.is_record());
+        assert!(!undef.is_pair());
+        assert!(!t.is_symbol());
+        assert!(!t.is_character());
+    }
+
+    #[test]
+    fn fixnum_is_number() {
+        // A fixnum has bit 0 = 1, upper bits hold the value
+        let fixnum = Value((42 << 1) | 1);
+        assert!(fixnum.is_number());
+        assert!(fixnum.is_immediate());
+        assert!(!fixnum.is_boolean());
+        assert!(!fixnum.is_pair());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@ pub mod keywords;
 pub mod lists;
 #[cfg(feature = "lsp")]
 pub mod lsp;
+#[cfg(feature = "plugins")]
+mod plugin_host;
 pub mod num;
 pub mod ports;
 pub mod proc;

--- a/src/plugin_host.rs
+++ b/src/plugin_host.rs
@@ -73,9 +73,15 @@ unsafe extern "C" fn host_make_vector(elems: *const PluginValue, len: usize) -> 
 
 // ── Value extraction ───────────────────────────────────────────────────────
 
-unsafe extern "C" fn host_to_integer(v: *const PluginValue) -> i64 {
+unsafe extern "C" fn host_to_integer(v: *const PluginValue, out: *mut i64) -> bool {
     let v = unsafe { &*plugin_ref_to_host(v) };
-    i64::try_from(v).unwrap_or(0)
+    match i64::try_from(v) {
+        Ok(n) => {
+            unsafe { *out = n };
+            true
+        }
+        Err(_) => false,
+    }
 }
 
 unsafe extern "C" fn host_to_float(v: *const PluginValue) -> f64 {
@@ -113,13 +119,19 @@ unsafe extern "C" fn host_to_string_copy(
 
 unsafe extern "C" fn host_car(v: *const PluginValue) -> PluginValue {
     let v = unsafe { &*plugin_ref_to_host(v) };
-    let pair: crate::lists::Pair = v.clone().try_into().expect("car: not a pair");
+    let pair: crate::lists::Pair = match v.clone().try_into() {
+        Ok(p) => p,
+        Err(_) => return PluginValue::undefined(),
+    };
     unsafe { host_to_plugin(pair.car()) }
 }
 
 unsafe extern "C" fn host_cdr(v: *const PluginValue) -> PluginValue {
     let v = unsafe { &*plugin_ref_to_host(v) };
-    let pair: crate::lists::Pair = v.clone().try_into().expect("cdr: not a pair");
+    let pair: crate::lists::Pair = match v.clone().try_into() {
+        Ok(p) => p,
+        Err(_) => return PluginValue::undefined(),
+    };
     unsafe { host_to_plugin(pair.cdr()) }
 }
 
@@ -146,7 +158,9 @@ fn plugin_bridge_wrapper(
     rest_args: &[HostValue],
     barrier: &mut ContBarrier,
 ) -> Application {
-    let fn_ptr_raw: i64 = (&env[0]).try_into().unwrap_or(0);
+    let fn_ptr_raw: i64 = (&env[0])
+        .try_into()
+        .expect("plugin bridge env[0] must be a valid fn pointer");
     let plugin_fn: scheme_rs_plugin_api::SimpleBridgeFn =
         unsafe { std::mem::transmute(fn_ptr_raw as usize) };
 
@@ -191,7 +205,9 @@ fn plugin_cps_bridge_wrapper(
     rest_args: &[HostValue],
     barrier: &mut ContBarrier,
 ) -> Application {
-    let fn_ptr_raw: i64 = (&env[0]).try_into().unwrap_or(0);
+    let fn_ptr_raw: i64 = (&env[0])
+        .try_into()
+        .expect("plugin CPS bridge env[0] must be a valid fn pointer");
     let cps_fn: scheme_rs_plugin_api::CpsBridgeFn =
         unsafe { std::mem::transmute(fn_ptr_raw as usize) };
 
@@ -356,7 +372,9 @@ pub(crate) fn make_plugin_blocking_procedure(
         barrier: &'a mut ContBarrier<'_>,
     ) -> futures::future::BoxFuture<'a, Application> {
         Box::pin(async move {
-            let fn_ptr_raw: i64 = (&env[0]).try_into().unwrap_or(0);
+            let fn_ptr_raw: i64 = (&env[0])
+                .try_into()
+                .expect("plugin blocking bridge env[0] must be a valid fn pointer");
             let plugin_fn: scheme_rs_plugin_api::SimpleBridgeFn =
                 unsafe { std::mem::transmute(fn_ptr_raw as usize) };
 
@@ -474,11 +492,21 @@ unsafe extern "C" fn host_apply_continuation(
     args: *const PluginValue,
     argc: usize,
 ) -> scheme_rs_plugin_api::ApplicationResult {
-    let k_val = unsafe { &*plugin_ref_to_host(k) }.clone();
-    let k_proc: Procedure = k_val.try_into().expect("apply_continuation: k is not a procedure");
-    let args_slice = unsafe { std::slice::from_raw_parts(plugin_ref_to_host(args), argc) };
-    let args_vec: Vec<HostValue> = args_slice.iter().cloned().collect();
-    let app = Application::new(k_proc, None, args_vec);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let k_val = unsafe { &*plugin_ref_to_host(k) }.clone();
+        let k_proc: Procedure = k_val
+            .try_into()
+            .expect("apply_continuation: k is not a procedure");
+        let args_slice = unsafe { std::slice::from_raw_parts(plugin_ref_to_host(args), argc) };
+        let args_vec: Vec<HostValue> = args_slice.iter().cloned().collect();
+        Application::new(k_proc, None, args_vec)
+    }));
+    let app = match result {
+        Ok(app) => app,
+        Err(_) => Application::halt_err(
+            Exception::error("apply_continuation: type conversion failed").into(),
+        ),
+    };
     unsafe { std::mem::transmute(Box::into_raw(Box::new(app)) as *mut c_void) }
 }
 
@@ -488,13 +516,25 @@ unsafe extern "C" fn host_make_application(
     args: *const PluginValue,
     argc: usize,
 ) -> scheme_rs_plugin_api::ApplicationResult {
-    let proc_val = unsafe { &*plugin_ref_to_host(proc_ptr) }.clone();
-    let proc: Procedure = proc_val.try_into().expect("make_application: proc is not a procedure");
-    let k_val = unsafe { &*plugin_ref_to_host(k) }.clone();
-    let k_proc: Procedure = k_val.try_into().expect("make_application: k is not a procedure");
-    let args_slice = unsafe { std::slice::from_raw_parts(plugin_ref_to_host(args), argc) };
-    let args_vec: Vec<HostValue> = args_slice.iter().cloned().collect();
-    let app = Application::new(proc, Some(k_proc), args_vec);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let proc_val = unsafe { &*plugin_ref_to_host(proc_ptr) }.clone();
+        let proc: Procedure = proc_val
+            .try_into()
+            .expect("make_application: proc is not a procedure");
+        let k_val = unsafe { &*plugin_ref_to_host(k) }.clone();
+        let k_proc: Procedure = k_val
+            .try_into()
+            .expect("make_application: k is not a procedure");
+        let args_slice = unsafe { std::slice::from_raw_parts(plugin_ref_to_host(args), argc) };
+        let args_vec: Vec<HostValue> = args_slice.iter().cloned().collect();
+        Application::new(proc, Some(k_proc), args_vec)
+    }));
+    let app = match result {
+        Ok(app) => app,
+        Err(_) => Application::halt_err(
+            Exception::error("make_application: type conversion failed").into(),
+        ),
+    };
     unsafe { std::mem::transmute(Box::into_raw(Box::new(app)) as *mut c_void) }
 }
 
@@ -515,6 +555,9 @@ unsafe extern "C" fn host_raise_error(
     };
     unsafe { std::mem::transmute(Box::into_raw(Box::new(app)) as *mut c_void) }
 }
+
+pub(crate) static HAS_FOREIGN_FINALIZERS: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
 
 pub(crate) static FOREIGN_FINALIZERS: LazyLock<Mutex<HashMap<usize, unsafe extern "C" fn(*mut c_void)>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
@@ -546,6 +589,7 @@ unsafe extern "C" fn host_register_type(
 
     if let Some(f) = finalizer {
         FOREIGN_FINALIZERS.lock().unwrap().insert(handle, f);
+        HAS_FOREIGN_FINALIZERS.store(true, std::sync::atomic::Ordering::Release);
     }
 
     handle

--- a/src/plugin_host.rs
+++ b/src/plugin_host.rs
@@ -1,0 +1,545 @@
+#![cfg(feature = "plugins")]
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::ffi::c_void;
+use std::sync::{Arc, LazyLock, Mutex};
+
+use scheme_rs_plugin_api::HostFnTable;
+
+use crate::ast::LibraryName;
+use crate::env::{TOP_LEVEL_BINDINGS, TopLevelBinding};
+use crate::exceptions::{Exception, raise};
+use crate::proc::{Application, BridgePtr, ContBarrier, Procedure};
+use crate::records::{Field, Record, RecordTypeDescriptor};
+use crate::runtime::Runtime;
+use crate::symbols::Symbol;
+use crate::value::Value as HostValue;
+
+type PluginValue = scheme_rs_plugin_api::Value;
+
+#[inline]
+unsafe fn plugin_to_host(v: PluginValue) -> HostValue {
+    unsafe { std::mem::transmute(v) }
+}
+
+#[inline]
+unsafe fn host_to_plugin(v: HostValue) -> PluginValue {
+    unsafe { std::mem::transmute(v) }
+}
+
+#[inline]
+fn plugin_ref_to_host(v: *const PluginValue) -> *const HostValue {
+    v as *const HostValue
+}
+
+// ── Value construction ─────────────────────────────────────────────────────
+
+unsafe extern "C" fn host_make_integer(n: i64) -> PluginValue {
+    let v = HostValue::from(n);
+    unsafe { host_to_plugin(v) }
+}
+
+unsafe extern "C" fn host_make_float(n: f64) -> PluginValue {
+    let v = HostValue::from(n);
+    unsafe { host_to_plugin(v) }
+}
+
+unsafe extern "C" fn host_make_string(ptr: *const u8, len: usize) -> PluginValue {
+    let s = unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, len)) };
+    let v = HostValue::from(s.to_string());
+    unsafe { host_to_plugin(v) }
+}
+
+unsafe extern "C" fn host_make_symbol(ptr: *const u8, len: usize) -> PluginValue {
+    let s = unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, len)) };
+    let sym = crate::symbols::Symbol::intern(s);
+    let v = HostValue::from(sym);
+    unsafe { host_to_plugin(v) }
+}
+
+unsafe extern "C" fn host_cons(car: PluginValue, cdr: PluginValue) -> PluginValue {
+    let car = unsafe { plugin_to_host(car) };
+    let cdr = unsafe { plugin_to_host(cdr) };
+    let pair = crate::lists::Pair::immutable(car, cdr);
+    unsafe { host_to_plugin(HostValue::from(pair)) }
+}
+
+unsafe extern "C" fn host_make_vector(elems: *const PluginValue, len: usize) -> PluginValue {
+    let slice = unsafe { std::slice::from_raw_parts(elems as *const HostValue, len) };
+    let vec: Vec<HostValue> = slice.iter().map(|v| v.clone()).collect();
+    unsafe { host_to_plugin(HostValue::from(vec)) }
+}
+
+// ── Value extraction ───────────────────────────────────────────────────────
+
+unsafe extern "C" fn host_to_integer(v: *const PluginValue) -> i64 {
+    let v = unsafe { &*plugin_ref_to_host(v) };
+    i64::try_from(v).unwrap_or(0)
+}
+
+unsafe extern "C" fn host_to_float(v: *const PluginValue) -> f64 {
+    let v = unsafe { &*plugin_ref_to_host(v) };
+    f64::try_from(v).unwrap_or(0.0)
+}
+
+unsafe extern "C" fn host_to_string_copy(
+    v: *const PluginValue,
+    out_ptr: *mut *mut u8,
+    out_len: *mut usize,
+) {
+    let v = unsafe { &*plugin_ref_to_host(v) };
+    let wide: crate::strings::WideString = match v.clone().try_into() {
+        Ok(w) => w,
+        Err(_) => {
+            unsafe {
+                *out_ptr = std::ptr::null_mut();
+                *out_len = 0;
+            }
+            return;
+        }
+    };
+    let s: String = wide.into();
+    let bytes = s.into_bytes().into_boxed_slice();
+    let len = bytes.len();
+    let ptr = Box::into_raw(bytes) as *mut u8;
+    unsafe {
+        *out_ptr = ptr;
+        *out_len = len;
+    }
+}
+
+// ── Pair ops ───────────────────────────────────────────────────────────────
+
+unsafe extern "C" fn host_car(v: *const PluginValue) -> PluginValue {
+    let v = unsafe { &*plugin_ref_to_host(v) };
+    let pair: crate::lists::Pair = v.clone().try_into().expect("car: not a pair");
+    unsafe { host_to_plugin(pair.car()) }
+}
+
+unsafe extern "C" fn host_cdr(v: *const PluginValue) -> PluginValue {
+    let v = unsafe { &*plugin_ref_to_host(v) };
+    let pair: crate::lists::Pair = v.clone().try_into().expect("cdr: not a pair");
+    unsafe { host_to_plugin(pair.cdr()) }
+}
+
+// ── Refcounting ────────────────────────────────────────────────────────────
+
+unsafe extern "C" fn host_value_retain(raw: usize) {
+    let v = unsafe { HostValue::from_raw_inc_rc(raw as *const ()) };
+    std::mem::forget(v);
+}
+
+unsafe extern "C" fn host_value_release(raw: usize) {
+    let _ = unsafe { HostValue::from_raw(raw as *const ()) };
+}
+
+// ── Plugin bridge wrapper ──────────────────────────────────────────────────
+
+/// Static bridge function that dispatches to a plugin's SimpleBridgeFn.
+/// env[0] holds the plugin function pointer as a raw i64.
+fn plugin_bridge_wrapper(
+    runtime: &Runtime,
+    env: &[HostValue],
+    k: Procedure,
+    args: &[HostValue],
+    rest_args: &[HostValue],
+    barrier: &mut ContBarrier,
+) -> Application {
+    let fn_ptr_raw: i64 = (&env[0]).try_into().unwrap_or(0);
+    let plugin_fn: scheme_rs_plugin_api::SimpleBridgeFn =
+        unsafe { std::mem::transmute(fn_ptr_raw as usize) };
+
+    let all_args: Vec<HostValue> = args.iter().chain(rest_args).cloned().collect();
+
+    let result = unsafe {
+        plugin_fn(
+            all_args.as_ptr() as *const PluginValue,
+            all_args.len(),
+        )
+    };
+
+    let raw_value = result.value.as_raw();
+    let error_ptr = result.error;
+    let error_len = result.error_len;
+    std::mem::forget(result);
+
+    if error_ptr.is_null() {
+        let host_val = unsafe { HostValue::from_raw(raw_value as *const ()) };
+        Application::new(k, None, vec![host_val])
+    } else {
+        let err_str = unsafe {
+            let slice = std::slice::from_raw_parts(error_ptr, error_len);
+            let s = String::from_utf8_lossy(slice).into_owned();
+            drop(Box::from_raw(std::slice::from_raw_parts_mut(
+                error_ptr as *mut u8,
+                error_len,
+            )));
+            s
+        };
+        raise(runtime.clone(), Exception::error(&err_str).into(), barrier)
+    }
+}
+
+// ── Pending bridge registration ────────────────────────────────────────────
+
+pub(crate) struct PendingBridge {
+    pub name: String,
+    pub lib_name: String,
+    pub num_args: usize,
+    pub variadic: bool,
+    pub func_ptr: usize,
+}
+
+pub(crate) struct PendingDefine {
+    pub name: String,
+    pub lib_name: String,
+    pub value: HostValue,
+}
+
+thread_local! {
+    static PENDING_BRIDGES: RefCell<Vec<PendingBridge>> = RefCell::new(Vec::new());
+    static PENDING_DEFINES: RefCell<Vec<PendingDefine>> = RefCell::new(Vec::new());
+    static LOADING_RUNTIME: RefCell<Option<Runtime>> = RefCell::new(None);
+    static CURRENT_LIB_NAME: RefCell<Option<String>> = RefCell::new(None);
+}
+
+pub(crate) fn set_loading_runtime(rt: &Runtime) {
+    LOADING_RUNTIME.with(|cell| *cell.borrow_mut() = Some(rt.clone()));
+}
+
+pub(crate) fn clear_loading_runtime() {
+    LOADING_RUNTIME.with(|cell| *cell.borrow_mut() = None);
+    CURRENT_LIB_NAME.with(|cell| *cell.borrow_mut() = None);
+}
+
+pub(crate) fn take_pending_bridges() -> Vec<PendingBridge> {
+    PENDING_BRIDGES.with(|pb| std::mem::take(&mut *pb.borrow_mut()))
+}
+
+pub(crate) fn take_pending_defines() -> Vec<PendingDefine> {
+    PENDING_DEFINES.with(|pd| std::mem::take(&mut *pd.borrow_mut()))
+}
+
+unsafe extern "C" fn host_register_bridge(
+    spec: *const scheme_rs_plugin_api::BridgeSpec,
+) -> bool {
+    let spec = unsafe { &*spec };
+    let name = unsafe {
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(spec.name_ptr, spec.name_len))
+    };
+    let lib_name = unsafe {
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(spec.lib_ptr, spec.lib_len))
+    };
+    let func = match spec.func {
+        Some(f) => f as usize,
+        None => return false,
+    };
+
+    let lib_name_owned = lib_name.to_string();
+    CURRENT_LIB_NAME.with(|cell| *cell.borrow_mut() = Some(lib_name_owned.clone()));
+    PENDING_BRIDGES.with(|pb| {
+        pb.borrow_mut().push(PendingBridge {
+            name: name.to_string(),
+            lib_name: lib_name_owned,
+            num_args: spec.num_args,
+            variadic: spec.variadic,
+            func_ptr: func,
+        });
+    });
+    true
+}
+
+/// Create a host Procedure wrapping a plugin's SimpleBridgeFn.
+pub(crate) fn make_plugin_procedure(
+    rt: &Runtime,
+    fn_ptr: usize,
+    num_args: usize,
+    variadic: bool,
+) -> Procedure {
+    let env = vec![HostValue::from(fn_ptr as i64)];
+    Procedure::new(
+        rt.clone(),
+        env,
+        plugin_bridge_wrapper as BridgePtr,
+        num_args,
+        variadic,
+    )
+}
+
+// ── host_call ──────────────────────────────────────────────────────────────
+
+unsafe extern "C" fn host_call(
+    proc: *const PluginValue,
+    args: *const PluginValue,
+    argc: usize,
+    err_ptr: *mut *mut u8,
+    err_len: *mut usize,
+) -> PluginValue {
+    let proc_val = unsafe { &*plugin_ref_to_host(proc) };
+    let procedure: Procedure = match proc_val.clone().try_into() {
+        Ok(p) => p,
+        Err(e) => {
+            let msg = format!("{e}");
+            let bytes = msg.into_bytes().into_boxed_slice();
+            let len = bytes.len();
+            let ptr = Box::into_raw(bytes) as *mut u8;
+            unsafe {
+                *err_ptr = ptr;
+                *err_len = len;
+            }
+            return PluginValue::undefined();
+        }
+    };
+
+    let args_slice = unsafe { std::slice::from_raw_parts(plugin_ref_to_host(args), argc) };
+    let host_args: Vec<HostValue> = args_slice.iter().map(|v| v.clone()).collect();
+
+    let mut barrier = ContBarrier::new();
+
+    #[cfg(feature = "async")]
+    let result = procedure.call_sync(&host_args, &mut barrier);
+    #[cfg(not(feature = "async"))]
+    let result = procedure.call(&host_args, &mut barrier);
+
+    match result {
+        Ok(vals) => {
+            unsafe {
+                *err_ptr = std::ptr::null_mut();
+                *err_len = 0;
+            }
+            let host_val = vals.into_iter().next().unwrap_or_else(HostValue::null);
+            unsafe { host_to_plugin(host_val) }
+        }
+        Err(e) => {
+            let msg = format!("{e}");
+            let bytes = msg.into_bytes().into_boxed_slice();
+            let len = bytes.len();
+            let ptr = Box::into_raw(bytes) as *mut u8;
+            unsafe {
+                *err_ptr = ptr;
+                *err_len = len;
+            }
+            PluginValue::undefined()
+        }
+    }
+}
+
+// ── Stubs (future tasks) ───────────────────────────────────────────────────
+
+unsafe extern "C" fn host_apply_continuation(
+    k: *const PluginValue,
+    args: *const PluginValue,
+    argc: usize,
+) -> scheme_rs_plugin_api::ApplicationResult {
+    let k_val = unsafe { &*plugin_ref_to_host(k) }.clone();
+    let k_proc: Procedure = k_val.try_into().expect("apply_continuation: k is not a procedure");
+    let args_slice = unsafe { std::slice::from_raw_parts(plugin_ref_to_host(args), argc) };
+    let args_vec: Vec<HostValue> = args_slice.iter().cloned().collect();
+    let app = Application::new(k_proc, None, args_vec);
+    unsafe { std::mem::transmute(Box::into_raw(Box::new(app)) as *mut c_void) }
+}
+
+unsafe extern "C" fn host_make_application(
+    proc_ptr: *const PluginValue,
+    k: *const PluginValue,
+    args: *const PluginValue,
+    argc: usize,
+) -> scheme_rs_plugin_api::ApplicationResult {
+    let proc_val = unsafe { &*plugin_ref_to_host(proc_ptr) }.clone();
+    let proc: Procedure = proc_val.try_into().expect("make_application: proc is not a procedure");
+    let k_val = unsafe { &*plugin_ref_to_host(k) }.clone();
+    let k_proc: Procedure = k_val.try_into().expect("make_application: k is not a procedure");
+    let args_slice = unsafe { std::slice::from_raw_parts(plugin_ref_to_host(args), argc) };
+    let args_vec: Vec<HostValue> = args_slice.iter().cloned().collect();
+    let app = Application::new(proc, Some(k_proc), args_vec);
+    unsafe { std::mem::transmute(Box::into_raw(Box::new(app)) as *mut c_void) }
+}
+
+unsafe extern "C" fn host_raise_error(
+    msg: *const u8,
+    len: usize,
+    _barrier: *mut c_void,
+) -> scheme_rs_plugin_api::ApplicationResult {
+    let err_str = unsafe {
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(msg, len))
+    };
+    let exception = Exception::error(err_str);
+    let app = Application::halt_err(exception.into());
+    unsafe { std::mem::transmute(Box::into_raw(Box::new(app)) as *mut c_void) }
+}
+
+static FOREIGN_FINALIZERS: LazyLock<Mutex<HashMap<usize, unsafe extern "C" fn(*mut c_void)>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+unsafe extern "C" fn host_register_type(
+    name: *const u8,
+    name_len: usize,
+    finalizer: Option<unsafe extern "C" fn(*mut c_void)>,
+) -> usize {
+    let name_str =
+        unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(name, name_len)) };
+    let sym = Symbol::intern(name_str);
+    let data_sym = Symbol::intern("data");
+
+    let rtd = Arc::new(RecordTypeDescriptor {
+        name: sym,
+        sealed: true,
+        opaque: true,
+        uid: Some(sym),
+        embedded_vtable: None,
+        embedded_constructor: None,
+        inherits: indexmap::IndexSet::new(),
+        num_inherited_fields: 0,
+        fields: vec![Field::Immutable(data_sym)],
+    });
+
+    let ptr = Arc::into_raw(rtd);
+    let handle = ptr as usize;
+
+    if let Some(f) = finalizer {
+        FOREIGN_FINALIZERS.lock().unwrap().insert(handle, f);
+    }
+
+    handle
+}
+
+unsafe extern "C" fn host_make_foreign(type_handle: usize, data: *mut c_void) -> PluginValue {
+    let rtd_ptr = type_handle as *const RecordTypeDescriptor;
+    let rtd = unsafe { Arc::from_raw(rtd_ptr) };
+    let rtd_clone = rtd.clone();
+    std::mem::forget(rtd);
+
+    let record = Record::new_plain(
+        rtd_clone,
+        vec![HostValue::from(data as usize as i64)],
+    );
+
+    unsafe { host_to_plugin(HostValue::from(record)) }
+}
+
+unsafe extern "C" fn host_get_foreign(
+    type_handle: usize,
+    value: *const PluginValue,
+) -> *mut c_void {
+    let v = unsafe { &*plugin_ref_to_host(value) };
+    let record: Record = match v.clone().try_into() {
+        Ok(r) => r,
+        Err(_) => return std::ptr::null_mut(),
+    };
+
+    let rtd_ptr = type_handle as *const RecordTypeDescriptor;
+    let expected_rtd = unsafe { Arc::from_raw(rtd_ptr) };
+    let matches = Arc::ptr_eq(&record.rtd(), &expected_rtd);
+    std::mem::forget(expected_rtd);
+
+    if !matches {
+        return std::ptr::null_mut();
+    }
+
+    let data_val = record.0.fields()[0].clone();
+    let ptr: i64 = match (&data_val).try_into() {
+        Ok(n) => n,
+        Err(_) => return std::ptr::null_mut(),
+    };
+
+    ptr as usize as *mut c_void
+}
+
+unsafe extern "C" fn host_define(name_ptr: *const u8, name_len: usize, value: PluginValue) {
+    let name = unsafe {
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(name_ptr, name_len))
+    };
+    let lib_name = CURRENT_LIB_NAME.with(|cell| cell.borrow().clone());
+    let Some(lib_name) = lib_name else {
+        panic!("host_define called without a current library (call register_bridge first)");
+    };
+    let host_val = unsafe { plugin_to_host(value) };
+    PENDING_DEFINES.with(|pd| {
+        pd.borrow_mut().push(PendingDefine {
+            name: name.to_string(),
+            lib_name,
+            value: host_val,
+        });
+    });
+}
+
+unsafe extern "C" fn host_lookup(
+    module_ptr: *const u8,
+    module_len: usize,
+    name_ptr: *const u8,
+    name_len: usize,
+) -> PluginValue {
+    let module_str = unsafe {
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(module_ptr, module_len))
+    };
+    let name_str = unsafe {
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(name_ptr, name_len))
+    };
+
+    let rt = LOADING_RUNTIME.with(|cell| cell.borrow().clone());
+    let Some(rt) = rt else {
+        panic!("host_lookup called outside of plugin loading context");
+    };
+
+    let lib_name = match LibraryName::from_str(module_str, None) {
+        Ok(ln) => ln,
+        Err(_) => return PluginValue::undefined(),
+    };
+
+    let registry = rt.get_registry();
+    let registry_inner = registry.0.read();
+    let Some(lib) = registry_inner.libs.get(&lib_name.name) else {
+        return PluginValue::undefined();
+    };
+
+    let sym = Symbol::intern(name_str);
+    let lib_inner = lib.0.read();
+    let Some(export) = lib_inner.exports.get(&sym) else {
+        return PluginValue::undefined();
+    };
+
+    let binding = export.binding;
+    drop(lib_inner);
+    drop(registry_inner);
+
+    let top_level = TOP_LEVEL_BINDINGS.lock();
+    match top_level.get(&binding) {
+        Some(TopLevelBinding::Global(global)) => {
+            let val = global.read();
+            unsafe { host_to_plugin(val) }
+        }
+        _ => PluginValue::undefined(),
+    }
+}
+
+// ── Table construction ─────────────────────────────────────────────────────
+
+pub fn build_host_fn_table() -> &'static HostFnTable {
+    let table = HostFnTable {
+        make_integer: host_make_integer,
+        make_float: host_make_float,
+        make_string: host_make_string,
+        make_symbol: host_make_symbol,
+        cons: host_cons,
+        make_vector: host_make_vector,
+        to_integer: host_to_integer,
+        to_float: host_to_float,
+        to_string_copy: host_to_string_copy,
+        car: host_car,
+        cdr: host_cdr,
+        call: host_call,
+        apply_continuation: host_apply_continuation,
+        make_application: host_make_application,
+        raise_error: host_raise_error,
+        register_type: host_register_type,
+        make_foreign: host_make_foreign,
+        get_foreign: host_get_foreign,
+        register_bridge: host_register_bridge,
+        value_retain: host_value_retain,
+        value_release: host_value_release,
+        define: host_define,
+        lookup: host_lookup,
+    };
+    Box::leak(Box::new(table))
+}

--- a/src/plugin_host.rs
+++ b/src/plugin_host.rs
@@ -3,7 +3,7 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ffi::c_void;
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::{Arc, LazyLock, Mutex, OnceLock};
 
 use scheme_rs_plugin_api::HostFnTable;
 
@@ -181,6 +181,36 @@ fn plugin_bridge_wrapper(
     }
 }
 
+/// CPS bridge wrapper: dispatches to a plugin's CpsBridgeFn.
+/// env[0] holds the CPS function pointer as a raw i64.
+fn plugin_cps_bridge_wrapper(
+    _runtime: &Runtime,
+    env: &[HostValue],
+    k: Procedure,
+    args: &[HostValue],
+    rest_args: &[HostValue],
+    barrier: &mut ContBarrier,
+) -> Application {
+    let fn_ptr_raw: i64 = (&env[0]).try_into().unwrap_or(0);
+    let cps_fn: scheme_rs_plugin_api::CpsBridgeFn =
+        unsafe { std::mem::transmute(fn_ptr_raw as usize) };
+
+    let k_val = HostValue::from(k);
+    let all_args: Vec<HostValue> = args.iter().chain(rest_args).cloned().collect();
+
+    let result = unsafe {
+        cps_fn(
+            &k_val as *const HostValue as *const PluginValue,
+            all_args.as_ptr() as *const PluginValue,
+            all_args.len(),
+            barrier as *mut ContBarrier as *mut c_void,
+        )
+    };
+
+    let app_ptr: *mut Application = unsafe { std::mem::transmute(result) };
+    unsafe { *Box::from_raw(app_ptr) }
+}
+
 // ── Pending bridge registration ────────────────────────────────────────────
 
 pub(crate) struct PendingBridge {
@@ -189,12 +219,24 @@ pub(crate) struct PendingBridge {
     pub num_args: usize,
     pub variadic: bool,
     pub func_ptr: usize,
+    pub cps_func_ptr: Option<usize>,
+    pub blocking: bool,
 }
 
 pub(crate) struct PendingDefine {
     pub name: String,
     pub lib_name: String,
     pub value: HostValue,
+}
+
+static PERSISTENT_RUNTIME: OnceLock<Runtime> = OnceLock::new();
+
+pub(crate) fn set_persistent_runtime(rt: &Runtime) {
+    PERSISTENT_RUNTIME.get_or_init(|| rt.clone());
+}
+
+pub(crate) fn get_persistent_runtime() -> Option<Runtime> {
+    PERSISTENT_RUNTIME.get().cloned()
 }
 
 thread_local! {
@@ -236,6 +278,8 @@ unsafe extern "C" fn host_register_bridge(
         None => return false,
     };
 
+    let cps_func_ptr = spec.cps_func.map(|f| f as usize);
+
     let lib_name_owned = lib_name.to_string();
     CURRENT_LIB_NAME.with(|cell| *cell.borrow_mut() = Some(lib_name_owned.clone()));
     PENDING_BRIDGES.with(|pb| {
@@ -245,6 +289,8 @@ unsafe extern "C" fn host_register_bridge(
             num_args: spec.num_args,
             variadic: spec.variadic,
             func_ptr: func,
+            cps_func_ptr,
+            blocking: spec.blocking,
         });
     });
     true
@@ -262,6 +308,102 @@ pub(crate) fn make_plugin_procedure(
         rt.clone(),
         env,
         plugin_bridge_wrapper as BridgePtr,
+        num_args,
+        variadic,
+    )
+}
+
+/// Create a host Procedure wrapping a plugin's CpsBridgeFn.
+pub(crate) fn make_plugin_cps_procedure(
+    rt: &Runtime,
+    fn_ptr: usize,
+    num_args: usize,
+    variadic: bool,
+) -> Procedure {
+    let env = vec![HostValue::from(fn_ptr as i64)];
+    Procedure::new(
+        rt.clone(),
+        env,
+        plugin_cps_bridge_wrapper as BridgePtr,
+        num_args,
+        variadic,
+    )
+}
+
+/// Create an async Procedure wrapping a blocking plugin SimpleBridgeFn.
+#[cfg(feature = "async")]
+pub(crate) fn make_plugin_blocking_procedure(
+    rt: &Runtime,
+    fn_ptr: usize,
+    num_args: usize,
+    variadic: bool,
+) -> Procedure {
+    use crate::proc::AsyncBridgePtr;
+
+    struct BlockingResult {
+        raw_value: usize,
+        error: Option<String>,
+    }
+
+    unsafe impl Send for BlockingResult {}
+
+    fn plugin_blocking_bridge_wrapper<'a>(
+        runtime: &'a Runtime,
+        env: &'a [HostValue],
+        k: Procedure,
+        args: &'a [HostValue],
+        rest_args: &'a [HostValue],
+        barrier: &'a mut ContBarrier<'_>,
+    ) -> futures::future::BoxFuture<'a, Application> {
+        Box::pin(async move {
+            let fn_ptr_raw: i64 = (&env[0]).try_into().unwrap_or(0);
+            let plugin_fn: scheme_rs_plugin_api::SimpleBridgeFn =
+                unsafe { std::mem::transmute(fn_ptr_raw as usize) };
+
+            let all_args: Vec<HostValue> = args.iter().chain(rest_args).cloned().collect();
+            let rt_clone = runtime.clone();
+
+            let result = tokio::task::spawn_blocking(move || {
+                let ret = unsafe {
+                    plugin_fn(
+                        all_args.as_ptr() as *const PluginValue,
+                        all_args.len(),
+                    )
+                };
+                let raw_value = ret.value.as_raw();
+                let error = if ret.error.is_null() {
+                    None
+                } else {
+                    Some(unsafe {
+                        let slice = std::slice::from_raw_parts(ret.error, ret.error_len);
+                        let s = String::from_utf8_lossy(slice).into_owned();
+                        drop(Box::from_raw(std::slice::from_raw_parts_mut(
+                            ret.error as *mut u8,
+                            ret.error_len,
+                        )));
+                        s
+                    })
+                };
+                std::mem::forget(ret);
+                BlockingResult { raw_value, error }
+            })
+            .await
+            .expect("spawn_blocking join failed");
+
+            if let Some(err_str) = result.error {
+                raise(rt_clone, Exception::error(&err_str).into(), barrier)
+            } else {
+                let host_val = unsafe { HostValue::from_raw(result.raw_value as *const ()) };
+                Application::new(k, None, vec![host_val])
+            }
+        })
+    }
+
+    let env = vec![HostValue::from(fn_ptr as i64)];
+    Procedure::new(
+        rt.clone(),
+        env,
+        plugin_blocking_bridge_wrapper as AsyncBridgePtr,
         num_args,
         variadic,
     )
@@ -359,17 +501,22 @@ unsafe extern "C" fn host_make_application(
 unsafe extern "C" fn host_raise_error(
     msg: *const u8,
     len: usize,
-    _barrier: *mut c_void,
+    barrier: *mut c_void,
 ) -> scheme_rs_plugin_api::ApplicationResult {
     let err_str = unsafe {
         std::str::from_utf8_unchecked(std::slice::from_raw_parts(msg, len))
     };
     let exception = Exception::error(err_str);
-    let app = Application::halt_err(exception.into());
+    let app = if let Some(rt) = get_persistent_runtime() {
+        let barrier = unsafe { &mut *(barrier as *mut ContBarrier) };
+        raise(rt, exception.into(), barrier)
+    } else {
+        Application::halt_err(exception.into())
+    };
     unsafe { std::mem::transmute(Box::into_raw(Box::new(app)) as *mut c_void) }
 }
 
-static FOREIGN_FINALIZERS: LazyLock<Mutex<HashMap<usize, unsafe extern "C" fn(*mut c_void)>>> =
+pub(crate) static FOREIGN_FINALIZERS: LazyLock<Mutex<HashMap<usize, unsafe extern "C" fn(*mut c_void)>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 unsafe extern "C" fn host_register_type(

--- a/src/records.rs
+++ b/src/records.rs
@@ -686,6 +686,11 @@ impl RecordInner {
         if self.rtd.embedded_vtable.is_some() {
             return;
         }
+        if !crate::plugin_host::HAS_FOREIGN_FINALIZERS
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return;
+        }
         let handle = Arc::as_ptr(&self.rtd) as usize;
         let finalizer = {
             let map = crate::plugin_host::FOREIGN_FINALIZERS.lock().unwrap();

--- a/src/records.rs
+++ b/src/records.rs
@@ -680,6 +680,30 @@ impl RecordInner {
     }
 }
 
+#[cfg(feature = "plugins")]
+impl RecordInner {
+    fn run_foreign_finalizer(&self) {
+        if self.rtd.embedded_vtable.is_some() {
+            return;
+        }
+        let handle = Arc::as_ptr(&self.rtd) as usize;
+        let finalizer = {
+            let map = crate::plugin_host::FOREIGN_FINALIZERS.lock().unwrap();
+            map.get(&handle).copied()
+        };
+        if let Some(finalizer) = finalizer {
+            let fields = self.fields();
+            if let Some(field) = fields.first() {
+                if let Ok(ptr_val) = i64::try_from(field) {
+                    unsafe {
+                        finalizer(ptr_val as usize as *mut std::ffi::c_void);
+                    }
+                }
+            }
+        }
+    }
+}
+
 unsafe impl Trace for RecordInner {
     unsafe fn visit_children(&self, visitor: &mut dyn FnMut(crate::gc::OpaqueGcPtr)) {
         let num_fields = self.num_unembedded_fields();
@@ -697,6 +721,9 @@ unsafe impl Trace for RecordInner {
     }
 
     unsafe fn finalize(&mut self) {
+        #[cfg(feature = "plugins")]
+        self.run_foreign_finalizer();
+
         unsafe {
             self.rtd.finalize();
         }

--- a/src/records.rs
+++ b/src/records.rs
@@ -408,6 +408,39 @@ impl Record {
         Self(inner)
     }
 
+    pub(crate) fn new_plain(rtd: Arc<RecordTypeDescriptor>, field_values: Vec<Value>) -> Self {
+        let prefix = Layout::from_size_align(
+            RecordInner::fields_offset(),
+            align_of::<GcInner<RecordInner>>(),
+        )
+        .unwrap();
+        let (layout, fields_offset) = prefix
+            .extend(Layout::array::<Value>(field_values.len()).unwrap())
+            .unwrap();
+        let layout = layout.pad_to_align();
+
+        unsafe {
+            let record = alloc::alloc(layout) as *mut GcInner<RecordInner>;
+            ptr::write(
+                record,
+                GcInner::new(RecordInner {
+                    rtd,
+                    fields: [],
+                }),
+            );
+            let fields_ptr = record.byte_add(fields_offset) as *mut Value;
+            for (i, field) in field_values.into_iter().enumerate() {
+                fields_ptr.add(i).write(field);
+            }
+            let inner = Gc {
+                ptr: NonNull::new(record).unwrap(),
+                marker: PhantomData,
+            };
+            crate::gc::unroot(&inner, layout);
+            Self(inner)
+        }
+    }
+
     pub fn cast<E: Embeddable>(&self) -> Option<Embedded<E>> {
         let embedded_ptr = self.0.embedded_ptr()?;
         let embedded_vtable = self.0.rtd.embedded_vtable.as_ref()?;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -736,8 +736,8 @@ pub mod plugin_loading {
     };
     use crate::exceptions::Exception;
     use crate::plugin_host::{
-        clear_loading_runtime, make_plugin_procedure, set_loading_runtime, take_pending_bridges,
-        take_pending_defines,
+        clear_loading_runtime, make_plugin_cps_procedure, make_plugin_procedure,
+        set_loading_runtime, set_persistent_runtime, take_pending_bridges, take_pending_defines,
     };
     use crate::runtime::Runtime;
     use crate::symbols::Symbol;
@@ -794,6 +794,7 @@ pub mod plugin_loading {
             })?;
 
             let table = crate::plugin_host::build_host_fn_table();
+            set_persistent_runtime(rt);
             set_loading_runtime(rt);
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
                 init_fn(table as *const scheme_rs_plugin_api::HostFnTable as *const ());
@@ -832,12 +833,38 @@ pub mod plugin_loading {
                     syms: HashMap::default(),
                 });
 
-                let proc = make_plugin_procedure(
-                    rt,
-                    bridge.func_ptr,
-                    bridge.num_args,
-                    bridge.variadic,
-                );
+                let proc = if let Some(cps_ptr) = bridge.cps_func_ptr {
+                    make_plugin_cps_procedure(
+                        rt,
+                        cps_ptr,
+                        bridge.num_args,
+                        bridge.variadic,
+                    )
+                } else {
+                    #[cfg(feature = "async")]
+                    if bridge.blocking {
+                        crate::plugin_host::make_plugin_blocking_procedure(
+                            rt,
+                            bridge.func_ptr,
+                            bridge.num_args,
+                            bridge.variadic,
+                        )
+                    } else {
+                        make_plugin_procedure(
+                            rt,
+                            bridge.func_ptr,
+                            bridge.num_args,
+                            bridge.variadic,
+                        )
+                    }
+                    #[cfg(not(feature = "async"))]
+                    make_plugin_procedure(
+                        rt,
+                        bridge.func_ptr,
+                        bridge.num_args,
+                        bridge.variadic,
+                    )
+                };
 
                 lib.syms.insert(Symbol::intern(&bridge.name), proc);
             }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -396,7 +396,7 @@ impl Registry {
     /// feature flags as the host. Version is checked at load time but
     /// ABI drift from different compilers is not detected.
     #[cfg(feature = "plugins")]
-    pub unsafe fn load_plugin(
+    pub unsafe fn load_rust_abi_plugin(
         &self,
         rt: &Runtime,
         library: libloading::Library,
@@ -721,4 +721,213 @@ fn load_lib_from_dir(
     }
 
     Ok(None)
+}
+
+// ── Plugin loading ─────────────────────────────────────────────────────────
+
+#[cfg(feature = "plugins")]
+pub mod plugin_loading {
+    use std::path::Path;
+
+    use crate::ast::{LibraryName, Version};
+    use crate::env::{
+        Binding, Export, Global, LibraryState, Scope, TOP_LEVEL_BINDINGS, TopLevelBinding,
+        TopLevelEnvironment, TopLevelEnvironmentInner, TopLevelKind, add_binding,
+    };
+    use crate::exceptions::Exception;
+    use crate::plugin_host::{
+        clear_loading_runtime, make_plugin_procedure, set_loading_runtime, take_pending_bridges,
+        take_pending_defines,
+    };
+    use crate::runtime::Runtime;
+    use crate::symbols::Symbol;
+    use crate::syntax::Identifier;
+    use crate::value::{Cell, Value};
+
+    use parking_lot::RwLock;
+    use rustc_hash::FxHashMap as HashMap;
+
+    use super::{Gc, Registry};
+
+    pub struct PluginHandle {
+        _lib: libloading::Library,
+    }
+
+    const EXPECTED_ABI_VERSION: u32 = 1;
+
+    impl Registry {
+        /// Load a plugin from a dynamic library path, registering its bridges.
+        ///
+        /// # Safety
+        /// The caller must ensure the library at `path` is a valid scheme-rs plugin.
+        pub unsafe fn load_plugin(
+            &self,
+            rt: &Runtime,
+            path: &Path,
+        ) -> Result<PluginHandle, Exception> {
+            let lib = unsafe { libloading::Library::new(path) }
+                .map_err(|e| Exception::error(&format!("failed to load plugin: {e}")))?;
+
+            let abi_version_fn: libloading::Symbol<unsafe extern "C" fn() -> u32> = unsafe {
+                lib.get(b"scheme_rs_plugin_abi_version")
+            }
+            .map_err(|e| {
+                Exception::error(&format!(
+                    "plugin missing scheme_rs_plugin_abi_version symbol: {e}"
+                ))
+            })?;
+
+            let version = unsafe { abi_version_fn() };
+            if version != EXPECTED_ABI_VERSION {
+                return Err(Exception::error(&format!(
+                    "plugin ABI version mismatch: expected {EXPECTED_ABI_VERSION}, got {version}"
+                )));
+            }
+
+            let init_fn: libloading::Symbol<unsafe extern "C" fn(*const ())> = unsafe {
+                lib.get(b"scheme_rs_plugin_init")
+            }
+            .map_err(|e| {
+                Exception::error(&format!(
+                    "plugin missing scheme_rs_plugin_init symbol: {e}"
+                ))
+            })?;
+
+            let table = crate::plugin_host::build_host_fn_table();
+            set_loading_runtime(rt);
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+                init_fn(table as *const scheme_rs_plugin_api::HostFnTable as *const ());
+            }));
+
+            let pending_bridges = take_pending_bridges();
+            let pending_defines = take_pending_defines();
+            clear_loading_runtime();
+
+            if let Err(payload) = result {
+                std::panic::resume_unwind(payload);
+            }
+
+            self.register_plugin_bridges(rt, &pending_bridges);
+            self.register_plugin_defines(rt, &pending_defines);
+
+            Ok(PluginHandle { _lib: lib })
+        }
+
+        fn register_plugin_bridges(
+            &self,
+            rt: &Runtime,
+            bridges: &[crate::plugin_host::PendingBridge],
+        ) {
+            struct Lib {
+                version: Version,
+                syms: HashMap<Symbol, crate::proc::Procedure>,
+            }
+            let mut libs = HashMap::<Vec<Symbol>, Lib>::default();
+
+            for bridge in bridges {
+                let lib_name =
+                    LibraryName::from_str(&bridge.lib_name, None).unwrap();
+                let lib = libs.entry(lib_name.name).or_insert_with(|| Lib {
+                    version: lib_name.version,
+                    syms: HashMap::default(),
+                });
+
+                let proc = make_plugin_procedure(
+                    rt,
+                    bridge.func_ptr,
+                    bridge.num_args,
+                    bridge.variadic,
+                );
+
+                lib.syms.insert(Symbol::intern(&bridge.name), proc);
+            }
+
+            let mut registry = self.0.write();
+
+            for (name, lib) in libs {
+                let scope = Scope::new();
+
+                let exports: Vec<_> = lib
+                    .syms
+                    .into_iter()
+                    .map(|(sym, proc)| {
+                        let binding = Binding::new();
+                        add_binding(Identifier::from_symbol(sym, scope), binding);
+                        (sym, proc, Export { binding, origin: None })
+                    })
+                    .collect();
+
+                let top = TopLevelEnvironment(Gc::new(RwLock::new(
+                    TopLevelEnvironmentInner {
+                        rt: rt.clone(),
+                        kind: TopLevelKind::Libary {
+                            name: LibraryName {
+                                version: lib.version,
+                                name: name.clone(),
+                            },
+                            path: None,
+                        },
+                        imports: HashMap::default(),
+                        exports: exports
+                            .iter()
+                            .map(|(sym, _, exp)| (*sym, exp.clone()))
+                            .collect(),
+                        state: LibraryState::Invoked,
+                        scope,
+                    },
+                )));
+
+                for (sym, proc, export) in exports {
+                    TOP_LEVEL_BINDINGS.lock().insert(
+                        export.binding,
+                        TopLevelBinding::Global(Global::new(
+                            sym,
+                            Cell::new(Value::from(proc)),
+                            false,
+                            top.clone(),
+                        )),
+                    );
+                }
+
+                registry.libs.insert(name, top);
+            }
+        }
+
+        fn register_plugin_defines(
+            &self,
+            _rt: &Runtime,
+            defines: &[crate::plugin_host::PendingDefine],
+        ) {
+            let registry = self.0.read();
+
+            for def in defines {
+                let lib_name = LibraryName::from_str(&def.lib_name, None).unwrap();
+                let sym = Symbol::intern(&def.name);
+
+                if let Some(lib) = registry.libs.get(&lib_name.name) {
+                    let scope = lib.0.read().scope;
+                    let binding = Binding::new();
+                    add_binding(Identifier::from_symbol(sym, scope), binding);
+
+                    lib.0.write().exports.insert(
+                        sym,
+                        Export {
+                            binding,
+                            origin: None,
+                        },
+                    );
+
+                    TOP_LEVEL_BINDINGS.lock().insert(
+                        binding,
+                        TopLevelBinding::Global(Global::new(
+                            sym,
+                            Cell::new(def.value.clone()),
+                            false,
+                            lib.clone(),
+                        )),
+                    );
+                }
+            }
+        }
+    }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -749,23 +749,33 @@ pub mod plugin_loading {
 
     use super::{Gc, Registry};
 
-    pub struct PluginHandle {
-        _lib: libloading::Library,
-    }
-
     const EXPECTED_ABI_VERSION: u32 = 1;
 
     impl Registry {
         /// Load a plugin from a dynamic library path, registering its bridges.
         ///
+        /// The library is stored in the registry with `ManuallyDrop` to prevent
+        /// dlclose — function pointers from the plugin live for the process lifetime.
+        ///
         /// # Safety
-        /// The caller must ensure the library at `path` is a valid scheme-rs plugin.
+        /// The caller must ensure the path points to a valid scheme-rs plugin.
         pub unsafe fn load_plugin(
             &self,
             rt: &Runtime,
             path: &Path,
-        ) -> Result<PluginHandle, Exception> {
-            let lib = unsafe { libloading::Library::new(path) }
+        ) -> Result<(), Exception> {
+            let canonical = std::fs::canonicalize(path).map_err(|e| {
+                Exception::error(&format!("failed to resolve plugin path: {e}"))
+            })?;
+
+            {
+                let inner = self.0.read();
+                if inner.loaded_plugin_paths.contains(&canonical) {
+                    return Ok(());
+                }
+            }
+
+            let lib = unsafe { libloading::Library::new(&canonical) }
                 .map_err(|e| Exception::error(&format!("failed to load plugin: {e}")))?;
 
             let abi_version_fn: libloading::Symbol<unsafe extern "C" fn() -> u32> = unsafe {
@@ -811,7 +821,11 @@ pub mod plugin_loading {
             self.register_plugin_bridges(rt, &pending_bridges);
             self.register_plugin_defines(rt, &pending_defines);
 
-            Ok(PluginHandle { _lib: lib })
+            let mut inner = self.0.write();
+            inner.plugins.push(super::PluginHandle::new(lib));
+            inner.loaded_plugin_paths.insert(canonical);
+
+            Ok(())
         }
 
         fn register_plugin_bridges(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -156,7 +156,7 @@ impl Runtime {
 
     /// # Safety
     ///
-    /// See [`Registry::load_plugin`].
+    /// See [`Registry::load_rust_abi_plugin`].
     #[cfg(feature = "plugins")]
     pub unsafe fn load_rust_abi_plugin(&self, library: libloading::Library) -> Result<(), Exception> {
         unsafe { self.get_registry().load_rust_abi_plugin(self, library) }
@@ -197,7 +197,7 @@ impl Runtime {
     pub unsafe fn load_plugin(
         &self,
         path: &std::path::Path,
-    ) -> Result<crate::registry::plugin_loading::PluginHandle, Exception> {
+    ) -> Result<(), Exception> {
         unsafe { self.get_registry().load_plugin(self, path) }
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -158,8 +158,8 @@ impl Runtime {
     ///
     /// See [`Registry::load_plugin`].
     #[cfg(feature = "plugins")]
-    pub unsafe fn load_plugin(&self, library: libloading::Library) -> Result<(), Exception> {
-        unsafe { self.get_registry().load_plugin(self, library) }
+    pub unsafe fn load_rust_abi_plugin(&self, library: libloading::Library) -> Result<(), Exception> {
+        unsafe { self.get_registry().load_rust_abi_plugin(self, library) }
     }
 
     pub(crate) fn get_registry(&self) -> Registry {
@@ -187,6 +187,18 @@ impl Runtime {
 
     pub fn source_cache(&self) -> MappedRwLockWriteGuard<'_, SourceCache> {
         RwLockWriteGuard::map(self.0.write(), |inner| &mut inner.source_cache)
+    }
+
+    /// Load a plugin from a dynamic library path.
+    ///
+    /// # Safety
+    /// The caller must ensure the path points to a valid scheme-rs plugin.
+    #[cfg(feature = "plugins")]
+    pub unsafe fn load_plugin(
+        &self,
+        path: &std::path::Path,
+    ) -> Result<crate::registry::plugin_loading::PluginHandle, Exception> {
+        unsafe { self.get_registry().load_plugin(self, path) }
     }
 }
 

--- a/tests/plugins.rs
+++ b/tests/plugins.rs
@@ -34,8 +34,7 @@ fn load_plugin_and_call_bridges() {
     assert!(dylib.exists(), "test plugin dylib not found at {dylib:?}");
 
     let rt = Runtime::new();
-    let lib = unsafe { libloading::Library::new(&dylib) }.expect("failed to dlopen test plugin");
-    unsafe { rt.load_plugin(lib) }.expect("failed to load plugin bridges");
+    unsafe { rt.load_plugin(&dylib) }.expect("failed to load plugin");
 
     scheme_rs_macros::maybe_await!(rt.run_program(Path::new("tests/plugins.scm")))
         .expect("scheme test failed");
@@ -60,21 +59,9 @@ fn load_same_plugin_twice_is_ok() {
     let dylib = plugin_dir.join(test_plugin_dylib_name());
 
     let rt = Runtime::new();
-    let lib1 = unsafe { libloading::Library::new(&dylib) }.unwrap();
-    unsafe { rt.load_plugin(lib1) }.expect("first load failed");
-
-    let lib2 = unsafe { libloading::Library::new(&dylib) }.unwrap();
-    unsafe { rt.load_plugin(lib2) }.expect("second load should succeed");
+    unsafe { rt.load_plugin(&dylib) }.expect("first load failed");
+    unsafe { rt.load_plugin(&dylib) }.expect("second load should succeed");
 
     scheme_rs_macros::maybe_await!(rt.run_program(Path::new("tests/plugins.scm")))
         .expect("bridges should work after double load");
-}
-
-#[cfg(feature = "plugins")]
-#[test]
-fn version_constant_matches_crate() {
-    assert_eq!(
-        scheme_rs::registry::SCHEME_RS_VERSION,
-        env!("CARGO_PKG_VERSION"),
-    );
 }

--- a/tests/plugins.scm
+++ b/tests/plugins.scm
@@ -3,3 +3,6 @@
 (assert-equal? (test-plugin-add 2 3) 5)
 (assert-equal? (test-plugin-add -1 1) 0)
 (assert-equal? (test-plugin-greeting) "hello from plugin")
+(assert-equal? (counter-value (make-counter 42)) 42)
+(assert-equal? (counter-value (make-counter 0)) 0)
+(assert-equal? (counter-value (make-counter -7)) -7)

--- a/tests/test-plugin/Cargo.toml
+++ b/tests/test-plugin/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-scheme-rs = { path = "../..", features = ["plugins", "async", "tokio"] }
+scheme-rs-plugin-api = { path = "../../plugin-api" }

--- a/tests/test-plugin/src/lib.rs
+++ b/tests/test-plugin/src/lib.rs
@@ -1,13 +1,55 @@
-use scheme_rs::exceptions::Exception;
-use scheme_rs::registry::bridge;
-use scheme_rs::value::Value;
+use std::ffi::c_void;
+use std::sync::OnceLock;
 
-#[bridge(name = "test-plugin-add", lib = "(test plugin)")]
-fn test_plugin_add(a: i64, b: i64) -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from(a + b)])
+use scheme_rs_plugin_api::*;
+
+#[plugin_bridge(name = "test-plugin-add", lib = "(test plugin)")]
+fn add(a: i64, b: i64) -> Result<i64, PluginError> {
+    Ok(a + b)
 }
 
-#[bridge(name = "test-plugin-greeting", lib = "(test plugin)")]
-fn test_plugin_greeting() -> Result<Vec<Value>, Exception> {
-    Ok(vec![Value::from("hello from plugin".to_string())])
+#[plugin_bridge(name = "test-plugin-greeting", lib = "(test plugin)")]
+fn greeting() -> Result<String, PluginError> {
+    Ok("hello from plugin".to_string())
+}
+
+struct Counter {
+    count: i64,
+}
+
+static COUNTER_TYPE: OnceLock<TypeHandle> = OnceLock::new();
+
+#[plugin_bridge(name = "make-counter", lib = "(test plugin)")]
+fn make_counter(initial: i64) -> Result<Value, PluginError> {
+    let counter = Box::new(Counter { count: initial });
+    let handle = *COUNTER_TYPE.get().unwrap();
+    Ok(make_foreign(handle, Box::into_raw(counter) as *mut c_void))
+}
+
+#[plugin_bridge(name = "counter-value", lib = "(test plugin)")]
+fn counter_value(v: Value) -> Result<i64, PluginError> {
+    let handle = *COUNTER_TYPE.get().unwrap();
+    let ptr = get_foreign(handle, &v);
+    if ptr.is_null() {
+        return Err(PluginError::type_error("expected counter"));
+    }
+    let counter = unsafe { &*(ptr as *const Counter) };
+    Ok(counter.count)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn scheme_rs_plugin_abi_version() -> u32 {
+    1
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn scheme_rs_plugin_init(host_table: *const ()) {
+    unsafe { scheme_rs_plugin_api::host::_init_host(host_table) };
+
+    COUNTER_TYPE.set(register_type("counter", None)).ok();
+
+    register_bridge(&__plugin_bridge_spec_add());
+    register_bridge(&__plugin_bridge_spec_greeting());
+    register_bridge(&__plugin_bridge_spec_make_counter());
+    register_bridge(&__plugin_bridge_spec_counter_value());
 }


### PR DESCRIPTION
First approach to plugins was a little naive. I didn't think about the two heaps being different. This is a first attempt at a more structured approach. 

## Summary

Replaces the dual-runtime plugin system with a stable C-ABI boundary. Plugins now depend on a thin `scheme-rs-plugin-api` subcrate instead of `scheme-rs` itself. No shared heap, no duplicated statics, no TypeId mismatches.

- **`plugin-api/`** subcrate with `Value` type (identical layout to host), conversion traits, opaque handles, and a `#[plugin_bridge]` proc macro
- **Host function table** passed at init time — plugins dispatch through it, but this is invisible to plugin authors
- **Three bridge tiers**: simple (auto-wrapped), CPS (continuation-aware), blocking async
- **Foreign type registration** with RTD identity and type-checked extraction
- **Module interaction** via `define`/`lookup`

## What a plugin looks like

```rust
use scheme_rs_plugin_api::*;

#[plugin_bridge(name = "add", lib = "(math)")]
fn add(a: i64, b: i64) -> Result<i64, PluginError> { Ok(a + b) }

#[unsafe(no_mangle)]
pub extern "C" fn scheme_rs_plugin_abi_version() -> u32 { 1 }

#[unsafe(no_mangle)]
pub extern "C" fn scheme_rs_plugin_init(host: *const ()) {
    unsafe { host::_init_host(host) };
    register_bridge(&__plugin_bridge_spec_add());
}
```

## Test plan

- [x] `cargo test --features plugins` — all tests pass
- [x] Test-plugin loads, registers bridges, calls Scheme procedures
- [x] Foreign type creation/extraction works (counter test)
- [x] Plugin depends only on `scheme-rs-plugin-api`, not `scheme-rs`
- [x] Double-loading a plugin is idempotent