### PR TITLE
fix: read_cell returns an uncounted reference to cell contents

### DIFF
--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -287,8 +287,17 @@ impl CompilationUnit<'_, '_> {
                 self.alloc_cell_codegen(into, *cexpr, deferred_procs, deferred_local_conts);
             }
             Cps::PrimOp(PrimOp::Read, args, result, cexpr) => {
+                // The binding outlives the read, so it has to own a reference:
+                // a `set!` to the same variable could otherwise drop the last
+                // one and free the value out from under us.
                 let value = self.value_codegen(&args[0]);
+                let clonev = self
+                    .module
+                    .declare_func_in_func(self.runtime_funcs.clonev, self.builder.func);
+                let call = self.builder.ins().call(clonev, &[value]);
+                let value = self.builder.inst_results(call)[0];
                 self.rebinds.rebind(result, IrValue::Value(value));
+                self.push_alloc(value);
                 self.cps_codegen(*cexpr, deferred_procs, deferred_local_conts);
             }
             Cps::PrimOp(PrimOp::Matches, args, bind_to, cexpr) => {

--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -971,9 +971,6 @@ impl CompilationUnit<'_, '_> {
         self.cps_codegen(cexpr, deferred_procs, deferred_local_conts);
     }
 
-    /// The binding outlives the read, so it has to own a reference: a `set!` to
-    /// the same variable could otherwise drop the last one and free the value
-    /// out from under us.
     fn read_codegen(
         &mut self,
         from: &CpsValue,

--- a/src/cps/codegen.rs
+++ b/src/cps/codegen.rs
@@ -287,18 +287,13 @@ impl CompilationUnit<'_, '_> {
                 self.alloc_cell_codegen(into, *cexpr, deferred_procs, deferred_local_conts);
             }
             Cps::PrimOp(PrimOp::Read, args, result, cexpr) => {
-                // The binding outlives the read, so it has to own a reference:
-                // a `set!` to the same variable could otherwise drop the last
-                // one and free the value out from under us.
-                let value = self.value_codegen(&args[0]);
-                let clonev = self
-                    .module
-                    .declare_func_in_func(self.runtime_funcs.clonev, self.builder.func);
-                let call = self.builder.ins().call(clonev, &[value]);
-                let value = self.builder.inst_results(call)[0];
-                self.rebinds.rebind(result, IrValue::Value(value));
-                self.push_alloc(value);
-                self.cps_codegen(*cexpr, deferred_procs, deferred_local_conts);
+                self.read_codegen(
+                    &args[0],
+                    result,
+                    *cexpr,
+                    deferred_procs,
+                    deferred_local_conts,
+                );
             }
             Cps::PrimOp(PrimOp::Matches, args, bind_to, cexpr) => {
                 let [pattern, expr] = args.as_slice() else {
@@ -973,6 +968,28 @@ impl CompilationUnit<'_, '_> {
         let cell = self.builder.inst_results(call)[0];
         self.rebinds.rebind(var, IrValue::Cell(cell));
         self.push_alloc(cell);
+        self.cps_codegen(cexpr, deferred_procs, deferred_local_conts);
+    }
+
+    /// The binding outlives the read, so it has to own a reference: a `set!` to
+    /// the same variable could otherwise drop the last one and free the value
+    /// out from under us.
+    fn read_codegen(
+        &mut self,
+        from: &CpsValue,
+        result: Local,
+        cexpr: Cps,
+        deferred_procs: &mut Vec<ProcedureBundle>,
+        deferred_local_conts: &mut Vec<ProcedureBundle>,
+    ) {
+        let value = self.value_codegen(from);
+        let clonev = self
+            .module
+            .declare_func_in_func(self.runtime_funcs.clonev, self.builder.func);
+        let call = self.builder.ins().call(clonev, &[value]);
+        let value = self.builder.inst_results(call)[0];
+        self.rebinds.rebind(result, IrValue::Value(value));
+        self.push_alloc(value);
         self.cps_codegen(cexpr, deferred_procs, deferred_local_conts);
     }
 

--- a/src/cps/mod.rs
+++ b/src/cps/mod.rs
@@ -138,7 +138,7 @@ impl PrimOp {
     pub(crate) fn info(&self) -> PrimOpInfo {
         match self {
             Self::Set => PrimOpInfo::new(2, false, false, false),
-            Self::Read => PrimOpInfo::new(1, false, false, false),
+            Self::Read => PrimOpInfo::new(1, false, false, true),
             Self::AllocCell => PrimOpInfo::new(0, false, false, true),
             Self::CallKnown0 => PrimOpInfo::new(1, false, true, false),
             Self::CallKnown1 => PrimOpInfo::new(0, false, true, true),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -405,7 +405,9 @@ unsafe extern "C" fn alloc_cell() -> *const () {
     Value::into_raw(Value::from(Cell(Gc::new(RwLock::new(Value::undefined())))))
 }
 
-/// Read the value of a Cell
+/// Read the value of a Cell. The returned pointer is borrowed from the cell and
+/// is not counted: callers that keep it alive past the next store to that cell
+/// have to clone it first.
 #[runtime_fn]
 unsafe extern "C" fn read_cell(cell: *const ()) -> *const () {
     unsafe {

--- a/tests/read_then_set.rs
+++ b/tests/read_then_set.rs
@@ -1,0 +1,3 @@
+mod common;
+
+common::run_test!(read_then_set);

--- a/tests/read_then_set.scm
+++ b/tests/read_then_set.scm
@@ -1,0 +1,19 @@
+(import (rnrs) (test))
+
+;; Reading a variable has to yield a counted reference to its contents. A `set!`
+;; can otherwise drop the last reference to the value that was just read, and
+;; the allocator hands that storage straight to the next allocation.
+
+(define g (/ 1.0 3.0))
+
+(define (read-then-clobber n)
+  (let ((v g))
+    (set! g n)
+    (let ((decoy (+ 7.0 n)))
+      (list v decoy))))
+
+(let loop ((n 0.0))
+  (when (< n 32.0)
+    (set! g (/ 1.0 3.0))
+    (assert-equal? (read-then-clobber n) (list (/ 1.0 3.0) (+ 7.0 n)))
+    (loop (+ n 1.0))))


### PR DESCRIPTION
A variable read compiles to `Cps::PrimOp(PrimOp::Read, ..)`, which bound the raw pointer from `read_cell` straight into an SSA value without incrementing its refcount, so the binding stayed a borrow of the cell's contents for its whole lifetime. A `set!` to that same variable drops the last reference to the value that was just read, and the very next allocation reuses the storage:

```scheme
(define g (/ 1.0 3.0))
(let ((v g))
  (set! g #f)                    ; frees v's storage (the cell was the only owner)
  (let ((decoy (/ 7.0 1.0)))     ; reuses that block
    (list v decoy)))             ; => (7.0 7.0), should be (0.3333333333333333 7.0)
```

Either the ref needs to be incremented artificially or we do as here, and clone it.