### PR TITLE
PrimOp::Matches missing needs_drop drops a live slot after macro expansion

### DIFF
--- a/src/cps/mod.rs
+++ b/src/cps/mod.rs
@@ -158,7 +158,7 @@ impl PrimOp {
             Self::Not => PrimOpInfo::new(1, false, false, false),
             Self::GetFrame => PrimOpInfo::new(1, false, false, true),
             Self::SetContinuationMark => PrimOpInfo::new(2, false, false, false),
-            Self::Matches => PrimOpInfo::new(2, false, false, false),
+            Self::Matches => PrimOpInfo::new(2, false, false, true),
             Self::ExpandTemplate => PrimOpInfo::new(4, false, true, true),
             Self::ErrorNoPatternsMatch => PrimOpInfo::new(0, false, false, false),
         }


### PR DESCRIPTION
Found the missing increment discussed in #326.


