### PR TITLE
perf: use mimalloc as the CLI's global allocator (-12% to -28% on real programs)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,16 @@ cranelift-module = "0.122"
 tokio = { version = "1.47", features = ["full"], optional = true }
 async-stream = { version = "0.3", optional = true }
 async-lock = { version = "3.4", optional = true }
+mimalloc = { version = "0.1.52", optional = true }
 
 [features]
-default = ["load-libraries-from-fs"]
+default = ["load-libraries-from-fs", "mimalloc"]
 async = ["dep:futures", "dep:async-stream", "dep:async-lock"]
 lsp = ["dep:lsp-server", "dep:lsp-types", "dep:serde", "dep:serde_json"]
 load-libraries-from-fs = []
 continuation-marks = []
 plugins = ["dep:libloading"]
+mimalloc = ["dep:mimalloc"]
 
 [profile.release]
 lto = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,13 @@ use scheme_rs::{
 use scheme_rs_macros::{maybe_async, maybe_await};
 use std::{path::Path, process, sync::Arc};
 
+// The interpreter's calling convention allocates a Box<Application> plus an
+// argument Vec per procedure application and per continuation invocation, so
+// the CLI is malloc-throughput bound on anything compute-heavy.
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[derive(Parser, Debug)]
 struct Args {
     /// Scheme programs to run


### PR DESCRIPTION
## What and why

While profiling a real Scheme workload (Gabriel-style `deriv`) I found the runtime is malloc-throughput bound, and not on the GC heap. Per iteration, on the older base:

- **~6,300 `Gc` allocations**
- **~79,600 system malloc/free pairs**

The 12.7x-larger traffic came from the calling convention: every procedure application and continuation invocation heap-allocated a `Box<Application>` (since removed) plus a collected `Vec<Value>` of arguments (still present), which the trampoline immediately destructures and frees. On a `samply` profile that path was **32% of mutator self-time in `libsystem_malloc`**, plus ~5.5% of `memmove` copying argument vectors. For comparison, all reference-count traffic was 9.6% and environment lookup was 0.0%.

So the allocator sits on the hot path, and swapping it is the cheapest available lever.

## Numbers

Measured on `d46ecaf` (current main), macOS 15 / arm64, criterion, quiet machine. Same commit in both columns; only the allocator differs.

| bench | system malloc | mimalloc | change |
|---|---|---|---|
| `fib` | 1.310 ms | 0.945 ms | **-28.2%** |
| `yin_yang` | 1.267 ms | 0.989 ms | **-21.9%** |
| `deriv`¹ | 1.171 ms | 0.938 ms | **-17.9%** |
| `integrate` | 397 µs | 347 µs | **-12.4%** |
| `cold boot` | 878 µs | 973 µs | **+22.1%** (+95 µs) |

All p = 0.00. ¹`deriv` is a Gabriel symbolic-differentiation benchmark I wrote locally (not in this repo); happy to contribute it separately if useful.

## Caveats, stated up front

1. **Cold boot gets worse** — mimalloc pays heap/segment initialization that a short process never amortizes. It is +95 µs in absolute terms, and per the discussion below that benchmark is anyway unreliable since the move to a single runtime per program.
2. **Magnitude may be platform-dependent.** Recent macOS `libsystem_malloc` (xzone) is weak at high-frequency small allocations. *Update: confirmed reproduced on Linux by @maplant.*
3. **Repo benchmarks do not inherit this change**, since `#[global_allocator]` in `src/main.rs` does not apply to bench targets. The table above was produced by injecting the allocator into the bench targets directly. If you want the benches to track the CLI, they each need the attribute too — I left that out to keep the diff honest about what it changes.

## The actual question

I put it in the binary behind a default-on `mimalloc` feature, because a `#[global_allocator]` in the library would silently override the allocator of every application embedding scheme-rs — which seems clearly wrong for a crate whose pitch is "Embedded scheme for the Rust ecosystem". Feature-gating also lets embedders skip mimalloc's C build with `--no-default-features`.

Alternatives, in case you prefer one:

- **Binary + default-on feature** (what this PR does) — CLI users get it, embedders opt out.
- **Binary + opt-in feature** (not default) — nobody is surprised, most people never find it.
- **Documentation only** — note in the README that embedders should pick a fast allocator, change nothing.
- **Attack the traffic instead of the allocator** (see below).

*Resolved in discussion: binary-local, as implemented.*

## Related, and probably more interesting

The deeper fix is to stop allocating per call at all — fixed-arity argument passing, or a runtime-owned contiguous argument stack instead of per-call `Vec<Value>`. That eliminates the traffic rather than making it cheaper, and it should compound with this change rather than overlap: mimalloc makes each allocation cheaper, fixed arity removes them.

There is also an adjacent payoff worth naming: if arguments live in runtime-owned storage rather than per-call heap vectors, the live value set becomes **walkable**. Root enumeration is currently impossible because `Gc` handles sit in opaque Rust locals, and that single limitation is what rules out deferred reference counting, backup tracing, and any moving collector. So the arity change may unlock considerably more than its own throughput win.

This PR is deliberately the small, boring, revertible version.
