### PR TITLE
fix: release deep object graphs iteratively so the collector cannot overflow its stack

### DIFF
--- a/src/gc/collection.rs
+++ b/src/gc/collection.rs
@@ -408,6 +408,16 @@ pub struct Collector {
     head: *mut GcHeader,
     tail: *mut GcHeader,
     next: *mut GcHeader,
+    /// Worklist for the iterative decrement/release cascade; empty between
+    /// drives, persistent to avoid a fresh allocation per cascade.
+    release_stack: Vec<ReleaseFrame>,
+}
+
+#[derive(Debug)]
+enum ReleaseFrame {
+    Decrement(OpaqueGcPtr),
+    Release(OpaqueGcPtr),
+    Free(OpaqueGcPtr),
 }
 
 unsafe impl Send for Collector {}
@@ -421,6 +431,7 @@ impl Collector {
             head: null_mut(),
             tail: null_mut(),
             next: null_mut(),
+            release_stack: Vec::new(),
         }
     }
 
@@ -523,19 +534,39 @@ impl Collector {
     }
 
     unsafe fn decrement(&mut self, s: OpaqueGcPtr) {
-        unsafe {
-            if s.dec_shared_rc() == 1 && !s.buffered() {
-                self.release(s);
-            }
-        }
+        unsafe { self.drive_release(ReleaseFrame::Decrement(s)) }
     }
 
     unsafe fn release(&mut self, s: OpaqueGcPtr) {
-        unsafe {
-            for_each_child(s, &mut |c| self.decrement(c));
-            s.set_color(Color::Black);
-            self.free(s)
+        unsafe { self.drive_release(ReleaseFrame::Release(s)) }
+    }
+
+    /// Iterative decrement/release cascade — the recursive form overflowed
+    /// the collector's 2 MiB stack on deep chains. Frame order replicates
+    /// the recursion exactly: Free(s) sits below s's child frames, so s is
+    /// finalized only after its whole subtree, and the child slice is
+    /// reversed so sibling subtrees complete in visit order.
+    unsafe fn drive_release(&mut self, first: ReleaseFrame) {
+        let mut stack = std::mem::take(&mut self.release_stack);
+        debug_assert!(stack.is_empty());
+        stack.push(first);
+        while let Some(frame) = stack.pop() {
+            unsafe {
+                match frame {
+                    ReleaseFrame::Decrement(s) => {
+                        if s.dec_shared_rc() == 1 && !s.buffered() {
+                            push_release_frames(&mut stack, s);
+                        }
+                    }
+                    ReleaseFrame::Release(s) => push_release_frames(&mut stack, s),
+                    ReleaseFrame::Free(s) => {
+                        s.set_color(Color::Black);
+                        self.free(s);
+                    }
+                }
+            }
         }
+        self.release_stack = stack;
     }
 
     unsafe fn process_cycles(&mut self) {
@@ -706,6 +737,17 @@ impl Collector {
     }
 }
 
+/// Expand a node being released: its children decrement (in visit order)
+/// before Free(s) pops.
+unsafe fn push_release_frames(stack: &mut Vec<ReleaseFrame>, s: OpaqueGcPtr) {
+    unsafe {
+        stack.push(ReleaseFrame::Free(s));
+        let children = stack.len();
+        for_each_child(s, &mut |c| stack.push(ReleaseFrame::Decrement(c)));
+        stack[children..].reverse();
+    }
+}
+
 unsafe fn for_each_child(s: OpaqueGcPtr, visitor: &mut dyn FnMut(OpaqueGcPtr)) {
     unsafe {
         (s.visit_children())(s.data(), visitor);
@@ -849,5 +891,148 @@ mod test {
         collect_garbage_sync();
 
         assert_eq!(Arc::strong_count(&out_ptr), 1);
+    }
+
+    /// Records the order in which the nodes of a released tree are finalized.
+    static FINALIZE_ORDER: Mutex<Vec<usize>> = Mutex::new(Vec::new());
+
+    struct Tag(usize);
+
+    unsafe impl Trace for Tag {
+        unsafe fn visit_children(&self, _visitor: &mut dyn FnMut(OpaqueGcPtr)) {}
+
+        unsafe fn finalize(&mut self) {
+            FINALIZE_ORDER.lock().push(self.0);
+        }
+    }
+
+    #[derive(Trace)]
+    struct TreeNode {
+        tag: Tag,
+        kids: Vec<Gc<RwLock<TreeNode>>>,
+    }
+
+    fn tree_node(tag: usize, kids: Vec<Gc<RwLock<TreeNode>>>) -> Gc<RwLock<TreeNode>> {
+        Gc::new(RwLock::new(TreeNode {
+            tag: Tag(tag),
+            kids,
+        }))
+    }
+
+    /// The iterative cascade must finalize in the same order the recursive one
+    /// did: depth first, children before parents, siblings in visit order.
+    #[test]
+    fn release_cascade_finalizes_depth_first_in_visit_order() {
+        init_gc();
+
+        //     0
+        //    / \
+        //   1   2
+        //  / \   \
+        // 3   4   5
+        let root = tree_node(
+            0,
+            vec![
+                tree_node(1, vec![tree_node(3, Vec::new()), tree_node(4, Vec::new())]),
+                tree_node(2, vec![tree_node(5, Vec::new())]),
+            ],
+        );
+
+        collect_garbage_sync();
+        collect_garbage_sync();
+        FINALIZE_ORDER.lock().clear();
+
+        drop(root);
+        collect_garbage_sync();
+        collect_garbage_sync();
+
+        assert_eq!(*FINALIZE_ORDER.lock(), vec![3, 4, 1, 5, 2, 0]);
+    }
+
+    /// Deep enough that a per-node recursion exhausts the collector thread's
+    /// default 2 MiB stack in any build profile.
+    const DEEP: usize = 200_000;
+
+    #[derive(Default, Trace)]
+    struct DeepNode {
+        next: Option<Gc<RwLock<DeepNode>>>,
+        chain: Option<Gc<RwLock<DeepNode>>>,
+        out: Option<Arc<()>>,
+    }
+
+    /// A singly-linked chain of `len` nodes; the deepest node holds `out`.
+    fn deep_chain(len: usize, out: &Arc<()>) -> Gc<RwLock<DeepNode>> {
+        let mut head = Gc::new(RwLock::new(DeepNode {
+            out: Some(out.clone()),
+            ..Default::default()
+        }));
+        for _ in 1..len {
+            head = Gc::new(RwLock::new(DeepNode {
+                next: Some(head),
+                ..Default::default()
+            }));
+        }
+        head
+    }
+
+    /// Dropping the sole handle to a deep chain cascades release through
+    /// every node on the collector thread. The recursive cascade overflowed
+    /// the collector stack (process abort).
+    #[test]
+    fn deep_chain_drop_releases_fully() {
+        init_gc();
+
+        let out = Arc::new(());
+        let head = deep_chain(DEEP, &out);
+        assert_eq!(Arc::strong_count(&out), 2);
+
+        // Drain the collections the chain's own allocations triggered. Once
+        // every node has been through an epoch its buffered flag is clear, so
+        // the drop below cascades in one release instead of releasing a single
+        // node per heap scan.
+        collect_garbage_sync();
+        collect_garbage_sync();
+
+        drop(head);
+        collect_garbage_sync();
+        collect_garbage_sync();
+        assert_eq!(Arc::strong_count(&out), 1, "deep chain not fully released");
+    }
+
+    /// free_cycle enters the same cascade through cyclic_decrement when a
+    /// freed cycle holds the last reference to a deep acyclic chain.
+    #[test]
+    fn deep_chain_behind_freed_cycle_releases_fully() {
+        init_gc();
+
+        let out = Arc::new(());
+        let chain = deep_chain(DEEP, &out);
+        // Drain the collections the chain's own allocations triggered so the
+        // epochs below are the only ones in flight.
+        collect_garbage_sync();
+        collect_garbage_sync();
+
+        let a = Gc::new(RwLock::new(DeepNode::default()));
+        let b = Gc::new(RwLock::new(DeepNode::default()));
+        a.write().next = Some(b.clone());
+        b.write().next = Some(a.clone());
+        b.write().chain = Some(chain.clone());
+
+        drop(a);
+        drop(b);
+        // Trial-deletes the a/b cycle; the chain stays black through the
+        // still-live handle (scan_black walks its full depth here).
+        collect_garbage_sync();
+
+        // free_cycles frees a/b; b's chain edge decrements the head to zero
+        // and the release cascades through the whole chain.
+        drop(chain);
+        collect_garbage_sync();
+        collect_garbage_sync();
+        assert_eq!(
+            Arc::strong_count(&out),
+            1,
+            "chain behind freed cycle not released"
+        );
     }
 }

--- a/src/gc/collection.rs
+++ b/src/gc/collection.rs
@@ -408,8 +408,7 @@ pub struct Collector {
     head: *mut GcHeader,
     tail: *mut GcHeader,
     next: *mut GcHeader,
-    /// Worklist for the iterative decrement/release cascade; empty between
-    /// drives, persistent to avoid a fresh allocation per cascade.
+    /// Empty between drives; kept allocated to avoid a Vec per cascade.
     release_stack: Vec<ReleaseFrame>,
 }
 
@@ -541,11 +540,8 @@ impl Collector {
         unsafe { self.drive_release(ReleaseFrame::Release(s)) }
     }
 
-    /// Iterative decrement/release cascade — the recursive form overflowed
-    /// the collector's 2 MiB stack on deep chains. Frame order replicates
-    /// the recursion exactly: Free(s) sits below s's child frames, so s is
-    /// finalized only after its whole subtree, and the child slice is
-    /// reversed so sibling subtrees complete in visit order.
+    /// Iterative decrement/release cascade; the recursive form overflowed the
+    /// collector's 2 MiB stack on deep chains.
     unsafe fn drive_release(&mut self, first: ReleaseFrame) {
         let mut stack = std::mem::take(&mut self.release_stack);
         debug_assert!(stack.is_empty());
@@ -737,8 +733,9 @@ impl Collector {
     }
 }
 
-/// Expand a node being released: its children decrement (in visit order)
-/// before Free(s) pops.
+/// Frame order reproduces the recursion exactly, and both halves matter: `Free`
+/// goes below the children so a node finalizes only after its subtree, and the
+/// child slice is reversed so siblings run in visit order.
 unsafe fn push_release_frames(stack: &mut Vec<ReleaseFrame>, s: OpaqueGcPtr) {
     unsafe {
         stack.push(ReleaseFrame::Free(s));
@@ -893,7 +890,6 @@ mod test {
         assert_eq!(Arc::strong_count(&out_ptr), 1);
     }
 
-    /// Records the order in which the nodes of a released tree are finalized.
     static FINALIZE_ORDER: Mutex<Vec<usize>> = Mutex::new(Vec::new());
 
     struct Tag(usize);
@@ -919,17 +915,13 @@ mod test {
         }))
     }
 
-    /// The iterative cascade must finalize in the same order the recursive one
-    /// did: depth first, children before parents, siblings in visit order.
+    /// The expected order is not arbitrary: it is what the recursive cascade
+    /// produced, so this pins pre-existing behaviour rather than the rewrite.
     #[test]
     fn release_cascade_finalizes_depth_first_in_visit_order() {
         init_gc();
 
-        //     0
-        //    / \
-        //   1   2
-        //  / \   \
-        // 3   4   5
+        // 0 -> (1 -> (3, 4), 2 -> 5)
         let root = tree_node(
             0,
             vec![
@@ -949,8 +941,7 @@ mod test {
         assert_eq!(*FINALIZE_ORDER.lock(), vec![3, 4, 1, 5, 2, 0]);
     }
 
-    /// Deep enough that a per-node recursion exhausts the collector thread's
-    /// default 2 MiB stack in any build profile.
+    /// Deep enough to exhaust the collector's 2 MiB stack in any build profile.
     const DEEP: usize = 200_000;
 
     #[derive(Default, Trace)]
@@ -960,7 +951,6 @@ mod test {
         out: Option<Arc<()>>,
     }
 
-    /// A singly-linked chain of `len` nodes; the deepest node holds `out`.
     fn deep_chain(len: usize, out: &Arc<()>) -> Gc<RwLock<DeepNode>> {
         let mut head = Gc::new(RwLock::new(DeepNode {
             out: Some(out.clone()),
@@ -975,9 +965,6 @@ mod test {
         head
     }
 
-    /// Dropping the sole handle to a deep chain cascades release through
-    /// every node on the collector thread. The recursive cascade overflowed
-    /// the collector stack (process abort).
     #[test]
     fn deep_chain_drop_releases_fully() {
         init_gc();
@@ -986,10 +973,9 @@ mod test {
         let head = deep_chain(DEEP, &out);
         assert_eq!(Arc::strong_count(&out), 2);
 
-        // Drain the collections the chain's own allocations triggered. Once
-        // every node has been through an epoch its buffered flag is clear, so
-        // the drop below cascades in one release instead of releasing a single
-        // node per heap scan.
+        // Load-bearing, not defensive: until every node has been through an
+        // epoch its buffered flag stops the cascade after one node, and the
+        // drop below would not recurse deeply enough to fail pre-fix.
         collect_garbage_sync();
         collect_garbage_sync();
 
@@ -999,16 +985,15 @@ mod test {
         assert_eq!(Arc::strong_count(&out), 1, "deep chain not fully released");
     }
 
-    /// free_cycle enters the same cascade through cyclic_decrement when a
-    /// freed cycle holds the last reference to a deep acyclic chain.
+    /// Covers the other entry point: `free_cycle` reaching the cascade through
+    /// `cyclic_decrement`, rather than the rc-zero sweep.
     #[test]
     fn deep_chain_behind_freed_cycle_releases_fully() {
         init_gc();
 
         let out = Arc::new(());
         let chain = deep_chain(DEEP, &out);
-        // Drain the collections the chain's own allocations triggered so the
-        // epochs below are the only ones in flight.
+        // Load-bearing, as above.
         collect_garbage_sync();
         collect_garbage_sync();
 
@@ -1020,12 +1005,10 @@ mod test {
 
         drop(a);
         drop(b);
-        // Trial-deletes the a/b cycle; the chain stays black through the
-        // still-live handle (scan_black walks its full depth here).
+        // Trial-deletes the a/b cycle.
         collect_garbage_sync();
 
-        // free_cycles frees a/b; b's chain edge decrements the head to zero
-        // and the release cascades through the whole chain.
+        // Frees a/b, whose chain edge then decrements the head to zero.
         drop(chain);
         collect_garbage_sync();
         collect_garbage_sync();

--- a/src/gc/collection.rs
+++ b/src/gc/collection.rs
@@ -973,9 +973,10 @@ mod test {
         let head = deep_chain(DEEP, &out);
         assert_eq!(Arc::strong_count(&out), 2);
 
-        // Load-bearing, not defensive: until every node has been through an
-        // epoch its buffered flag stops the cascade after one node, and the
-        // drop below would not recurse deeply enough to fail pre-fix.
+        // Do not remove these. Until every node has been through an epoch its
+        // buffered flag stops the cascade after a single node, so without them
+        // the drop below never recurses deeply and this test passes even
+        // against the unfixed recursive cascade.
         collect_garbage_sync();
         collect_garbage_sync();
 
@@ -993,7 +994,7 @@ mod test {
 
         let out = Arc::new(());
         let chain = deep_chain(DEEP, &out);
-        // Load-bearing, as above.
+        // Do not remove these; same reason as the previous test.
         collect_garbage_sync();
         collect_garbage_sync();
 

--- a/src/gc/collection.rs
+++ b/src/gc/collection.rs
@@ -409,11 +409,11 @@ pub struct Collector {
     tail: *mut GcHeader,
     next: *mut GcHeader,
     /// Empty between drives; kept allocated to avoid a Vec per cascade.
-    release_stack: Vec<ReleaseFrame>,
+    release_stack: Vec<DropAction>,
 }
 
 #[derive(Debug)]
-enum ReleaseFrame {
+enum DropAction {
     Decrement(OpaqueGcPtr),
     Release(OpaqueGcPtr),
     Free(OpaqueGcPtr),
@@ -533,36 +533,41 @@ impl Collector {
     }
 
     unsafe fn decrement(&mut self, s: OpaqueGcPtr) {
-        unsafe { self.drive_release(ReleaseFrame::Decrement(s)) }
+        unsafe { self.maybe_release(DropAction::Decrement(s)) }
     }
 
     unsafe fn release(&mut self, s: OpaqueGcPtr) {
-        unsafe { self.drive_release(ReleaseFrame::Release(s)) }
+        unsafe { self.maybe_release(DropAction::Release(s)) }
     }
 
-    /// Iterative decrement/release cascade; the recursive form overflowed the
-    /// collector's 2 MiB stack on deep chains.
-    unsafe fn drive_release(&mut self, first: ReleaseFrame) {
-        let mut stack = std::mem::take(&mut self.release_stack);
-        debug_assert!(stack.is_empty());
-        stack.push(first);
-        while let Some(frame) = stack.pop() {
+    unsafe fn maybe_release(&mut self, first: DropAction) {
+        self.release_stack.push(first);
+        while let Some(action) = self.release_stack.pop() {
             unsafe {
-                match frame {
-                    ReleaseFrame::Decrement(s) => {
+                match action {
+                    DropAction::Decrement(s) => {
                         if s.dec_shared_rc() == 1 && !s.buffered() {
-                            push_release_frames(&mut stack, s);
+                            self.drop_children(s);
                         }
                     }
-                    ReleaseFrame::Release(s) => push_release_frames(&mut stack, s),
-                    ReleaseFrame::Free(s) => {
+                    DropAction::Release(s) => self.drop_children(s),
+                    DropAction::Free(s) => {
                         s.set_color(Color::Black);
                         self.free(s);
                     }
                 }
             }
         }
-        self.release_stack = stack;
+    }
+
+    /// `Free` goes below the children so a node finalizes only after its
+    /// subtree.
+    unsafe fn drop_children(&mut self, s: OpaqueGcPtr) {
+        unsafe {
+            self.release_stack.push(DropAction::Free(s));
+            let stack = &mut self.release_stack;
+            for_each_child(s, &mut |c| stack.push(DropAction::Decrement(c)));
+        }
     }
 
     unsafe fn process_cycles(&mut self) {
@@ -730,18 +735,6 @@ impl Collector {
             // Deallocate the object:
             std::alloc::dealloc(s.header.as_ptr() as *mut u8, s.layout());
         }
-    }
-}
-
-/// Frame order reproduces the recursion exactly, and both halves matter: `Free`
-/// goes below the children so a node finalizes only after its subtree, and the
-/// child slice is reversed so siblings run in visit order.
-unsafe fn push_release_frames(stack: &mut Vec<ReleaseFrame>, s: OpaqueGcPtr) {
-    unsafe {
-        stack.push(ReleaseFrame::Free(s));
-        let children = stack.len();
-        for_each_child(s, &mut |c| stack.push(ReleaseFrame::Decrement(c)));
-        stack[children..].reverse();
     }
 }
 
@@ -915,10 +908,8 @@ mod test {
         }))
     }
 
-    /// The expected order is not arbitrary: it is what the recursive cascade
-    /// produced, so this pins pre-existing behaviour rather than the rewrite.
     #[test]
-    fn release_cascade_finalizes_depth_first_in_visit_order() {
+    fn release_cascade_finalizes_children_before_parents() {
         init_gc();
 
         // 0 -> (1 -> (3, 4), 2 -> 5)
@@ -938,7 +929,12 @@ mod test {
         collect_garbage_sync();
         collect_garbage_sync();
 
-        assert_eq!(*FINALIZE_ORDER.lock(), vec![3, 4, 1, 5, 2, 0]);
+        let order = FINALIZE_ORDER.lock().clone();
+        assert_eq!(order.len(), 6, "not every node finalized: {order:?}");
+        let at = |tag| order.iter().position(|&t| t == tag).unwrap();
+        for (child, parent) in [(3, 1), (4, 1), (5, 2), (1, 0), (2, 0)] {
+            assert!(at(child) < at(parent), "{child} finalized after {parent}");
+        }
     }
 
     /// Deep enough to exhaust the collector's 2 MiB stack in any build profile.


### PR DESCRIPTION
## Symptom

Releasing a deep object graph kills the process, not just the collection.

The collector tears down garbage recursively: `decrement` → `release` → `for_each_child` → `decrement`, one set of stack frames per object. It runs on the default 2 MiB stack of a plain `std::thread::spawn`, so a sufficiently deep chain of `Gc` objects walks off the guard page. A collector death takes the whole process with it.

A 200,000-element list is enough. On `main` today:

```scheme
(import (rnrs) (runtime (1)))
(define (build n acc) (if (= n 0) acc (build (- n 1) (cons n acc))))
(define lst (build 200000 '()))
(display (length lst)) (newline)
(collect-garbage)
(set! lst '())
(collect-garbage)
(display "released") (newline)
```

```
200000

thread '<unknown>' has overflowed its stack
fatal runtime error: stack overflow, aborting
```

`Collector::release` → `for_each_child` → `Pair::visit_children` → `Collector::decrement` → `Collector::release`, repeating until the stack is gone. With this change the same program prints `released` and exits cleanly.

Note the depth that matters is the depth of the *release cascade*, not the size of the heap: a long-lived list, a deep continuation chain, or any long parent→child spine hits it. Freshly allocated objects mostly escape it by accident, because their `buffered` flag stops the cascade after one node until they have been through an epoch.

## Mechanism

`decrement` and `release` become thin entry points onto an explicit worklist driven by `maybe_release`, with three action kinds:

- `Decrement(s)` — the old `decrement` body verbatim: dec the rc, and on the last reference expand `s`.
- `Release(s)` — expand `s` directly, so the epoch's rc-zero sweep can enter without a second dec.
- `Free(s)` — recolor Black and free.

Expanding a node (`drop_children`) pushes `Free(s)`, then its children as `Decrement` actions.

The worklist is a persistent `Vec` on the `Collector`, empty between drives with its capacity retained, so there is no per-node allocation and no boxed frames.

## Ordering

`Free(s)` is pushed *beneath* `s`'s child actions, so `s`'s recolor and finalize/free happen only after `s`'s entire subtree has been processed. Children still finalize before parents, which is what a finalizer can observe.

Sibling order is not preserved and is not a property worth preserving: `for_each_child`'s enumeration order is undefined, so children are pushed as they are seen. `release_cascade_finalizes_children_before_parents` asserts the child-before-parent invariant on a small branching tree; it fails if `Free(s)` is pushed above the children instead of below.

One deliberate difference, not observable in behavior: a node's children are now enumerated in a single `for_each_child` pass before any of them is processed, where the recursion re-entered the cascade from inside the visitor. The cascade never mutates the parent's data — only other objects' headers, plus finalization of strictly-garbage nodes — so the enumerated child set is identical. As a side effect, finalizers within a cascade no longer run inside a `visit_children` borrow of the parent. `free_cycle`'s own entry is unchanged: it still drives full cascades from inside its `for_each_child` borrow of each cycle member (the `cyclic_decrement` visitor), a pre-existing pattern left alone here.

## Tests

Both deep tests abort pre-fix with `has overflowed its stack` / SIGABRT at 200k nodes, and pass after. Each was checked individually, and instrumented to confirm it enters through the path it claims to cover:

- `deep_chain_drop_releases_fully` — the epoch's rc-zero sweep, `shared_rc == 0` → `release`.
- `deep_chain_behind_freed_cycle_releases_fully` — the other entry: a garbage cycle holds the last reference to a deep acyclic chain, so the cascade starts in `free_cycle` → `cyclic_decrement` → `decrement`.

Both quiesce with a couple of `collect_garbage_sync` calls after building the chain. This is load-bearing rather than defensive: the chain's own allocations trigger background collections, and without draining them the second test's epoch sequencing drifts — the cycle gets freed before the chain handle is dropped, and the test silently exercises the sweep path instead of `free_cycle`.

- `release_cascade_finalizes_children_before_parents` — the ordering test described above.

## Deliberately not touched

The trial-deletion walks — `mark_gray`, `scan`, `scan_black`, `collect_white` — have been iterative since a903776 (#158). They are unchanged here and pass unmodified at 200k depth; both deep tests walk them at full depth before the cascade under test runs.

## Verification

`cargo build`, `cargo test`, `cargo clippy --all-targets` and `cargo fmt --check` are clean. The gc tests were run repeatedly in both debug and release to check for flakiness. `cargo build --features async` fails on `d46ecaf` already; that is pre-existing and untouched by this change.

